### PR TITLE
test(tooling): Set up unit testing framework with PlatformIO

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,46 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+.astyleignore text eol=lf
+.astylerc text eol=lf
+.codespellignore text eol=lf
+.codespellrc text eol=lf
+.editorconfig text eol=lf
+.flake8 text eol=lf
+.gitattributes text eol=lf
+.gitignore text eol=lf
+
+*.adoc text eol=lf
+*.c text eol=lf
+*.cfg text eol=lf
+*.cmake text eol=lf
+*.cpp text eol=lf
+*.css text eol=lf
+*.dtsi text eol=lf
+*.gv text eol=lf
+*.h text eol=lf
+*.html text eol=lf
+*.in text eol=lf
+*.ino text eol=lf
+*.json text eol=lf
+*.ld text eol=lf
+*.md text eol=lf
+*.MD text eol=lf
+*.old text eol=lf
+*.patch text eol=lf
+*.pde text eol=lf
+*.properties text eol=lf
+*.py text eol=lf
+*.s text eol=lf
+*.S text eol=lf
+*.sh text eol=lf
+*.spec text eol=lf
+*.txt text eol=lf
+*.yml text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.jpg binary
+*.pdf binary
+*.png binary

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,8 +12,8 @@
 
 - [ ] `make lint` passes (clang-format)
 - [ ] `make build` passes (PlatformIO)
-- [ ] `make test` passes (if tests exist)
-- [ ] Tested on hardware (if applicable)
+- [ ] `make test-native` passes (if native tests exist)
+- [ ] `make test-hardware` passes on a connected STeaMi (if hardware tests exist)
 - [ ] README updated (if adding/changing public API)
 - [ ] Examples added/updated (if applicable)
 - [ ] Commit messages follow conventional commits format

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,3 +36,6 @@ jobs:
 
       - name: Build project
         run: make build
+
+      - name: Run native tests
+        run: make test-native

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
+}

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,14 @@ upload: .venv/bin/pio ## Upload to board
 test: .venv/bin/pio ## Run unit tests (no-op when tests/ directory is empty)
 	@if [ -n "$$(find tests -mindepth 1 -not -name .gitkeep 2>/dev/null)" ]; then pio test; else echo "tests/ has no suites yet — skipping (will auto-enable when tests land)"; fi
 
+.PHONY: test-native
+test-native: .venv/bin/pio ## Run host-side native tests (no board required)
+	pio test -e native
+
+.PHONY: test-hardware
+test-hardware: .venv/bin/pio ## Run on-board hardware tests (STeaMi required)
+	pio test -e steami
+
 # --- CI ---
 
 .PHONY: ci

--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,6 @@ upload: .venv/bin/pio ## Upload to board
 
 # --- Testing ---
 
-.PHONY: test
-test: .venv/bin/pio ## Run unit tests (no-op when tests/ directory is empty)
-	@if [ -n "$$(find tests -mindepth 1 -not -name .gitkeep 2>/dev/null)" ]; then pio test; else echo "tests/ has no suites yet — skipping (will auto-enable when tests land)"; fi
-
 .PHONY: test-native
 test-native: .venv/bin/pio ## Run host-side native tests (no board required)
 	pio test -e native

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ test-hardware: .venv/bin/pio ## Run on-board hardware tests (STeaMi required)
 # --- CI ---
 
 .PHONY: ci
-ci: lint build test ## Run all CI checks (lint + build + test)
+ci: lint build test-native ## Run all CI checks (lint + build + native tests, no board required)
 
 # --- Utilities ---
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Run `make help` to see all available targets:
 | `make lint` | Run clang-format check |
 | `make lint-fix` | Auto-fix formatting |
 | `make build` | Build with PlatformIO |
-| `make test` | Run unit tests |
+| `make test-native` | Run host-side unit tests (no board required) |
+| `make test-hardware` | Run on-board unit tests (STeaMi required) |
 | `make upload` | Upload to board |
 | `make clean` | Remove build artifacts |
 | `make deepclean` | Remove everything including node_modules |

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ make setup    # Install npm tooling, git hooks, and PlatformIO (in a local .venv
 
 `make setup` creates a local Python virtualenv in `.venv/` and installs
 PlatformIO there, so no global `pip install` is required. All `make` targets
