### PR TITLE
tooling: add PlatformIO support for STeaMi board (STM32WB55RG)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,13 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Install PlatformIO
-        run: pip install platformio
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup dev environment
+        run: make setup
 
       - name: Build project
         run: make build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,14 @@ jobs:
         with:
           node-version: 22
 
+      - name: Cache PlatformIO packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.platformio
+          key: pio-${{ runner.os }}-${{ hashFiles('platformio.ini', 'boards/steami.json') }}
+          restore-keys: |
+            pio-${{ runner.os }}-
+
       - name: Setup dev environment
         run: make setup
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install PlatformIO
+        run: pip install platformio
+
+      - name: Build project
+        run: make build

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 # Node (tooling)
 node_modules/
 
+# Python venv (PlatformIO toolchain)
+.venv/
+
 # IDE
 *.swp
 *.swo

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ upload: ## Upload to board
 # --- Testing ---
 
 .PHONY: test
-test: ## Run unit tests
-	pio test
+test: ## Run unit tests (no-op when no test/ directory exists)
+	@if [ -d test ]; then pio test; else echo "No test/ directory yet — skipping (will auto-enable when tests land)"; fi
 
 # --- CI ---
 

--- a/Makefile
+++ b/Makefile
@@ -44,17 +44,17 @@ lint-fix: ## Auto-fix formatting
 # --- Build ---
 
 .PHONY: build
-build: ## Build with PlatformIO
+build: .venv/bin/pio ## Build with PlatformIO
 	pio run
 
 .PHONY: upload
-upload: ## Upload to board
+upload: .venv/bin/pio ## Upload to board
 	pio run --target upload --upload-port $(PORT)
 
 # --- Testing ---
 
 .PHONY: test
-test: ## Run unit tests (no-op when tests/ directory is empty)
+test: .venv/bin/pio ## Run unit tests (no-op when tests/ directory is empty)
 	@if [ -n "$$(find tests -mindepth 1 -not -name .gitkeep 2>/dev/null)" ]; then pio test; else echo "tests/ has no suites yet — skipping (will auto-enable when tests land)"; fi
 
 # --- CI ---

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,22 @@ node_modules/.package-lock.json: package.json package-lock.json
 	npm install
 	@touch $@
 
+# PlatformIO is installed in a local Python virtualenv so the toolchain
+# is reproducible and doesn't pollute the system Python.
+.venv/bin/pio:
+	python3 -m venv .venv
+	.venv/bin/pip install --upgrade pip
+	.venv/bin/pip install platformio
+
+.PHONY: install-pio
+install-pio: .venv/bin/pio ## Install PlatformIO in a local Python venv
+
 .PHONY: prepare
 prepare: node_modules/.package-lock.json ## Install git hooks
 	husky
 
 .PHONY: setup
-setup: install prepare ## Full dev environment setup
+setup: install install-pio prepare ## Full dev environment setup
 
 .PHONY: install
 install: node_modules/.package-lock.json ## Install dev tools (npm)
@@ -59,8 +69,9 @@ clean: ## Remove build artifacts
 	rm -rf .pio
 
 .PHONY: deepclean
-deepclean: clean ## Remove everything including node_modules
+deepclean: clean ## Remove everything including node_modules and venv
 	@if [ -d node_modules ]; then rm -rf node_modules && echo "node_modules removed"; else echo "node_modules not found, skipping"; fi
+	@if [ -d .venv ]; then rm -rf .venv && echo ".venv removed"; else echo ".venv not found, skipping"; fi
 
 .PHONY: help
 help: ## Show this help

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ upload: ## Upload to board
 # --- Testing ---
 
 .PHONY: test
-test: ## Run unit tests (no-op when no test/ directory exists)
-	@if [ -d test ]; then pio test; else echo "No test/ directory yet — skipping (will auto-enable when tests land)"; fi
+test: ## Run unit tests (no-op when tests/ directory is empty)
+	@if [ -n "$$(find tests -mindepth 1 -not -name .gitkeep 2>/dev/null)" ]; then pio test; else echo "tests/ has no suites yet — skipping (will auto-enable when tests land)"; fi
 
 # --- CI ---
 

--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ sudo tee /etc/udev/rules.d/60-steami.rules > /dev/null <<'EOF'
 # STeaMi / ARM mbed DAPLink
 # CMSIS-DAP v2 (WinUSB bulk — used by OpenOCD by default)
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0d28", ATTRS{idProduct}=="0204", \
-    MODE="0666", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+    TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
 # CMSIS-DAP v1 (HID fallback — used by pyocd and older OpenOCD)
 KERNEL=="hidraw*", ATTRS{idVendor}=="0d28", ATTRS{idProduct}=="0204", \
