### PR TITLE
tooling: add .editorconfig for consistent formatting across IDEs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.{h,cpp,ino}]
+indent_style = space
+indent_size = 4
+
+[*.{json,yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,9 +6,10 @@ insert_final_newline = true
 charset = utf-8
 trim_trailing_whitespace = true
 
-[*.{h,cpp,ino}]
+[*.{h,hpp,c,cc,cpp,ino}]
 indent_style = space
 indent_size = 4
+max_line_length = 100
 
 [*.{json,yml,yaml}]
 indent_style = space
@@ -19,3 +20,7 @@ indent_style = tab
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.sh]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
### **Description**

Adds a root-level `.editorconfig` file to enforce consistent basic formatting rules across all editors (VS Code, CLion, Arduino IDE, etc.) without requiring additional configuration.

This helps reduce formatting inconsistencies such as mixed indentation styles, missing final newlines, or trailing whitespace.

Closes #64

### **Configuration**

The following rules are defined:

* **Global**

  * LF line endings
  * UTF-8 encoding
  * Final newline enforced
  * Trailing whitespace trimmed

* **C/C++ / Arduino (`.h`, `.cpp`, `.ino`)**

  * 4 spaces indentation

* **JSON / YAML**

  * 2 spaces indentation

* **Makefile**

  * Tabs (required by `make`)

* **Markdown**

  * Trailing whitespace preserved (to support intentional line breaks)