-(`build`, `upload`, `test`) transparently use this local `pio`.
+(`build`, `upload`, `test-native`, `test-hardware`) transparently use this
+local `pio`.
 
 To use `pio` directly outside of `make`, activate the venv first:
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,5 +15,6 @@ platform = native
 test_framework = unity
 test_filter = native/test_*
 build_flags =
+  -std=c++17
   -D UNIT_TEST
   -I tests/native/helpers

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,4 +1,5 @@
 [platformio]
+default_envs = steami
 test_dir = tests
 
 [env:steami]
@@ -6,3 +7,13 @@ platform = ststm32@^19
 board = steami
 framework = arduino
 monitor_speed = 115200
+test_framework = unity
+test_filter = hardware/test_*
+
+[env:native]
+platform = native
+test_framework = unity
+test_filter = native/test_*
+build_flags =
+  -D UNIT_TEST
+  -I tests/native/helpers

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -1,0 +1,167 @@
+# Testing
+
+## Overview
+
+This repository uses PlatformIO's unit testing framework to validate Arduino drivers for the STeaMi board.
+
+Two complementary testing approaches are used:
+
+* **Hardware tests (`tests/hardware/`)**
+  Run directly on a connected STeaMi board.
+
+* **Native tests (`tests/native/`)**
+  Run on the host machine (desktop) using mocks to simulate hardware behavior.
+
+This mixed strategy allows both real hardware validation and fast, reproducible tests without requiring a board.
+
+---
+
+## Test Structure
+
+```
+tests/
+├── hardware/
+│   └── test_<name>/
+│       └── test_main.cpp
+├── native/
+│   └── test_<name>/
+│       └── test_main.cpp
+└── TESTING.md
+```
+
+* Each test suite must be inside a folder named `test_<name>`
+* Each suite contains a `test_main.cpp`
+* Tests use the Unity framework
+
+---
+
+## Running Tests
+
+### Hardware tests (on STeaMi board)
+
+```bash
+pio test -e steami
+```
+
+Requirements:
+
+* STeaMi board connected via USB
+* Correct upload port configured if needed
+
+---
+
+### Native tests (desktop)
+
+```bash
+pio test -e native
+```
+
+* No hardware required
+* Faster execution
+* Uses mocked Arduino APIs
+
+---
+
+### Run a specific test suite
+
+```bash
+pio test -e steami -f hardware/test_led
+pio test -e native -f native/test_led
+```
+
+---
+
+### Using Makefile
+
+```bash
+make test
+```
+
+This runs all configured tests via PlatformIO. 
+
+---
+
+## Testing Strategy
+
+### Hardware tests
+
+Used to validate:
+
+* Real hardware behavior
+* GPIO, I2C, SPI communication
+* Integration with the STeaMi board
+
+Example:
+
+* LED blinking
+* Sensor register read
+
+---
+
+### Native tests (mock-based)
+
+Used to validate:
+
+* Driver logic
+* Register handling
+* Data processing
+
+Mocks replace Arduino functions such as:
+
+* `pinMode`
+* `digitalWrite`
+* `Wire`
+
+Example:
+
+* Simulated LED state tracking
+* Fake I2C register reads
+
+---
+
+## Mocking Approach
+
+Native tests use lightweight mocks to simulate Arduino behavior.
+
+Example for GPIO:
+
+* `digitalWrite(pin, value)` stores state in memory
+* Tests assert expected pin values
+
+Example for I2C (future):
+
+* Fake `Wire` implementation
+* Simulated register map
+
+This allows testing driver logic without hardware.
+
+---
+
+## Current Status
+
+* Basic hardware test infrastructure is working
+* Native test environment with mocks is functional
+* LED mock test provides a minimal working example
+
+Future work:
+
+* Add driver-specific tests (e.g. HTS221, WSEN-HIDS)
+* Extend I2C mock (`Wire`)
+* Increase coverage of driver APIs
+
+---
+
+## Guidelines
+
+* Prefer testing public driver APIs (`begin()`, `deviceId()`, etc.)
+* Keep tests simple and deterministic
+* Avoid hardware dependencies in native tests
+* Use hardware tests for integration validation
+
+---
+
+## Notes
+
+* Hardware tests require a connected STeaMi board
+* Native tests are suitable for CI environments
+* Both approaches are complementary and should be used together

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -74,10 +74,12 @@ pio test -e native -f native/test_led
 ### Using Makefile
 
 ```bash
-make test
+make test-native      # Host-side tests, no board required
+make test-hardware    # On-board tests, STeaMi required
 ```
 