-    MODE="0666", TAG+="uaccess"
+    TAG+="uaccess"
 EOF
 sudo udevadm control --reload-rules && sudo udevadm trigger
 ```

--- a/README.md
+++ b/README.md
@@ -90,6 +90,67 @@ Git hooks are managed by [husky](https://typicode.github.io/husky/) and run auto
 - **commit-msg** — validates commit message format via [commitlint](https://commitlint.js.org/)
 - **pre-commit** — branch name validation, content checks, clang-format on staged files
 
+## Troubleshooting uploads
+
+PlatformIO's default uploader on STeaMi is OpenOCD over CMSIS-DAP. On Linux,
+the most common failure mode is `Error: unable to find CMSIS-DAP device`
+(or similar) caused by incomplete udev rules.
+
+### Install udev rules
+
+The rules shipped with [pyocd](https://github.com/pyocd/pyOCD) only grant
+access to the CMSIS-DAP v1 HID interface. OpenOCD prefers the CMSIS-DAP v2
+WinUSB backend (libusb bulk transfers), which needs a separate rule on the
+USB subsystem. Install both, and tell ModemManager to stop probing the
+virtual serial port:
+
+```bash
+sudo tee /etc/udev/rules.d/60-steami.rules > /dev/null <<'EOF'
+# STeaMi / ARM mbed DAPLink
+# CMSIS-DAP v2 (WinUSB bulk — used by OpenOCD by default)
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0d28", ATTRS{idProduct}=="0204", \
+    MODE="0666", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+# CMSIS-DAP v1 (HID fallback — used by pyocd and older OpenOCD)
+KERNEL=="hidraw*", ATTRS{idVendor}=="0d28", ATTRS{idProduct}=="0204", \
+    MODE="0666", TAG+="uaccess"
+EOF
+sudo udevadm control --reload-rules && sudo udevadm trigger
+```
+
+Then unplug and replug the board.
+
+### Fallback: use pyocd instead of OpenOCD
+
+If OpenOCD still fails after the udev rules, pyocd is a drop-in alternative
+with broader DAPLink firmware compatibility and bundled target definitions:
+
+```bash
+source .venv/bin/activate
+pip install pyocd
+```
+
+Then edit [`platformio.ini`](platformio.ini):
+
+```ini
+upload_protocol = custom
+upload_command = pyocd flash --target stm32wb55rgvx $SOURCE
+```
+
+The exact pyocd target name may vary by pack version — run
+`pyocd list --targets | grep -i wb55` to confirm. You may need to install
+the CMSIS pack first: `pyocd pack install stm32wb55`.
+
+### Check OpenOCD version
+
+PlatformIO bundles its own OpenOCD at
+`~/.platformio/packages/tool-openocd/bin/openocd`. STM32WB55 support has
+improved across versions — if both remedies above fail, verify the bundled
+OpenOCD is recent:
+
+```bash
+~/.platformio/packages/tool-openocd/bin/openocd --version
+```
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -100,14 +100,14 @@ the most common failure mode is `Error: unable to find CMSIS-DAP device`
 
 The rules shipped with [pyocd](https://github.com/pyocd/pyOCD) only grant
 access to the CMSIS-DAP v1 HID interface. OpenOCD prefers the CMSIS-DAP v2
-WinUSB backend (libusb bulk transfers), which needs a separate rule on the
-USB subsystem. Install both, and tell ModemManager to stop probing the
-virtual serial port:
+bulk interface (accessed via libusb on Linux), which needs a separate rule
+on the USB subsystem. Install both, and tell ModemManager to stop probing
+the virtual serial port:
 
 ```bash
 sudo tee /etc/udev/rules.d/60-steami.rules > /dev/null <<'EOF'
 # STeaMi / ARM mbed DAPLink
-# CMSIS-DAP v2 (WinUSB bulk — used by OpenOCD by default)
+# CMSIS-DAP v2 (bulk interface — used by OpenOCD by default)
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0d28", ATTRS{idProduct}=="0204", \
     TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
 # CMSIS-DAP v1 (HID fallback — used by pyocd and older OpenOCD)

--- a/README.md
+++ b/README.md
@@ -51,8 +51,22 @@ pio run --target upload
 
 ### Setup
 
+Requires **Python 3** (with `venv` — on Debian/Ubuntu: `sudo apt install python3-venv`)
+and **Node.js** (for the git hooks tooling).
+
 ```bash
-make setup    # Install npm dependencies (git hooks) and dev tools
+make setup    # Install npm tooling, git hooks, and PlatformIO (in a local .venv/)
+```
+
+`make setup` creates a local Python virtualenv in `.venv/` and installs
+PlatformIO there, so no global `pip install` is required. All `make` targets
+(`build`, `upload`, `test`) transparently use this local `pio`.
+
+To use `pio` directly outside of `make`, activate the venv first:
+
+```bash
+source .venv/bin/activate
+pio device monitor -b 115200
 ```
 
 ### Available commands