-This runs all configured tests via PlatformIO. 
+Each target is a thin wrapper around `pio test -e <env>`, pinned to
+the venv pio installed by `make setup`.
 
 ---
 

--- a/tests/hardware/test_led/test_main.cpp
+++ b/tests/hardware/test_led/test_main.cpp
@@ -3,41 +3,37 @@
 #include <Arduino.h>
 #include <unity.h>
 
-#define LED_RED_PIN LED_BUILTIN
-#define LED_GREEN_PIN LED_BUILTIN
-#define LED_BLUE_PIN LED_BUILTIN
-
 void setUp() {}
 void tearDown() {}
 
 void test_led_pins_output_mode() {
-    pinMode(LED_RED_PIN, OUTPUT);
-    pinMode(LED_GREEN_PIN, OUTPUT);
-    pinMode(LED_BLUE_PIN, OUTPUT);
+    pinMode(LED_RED, OUTPUT);
+    pinMode(LED_GREEN, OUTPUT);
+    pinMode(LED_BLUE, OUTPUT);
 
     // if we reach this point without crashing, we assume the pins are set correctly
     TEST_ASSERT_TRUE(true);
 }
 
 void test_led_blink_sequence() {
-    pinMode(LED_RED_PIN, OUTPUT);
-    pinMode(LED_GREEN_PIN, OUTPUT);
-    pinMode(LED_BLUE_PIN, OUTPUT);
+    pinMode(LED_RED, OUTPUT);
+    pinMode(LED_GREEN, OUTPUT);
+    pinMode(LED_BLUE, OUTPUT);
 
     // red
-    digitalWrite(LED_RED_PIN, HIGH);
+    digitalWrite(LED_RED, HIGH);
     delay(300);
-    digitalWrite(LED_RED_PIN, LOW);
+    digitalWrite(LED_RED, LOW);
 
     // green
-    digitalWrite(LED_GREEN_PIN, HIGH);
+    digitalWrite(LED_GREEN, HIGH);
     delay(300);
-    digitalWrite(LED_GREEN_PIN, LOW);
+    digitalWrite(LED_GREEN, LOW);
 
     // blue
-    digitalWrite(LED_BLUE_PIN, HIGH);
+    digitalWrite(LED_BLUE, HIGH);
     delay(300);
-    digitalWrite(LED_BLUE_PIN, LOW);
+    digitalWrite(LED_BLUE, LOW);
 
     TEST_ASSERT_TRUE(true);
 }

--- a/tests/hardware/test_led/test_main.cpp
+++ b/tests/hardware/test_led/test_main.cpp
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <Arduino.h>
+#include <unity.h>
+
+#define LED_RED_PIN LED_BUILTIN
+#define LED_GREEN_PIN LED_BUILTIN
+#define LED_BLUE_PIN LED_BUILTIN
+
+void setUp() {}
+void tearDown() {}
+
+void test_led_pins_output_mode() {
+    pinMode(LED_RED_PIN, OUTPUT);
+    pinMode(LED_GREEN_PIN, OUTPUT);
+    pinMode(LED_BLUE_PIN, OUTPUT);
+
+    // if we reach this point without crashing, we assume the pins are set correctly
+    TEST_ASSERT_TRUE(true);
+}
+
+void test_led_blink_sequence() {
+    pinMode(LED_RED_PIN, OUTPUT);
+    pinMode(LED_GREEN_PIN, OUTPUT);
+    pinMode(LED_BLUE_PIN, OUTPUT);
+
+    // red
+    digitalWrite(LED_RED_PIN, HIGH);
+    delay(300);
+    digitalWrite(LED_RED_PIN, LOW);
+
+    // green
+    digitalWrite(LED_GREEN_PIN, HIGH);
+    delay(300);
+    digitalWrite(LED_GREEN_PIN, LOW);
+
+    // blue
+    digitalWrite(LED_BLUE_PIN, HIGH);
+    delay(300);
+    digitalWrite(LED_BLUE_PIN, LOW);
+
+    TEST_ASSERT_TRUE(true);
+}
+
+void setup() {
+    delay(2000);
+    UNITY_BEGIN();
+
+    RUN_TEST(test_led_pins_output_mode);
+    RUN_TEST(test_led_blink_sequence);
+
+    UNITY_END();
+}
+
+void loop() {}