--- a/boards/steami.json
+++ b/boards/steami.json
@@ -17,7 +17,7 @@
     "onboard_tools": ["cmsis-dap"],
     "jlink_device": "STM32WB55xx",
     "openocd_target": "stm32wbx",
-    "svd_path": "STM32WB55.svd"
+    "svd_path": "STM32WB55_CM4.svd"
   },
   "frameworks": ["arduino"],
   "name": "STeaMi",

--- a/boards/steami.json
+++ b/boards/steami.json
@@ -23,8 +23,8 @@
   "url": "https://www.steami.cc/",
   "vendor": "STeaMi",
   "upload": {
-    "maximum_ram_size": 262144,
-    "maximum_size": 1048576,
+    "maximum_ram_size": 196608,
+    "maximum_size": 524288,
     "protocol": "cmsis-dap",
     "protocols": ["blackmagic", "cmsis-dap", "jlink", "stlink"]
   }

--- a/boards/steami.json
+++ b/boards/steami.json
@@ -1,0 +1,31 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DSTM32WB -DSTM32WB55xx",
+    "f_cpu": "64000000L",
+    "mcu": "stm32wb55rg",
+    "product_line": "STM32WB55xx",
+    "variant": "STM32WBxx/WB55R(C-E-G)V",
+    "arduino": {
+      "board": "STEAM32_WB55RG",
+      "variant_h": "variant_STEAM32_WB55RG.h"
+    }
+  },
+  "debug": {
+    "jlink_device": "STM32WB55xx",
+    "openocd_target": "stm32wbx",
+    "svd_path": "STM32WB55.svd"
+  },
+  "frameworks": ["arduino"],
+  "name": "STeaMi",
+  "platform": "ststm32",
+  "url": "https://www.steami.cc/",
+  "vendor": "STeaMi",
+  "upload": {
+    "maximum_ram_size": 262144,
+    "maximum_size": 1048576,
+    "protocol": "cmsis-dap",
+    "protocols": ["blackmagic", "cmsis-dap", "jlink", "stlink"]
+  }
+}

--- a/boards/steami.json
+++ b/boards/steami.json
@@ -13,6 +13,8 @@
     }
   },
   "debug": {
+    "default_tools": ["cmsis-dap"],
+    "onboard_tools": ["cmsis-dap"],
     "jlink_device": "STM32WB55xx",
     "openocd_target": "stm32wbx",
     "svd_path": "STM32WB55.svd"
@@ -26,6 +28,6 @@
     "maximum_ram_size": 196608,
     "maximum_size": 524288,
     "protocol": "cmsis-dap",
-    "protocols": ["blackmagic", "cmsis-dap", "jlink", "stlink"]
+    "protocols": ["cmsis-dap", "blackmagic", "jlink", "stlink"]
   }
 }

--- a/env.mk
+++ b/env.mk
@@ -1,2 +1,2 @@
-export PATH := $(CURDIR)/node_modules/.bin:$(PATH)
+export PATH := $(CURDIR)/.venv/bin:$(CURDIR)/node_modules/.bin:$(PATH)
 PORT ?= /dev/ttyACM0

--- a/platformio.ini
+++ b/platformio.ini
@@ -2,3 +2,4 @@
 platform = ststm32@^19
 board = steami
 framework = arduino