--- a/tests/native/helpers/Arduino.h
+++ b/tests/native/helpers/Arduino.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <map>
+
+#define HIGH 1
+#define LOW 0
+#define OUTPUT 1
+#define INPUT 0
+
+inline std::map<int, int>& gpioPinState() {
+    static std::map<int, int> state;
+    return state;
+}
+
+inline std::map<int, int>& gpioPinMode() {
+    static std::map<int, int> mode;
+    return mode;
+}
+
+inline void pinMode(int pin, int mode) {
+    gpioPinMode()[pin] = mode;
+}
+
+inline void digitalWrite(int pin, int value) {
+    gpioPinState()[pin] = value;
+}
+
+inline int digitalRead(int pin) {
+    return gpioPinState()[pin];
+}
+
+inline void delay(unsigned long) {}

--- a/tests/native/helpers/FakeWire.cpp
+++ b/tests/native/helpers/FakeWire.cpp
@@ -1,5 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
-
-#include "Wire.h"
-
-TwoWire Wire;

--- a/tests/native/helpers/FakeWire.cpp
+++ b/tests/native/helpers/FakeWire.cpp
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "Wire.h"
+
+TwoWire Wire;

--- a/tests/native/helpers/Wire.h
+++ b/tests/native/helpers/Wire.h
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <vector>
+
+class TwoWire {
+   public:
+    void begin() {}
+
+    void setRegister(uint8_t reg, uint8_t value) { registers_[reg] = value; }
+
+    void beginTransmission(uint8_t address) {
+        currentAddress_ = address;
+        txBuffer_.clear();
+    }
+
+    size_t write(uint8_t value) {
+        txBuffer_.push_back(value);
+        return 1;
+    }
+
+    uint8_t endTransmission(bool = true) {
+        if (txBuffer_.size() == 1) {
+            currentRegister_ = txBuffer_[0];
+        } else if (txBuffer_.size() >= 2) {
+            uint8_t reg = txBuffer_[0];
+            uint8_t val = txBuffer_[1];
+            registers_[reg] = val;
+            currentRegister_ = reg;
+        }
+        return 0;
+    }
+
+    uint8_t requestFrom(uint8_t, uint8_t quantity) {
+        rxBuffer_.clear();
+        for (uint8_t i = 0; i < quantity; ++i) {
+            rxBuffer_.push_back(registers_[currentRegister_ + i]);
+        }
+        rxIndex_ = 0;
+        return quantity;
+    }
+
+    int available() { return static_cast<int>(rxBuffer_.size() - rxIndex_); }
+
+    int read() {
+        if (rxIndex_ < rxBuffer_.size()) {
+            return rxBuffer_[rxIndex_++];
+        }
+        return -1;
+    }
+
+   private:
+    uint8_t currentAddress_ = 0;
+    uint8_t currentRegister_ = 0;
+    std::vector<uint8_t> txBuffer_;
+    std::vector<uint8_t> rxBuffer_;
+    size_t rxIndex_ = 0;
+    std::map<uint8_t, uint8_t> registers_;
+};
+
+extern TwoWire Wire;

--- a/tests/native/helpers/Wire.h
+++ b/tests/native/helpers/Wire.h
@@ -62,4 +62,4 @@ class TwoWire {
     std::map<uint8_t, uint8_t> registers_;
 };
 
-extern TwoWire Wire;
+inline TwoWire Wire;