+monitor_speed = 115200

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,4 @@
+[env:steami]
+platform = ststm32@^19
+board = steami
+framework = arduino

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,3 +1,6 @@
+[platformio]
+test_dir = tests
+
 [env:steami]
 platform = ststm32@^19
 board = steami

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,30 +1,35 @@
+// Build smoke-test sketch: validates the board definition + STM32duino variant
+// compile. Not an example — see lib/<component>/examples/ for driver usage.
+// TODO(#102): once a driver is implemented under lib/, exercise it here so CI
+// also validates driver linkage.
+
 #include <Arduino.h>
 
 void setup() {
-  // Initialisation du port série (défini par la variant)
-  Serial.begin(115200);
-  delay(2000);
+    // Serial initialized by the variant
+    Serial.begin(115200);
+    delay(2000);
 
-  Serial.println("STeaMi minimal test");
+    Serial.println("STeaMi minimal test");
 
-  // LEDs définies dans la variant
-  pinMode(LED_RED, OUTPUT);
-  pinMode(LED_GREEN, OUTPUT);
-  pinMode(LED_BLUE, OUTPUT);
+    // LEDs defined by the variant
+    pinMode(LED_RED, OUTPUT);
+    pinMode(LED_GREEN, OUTPUT);
+    pinMode(LED_BLUE, OUTPUT);
 }
 
 void loop() {
-  Serial.println("Blink");
+    Serial.println("Blink");
 
-  // Allume toutes les LEDs
-  digitalWrite(LED_RED, HIGH);
-  digitalWrite(LED_GREEN, HIGH);
-  digitalWrite(LED_BLUE, HIGH);
-  delay(500);
+    // Turn all LEDs on
+    digitalWrite(LED_RED, HIGH);
+    digitalWrite(LED_GREEN, HIGH);
+    digitalWrite(LED_BLUE, HIGH);
+    delay(500);
 
-  // Éteint toutes les LEDs
-  digitalWrite(LED_RED, LOW);
-  digitalWrite(LED_GREEN, LOW);
-  digitalWrite(LED_BLUE, LOW);
-  delay(500);
+    // Turn all LEDs off
+    digitalWrite(LED_RED, LOW);
+    digitalWrite(LED_GREEN, LOW);
+    digitalWrite(LED_BLUE, LOW);
+    delay(500);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,30 @@
+#include <Arduino.h>
+
+void setup() {
+  // Initialisation du port série (défini par la variant)
+  Serial.begin(115200);
+  delay(2000);
+
+  Serial.println("STeaMi minimal test");
+
+  // LEDs définies dans la variant
+  pinMode(LED_RED, OUTPUT);
+  pinMode(LED_GREEN, OUTPUT);
+  pinMode(LED_BLUE, OUTPUT);
+}
+
+void loop() {
+  Serial.println("Blink");
+
+  // Allume toutes les LEDs
+  digitalWrite(LED_RED, HIGH);
+  digitalWrite(LED_GREEN, HIGH);
+  digitalWrite(LED_BLUE, HIGH);
+  delay(500);
+
+  // Éteint toutes les LEDs
+  digitalWrite(LED_RED, LOW);
+  digitalWrite(LED_GREEN, LOW);
+  digitalWrite(LED_BLUE, LOW);
+  delay(500);
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include <Arduino.h>
 
 void setup() {
-    // Serial initialized by the variant
+    // Serial instance and pins are defined by the variant
     Serial.begin(115200);
     delay(2000);
 


### PR DESCRIPTION
### **Description**

This PR adds full PlatformIO support for the STeaMi board (STM32WB55RG), including a custom board definition and integration with the upstream STM32duino variant.

---

### **Closes**

* Closes #1
* Closes #67
* Closes #18 

### Dependencies
- Closes #20 (via dependent PR #87)
- Closes #21 (via dependent PR #88)
- Closes #48 (via dependent PR #90)

---

### **What’s included**

#### 1. PlatformIO configuration

---

* Add `platformio.ini` configured for:

  * `platform = ststm32`
  * `framework = arduino`
  * custom board: `steami`
* Ensure project builds with `pio run`
* Ensure upload works via `cmsis-dap`

#### 2. Custom board definition

* Add `boards/steami.json` with:

  * `mcu = stm32wb55rg`
  * `product_line = STM32WB55xx`
  * required `extra_flags`:

    ```
    -DSTM32WB -DSTM32WB55xx
    ```
* Configure memory sizes (1MB Flash / 256KB RAM)
* Configure debug and upload targets

#### 3. Use upstream STM32duino variant (no duplication)

Instead of copying variant files, this PR reuses the official STM32duino variant:

* `variant: STM32WBxx/WB55R(C-E-G)V`
* `variant_h: variant_STEAM32_WB55RG.h`
* `board: STEAM32_WB55RG`

Source:

* [https://github.com/stm32duino/Arduino_Core_STM32/blob/main/variants/STM32WBxx/WB55R(C-E-G)V/variant_STEAM32_WB55RG.cpp](https://github.com/stm32duino/Arduino_Core_STM32/blob/main/variants/STM32WBxx/WB55R%28C-E-G%29V/variant_STEAM32_WB55RG.cpp)
* [https://github.com/stm32duino/Arduino_Core_STM32/blob/main/variants/STM32WBxx/WB55R(C-E-G)V/variant_STEAM32_WB55RG.h](https://github.com/stm32duino/Arduino_Core_STM32/blob/main/variants/STM32WBxx/WB55R%28C-E-G%29V/variant_STEAM32_WB55RG.h)

This ensures:

* correct pin mapping
* correct peripheral configuration
* no code duplication or maintenance overhead

#### 4. CI integration

* Add `.github/workflows/build.yml`
* Run `pio run` to validate build on each PR

---

### **Validation**

* ✅ `pio run` → builds successfully
* ✅ `pio run -t upload` → works with STeaMi board
* ✅ Serial monitor functional
* ✅ Variant correctly resolved from STM32duino core

### **How to run**
```python 
pio run -t clean
pio run -t upload
pio device monitor -b 115200
```