--- a/tests/native/test_led/test_main.cpp
+++ b/tests/native/test_led/test_main.cpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <Arduino.h>
+#include <unity.h>
+
+#define LED_RED_PIN 1
+#define LED_GREEN_PIN 2
+#define LED_BLUE_PIN 3
+
+void setUp(void) {
+    gpioPinState().clear();
+    gpioPinMode().clear();
+}
+
+void tearDown(void) {}
+
+void test_led_pins_configured_output(void) {
+    pinMode(LED_RED_PIN, OUTPUT);
+    pinMode(LED_GREEN_PIN, OUTPUT);
+    pinMode(LED_BLUE_PIN, OUTPUT);
+
+    TEST_ASSERT_EQUAL(OUTPUT, gpioPinMode()[LED_RED_PIN]);
+    TEST_ASSERT_EQUAL(OUTPUT, gpioPinMode()[LED_GREEN_PIN]);
+    TEST_ASSERT_EQUAL(OUTPUT, gpioPinMode()[LED_BLUE_PIN]);
+}
+
+void test_led_write_sequence(void) {
+    pinMode(LED_RED_PIN, OUTPUT);
+
+    digitalWrite(LED_RED_PIN, HIGH);
+    TEST_ASSERT_EQUAL(HIGH, gpioPinState()[LED_RED_PIN]);
+
+    digitalWrite(LED_RED_PIN, LOW);
+    TEST_ASSERT_EQUAL(LOW, gpioPinState()[LED_RED_PIN]);
+}
+
+void test_led_rgb_sequence(void) {
+    pinMode(LED_RED_PIN, OUTPUT);
+    pinMode(LED_GREEN_PIN, OUTPUT);
+    pinMode(LED_BLUE_PIN, OUTPUT);
+
+    digitalWrite(LED_RED_PIN, HIGH);
+    TEST_ASSERT_EQUAL(HIGH, gpioPinState()[LED_RED_PIN]);
+
+    digitalWrite(LED_GREEN_PIN, HIGH);
+    TEST_ASSERT_EQUAL(HIGH, gpioPinState()[LED_GREEN_PIN]);
+
+    digitalWrite(LED_BLUE_PIN, HIGH);
+    TEST_ASSERT_EQUAL(HIGH, gpioPinState()[LED_BLUE_PIN]);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_led_pins_configured_output);
+    RUN_TEST(test_led_write_sequence);
+    RUN_TEST(test_led_rgb_sequence);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

Sets up a unit testing framework for Arduino drivers using PlatformIO, with two complementary approaches: on-board hardware tests and host-side native tests with mocks.

Closes #20

## Changes

### PlatformIO test environments

* `[env:steami]`: `test_framework = unity`, `test_filter = hardware/test_*`
* `[env:native]`: `platform = native`, `test_framework = unity`, `test_filter = native/test_*`, `build_flags = -D UNIT_TEST -I tests/native/helpers`
* `default_envs = steami` keeps `pio run` building only the firmware (native is only touched by `pio test -e native`)

### Test tree (under `tests/`, plural — aligned with `lib/*/examples/` convention and `test_dir = tests` from PR #84)

* `tests/hardware/test_led/` — on-board test exercising variant `LED_RED` / `LED_GREEN` / `LED_BLUE` macros (verifies the board definition wiring, not just a single `LED_BUILTIN`)
* `tests/native/test_led/` — host-side LED test asserting mock GPIO state
* `tests/native/helpers/`:
  * `Arduino.h` — lightweight GPIO mock (`pinMode` / `digitalWrite` / `digitalRead` / `delay`), state accessible via `gpioPinMode()` and `gpioPinState()`
  * `Wire.h` — TwoWire mock with register-map-style semantics (useful for I2C drivers). Uses `inline TwoWire Wire;` (C++17) so every TU that includes the header pulls in the definition without a separate source file
* `tests/TESTING.md` — testing strategy, run commands, mocking approach, guidelines

### Makefile

* `make test-native` — runs `pio test -e native` (no board required)
* `make test-hardware` — runs `pio test -e steami` (STeaMi required)
* `make ci` runs `lint + build + test-native` — board-less, safe in CI and for local pre-push validation
* Generic `make test` deliberately dropped to avoid hiding a hardware dependency behind an ambiguous name

### CI

* New step **Run native tests** in `.github/workflows/build.yml` calling `make test-native` — every push/PR now exercises host-side tests automatically

### Miscellaneous

* `.vscode/extensions.json` recommends `platformio.platformio-ide` and disables `ms-vscode.cpptools-extension-pack` to avoid competing C++ toolchains
* `.gitattributes` normalizes text file line endings (complements `.editorconfig end_of_line = lf`, useful for Windows contributors with `core.autocrlf`)
* All new C++ sources carry `// SPDX-License-Identifier: GPL-3.0-or-later` per issue #104

## Verification

* `pio test -e native` → 3/3 tests passing in ~0.3 s
* `make ci` → lint + build + native tests, runs without a board
* `pio project config` parses cleanly; `clang-format --dry-run --Werror` clean on all new C++ files

## Checklist

* [x] `make lint` passes (clang-format)
* [x] `make build` passes (PlatformIO)
* [x] `make test-native` passes (3/3 in ~0.3 s)
* [ ] `make test-hardware` passes — needs a re-flash since the LED test now uses `LED_RED/GREEN/BLUE` instead of `LED_BUILTIN`
* [x] README and `tests/TESTING.md` updated
* [x] SPDX headers on all new C++ files
* [x] Commit messages follow conventional commits format