### PR TITLE
test(tooling): Enrich TwoWire mock for host-side I2C driver tests.

### DIFF
--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -123,19 +123,72 @@ Example:
 
 ## Mocking Approach
 
-Native tests use lightweight mocks to simulate Arduino behavior.
+Native tests use lightweight mocks to simulate Arduino behavior. Mocks live
+in `tests/native/helpers/` and are automatically available to every native
+test via the `[env:native]` build flag `-I tests/native/helpers`.
 
-Example for GPIO:
+### GPIO mock
 
-* `digitalWrite(pin, value)` stores state in memory
-* Tests assert expected pin values
+`tests/native/helpers/Arduino.h` provides:
 
-Example for I2C (future):
+* `pinMode(pin, mode)` records the mode into `gpioPinMode()`
+* `digitalWrite(pin, value)` records the state into `gpioPinState()`
+* `digitalRead(pin)` returns the last recorded state
+* `delay(ms)` is a no-op
 
-* Fake `Wire` implementation
-* Simulated register map
+Tests assert expected pin state by querying the two maps directly.
 
-This allows testing driver logic without hardware.
+### I2C mock (`TwoWire`)
+
+`tests/native/helpers/Wire.h` provides a minimal host-side implementation
+of the Arduino `TwoWire` class, plus a single `inline TwoWire Wire;` global
+so drivers typed as `TwoWire&` can be passed either `Wire` or a locally
+constructed instance.
+
+Features:
+
+* Preload a register value on a specific address:
+
+  ```cpp
+  wire.setRegister(address, reg, value);
+  ```
+
+* Simulate a register read (`beginTransmission` / `write` / `endTransmission(false)` / `requestFrom` / `read`) — backed by the preloaded values.
+* Capture every `endTransmission` that carries a register write:
+
+  ```cpp
+  const auto& writes = wire.getWrites();  // vector<WriteOp{address, reg, value}>
+  wire.clearWrites();
+  ```
+
+* Multi-byte reads via `requestFrom(address, quantity)` then repeated `read()`.
+* Registers are keyed by `(address, reg)`, so a single `TwoWire` instance can simulate several I2C peripherals on the same bus.
+
+The contract is pinned by the `tests/native/test_wire/` suite; see it for the expected invocation sequence.
+
+---
+
+## Example: driver test using the Wire mock
+
+```cpp
+#include <unity.h>
+
+#include "Wire.h"
+#include "MyDriver.h"  // accepts TwoWire& in its constructor
+
+TwoWire wire;
+MyDriver drv(wire);
+
+void setUp(void) {
+    wire = TwoWire();
+    drv = MyDriver(wire);
+}
+
+void test_begin_checks_who_am_i(void) {
+    wire.setRegister(MyDriver::ADDRESS, MyDriver::REG_WHO_AM_I, 0xBC);
+    TEST_ASSERT_TRUE(drv.begin());
+}
+```
 
 ---
 
@@ -143,12 +196,13 @@ This allows testing driver logic without hardware.
 
 * Basic hardware test infrastructure is working
 * Native test environment with mocks is functional
-* LED mock test provides a minimal working example
+* LED mock test covers GPIO recording
+* Wire mock test pins the I2C mock contract (register preload, write capture, multi-byte reads, per-address isolation)
 
 Future work:
 
 * Add driver-specific tests (e.g. HTS221, WSEN-HIDS)
-* Extend I2C mock (`Wire`)
+* Extend mocks as new peripheral types need host-side coverage (SPI, PDM, etc.)
 * Increase coverage of driver APIs
 
 ---

--- a/tests/native/helpers/Wire.h
+++ b/tests/native/helpers/Wire.h
@@ -23,10 +23,16 @@ class TwoWire {
 
     uint8_t endTransmission(bool = true) {
         if (txBuffer_.size() >= 2) {
+            // [reg, val0, val1, ...] — I2C auto-increment: each value lands at
+            // reg + offset, one WriteOp per byte so tests can assert the full
+            // write sequence.
             uint8_t reg = txBuffer_[0];
-            uint8_t val = txBuffer_[1];
-            registers_[makeKey(currentAddress_, reg)] = val;
-            writes_.push_back({currentAddress_, reg, val});
+            for (size_t i = 1; i < txBuffer_.size(); ++i) {
+                uint8_t targetReg = static_cast<uint8_t>(reg + (i - 1));
+                uint8_t val = txBuffer_[i];
+                registers_[makeKey(currentAddress_, targetReg)] = val;
+                writes_.push_back({currentAddress_, targetReg, val});
+            }
             currentRegisterByAddr_[currentAddress_] = reg;
         } else if (txBuffer_.size() == 1) {
             currentRegisterByAddr_[currentAddress_] = txBuffer_[0];

--- a/tests/native/helpers/Wire.h
+++ b/tests/native/helpers/Wire.h
@@ -27,17 +27,18 @@ class TwoWire {
             uint8_t val = txBuffer_[1];
             registers_[makeKey(currentAddress_, reg)] = val;
             writes_.push_back({currentAddress_, reg, val});
-            currentRegister_ = reg;
+            currentRegisterByAddr_[currentAddress_] = reg;
         } else if (txBuffer_.size() == 1) {
-            currentRegister_ = txBuffer_[0];
+            currentRegisterByAddr_[currentAddress_] = txBuffer_[0];
         }
         return 0;
     }
 
     uint8_t requestFrom(uint8_t address, uint8_t quantity) {
         rxBuffer_.clear();
+        uint8_t reg = currentRegisterByAddr_[address];
         for (uint8_t i = 0; i < quantity; ++i) {
-            rxBuffer_.push_back(registers_[makeKey(address, currentRegister_ + i)]);
+            rxBuffer_.push_back(registers_[makeKey(address, reg + i)]);
         }
         rxIndex_ = 0;
         return quantity;
@@ -79,7 +80,7 @@ class TwoWire {
     }
 
     uint8_t currentAddress_ = 0;
-    uint8_t currentRegister_ = 0;
+    std::map<uint8_t, uint8_t> currentRegisterByAddr_;
     std::vector<uint8_t> txBuffer_;
     std::vector<uint8_t> rxBuffer_;
     size_t rxIndex_ = 0;

--- a/tests/native/helpers/Wire.h
+++ b/tests/native/helpers/Wire.h
@@ -11,8 +11,6 @@ class TwoWire {
    public:
     void begin() {}
 
-    void setRegister(uint8_t reg, uint8_t value) { registers_[reg] = value; }
-
     void beginTransmission(uint8_t address) {
         currentAddress_ = address;
         txBuffer_.clear();
@@ -24,21 +22,22 @@ class TwoWire {
     }
 
     uint8_t endTransmission(bool = true) {
-        if (txBuffer_.size() == 1) {
-            currentRegister_ = txBuffer_[0];
-        } else if (txBuffer_.size() >= 2) {
+        if (txBuffer_.size() >= 2) {
             uint8_t reg = txBuffer_[0];
             uint8_t val = txBuffer_[1];
-            registers_[reg] = val;
+            registers_[makeKey(currentAddress_, reg)] = val;
+            writes_.push_back({currentAddress_, reg, val});
             currentRegister_ = reg;
+        } else if (txBuffer_.size() == 1) {
+            currentRegister_ = txBuffer_[0];
         }
         return 0;
     }
 
-    uint8_t requestFrom(uint8_t, uint8_t quantity) {
+    uint8_t requestFrom(uint8_t address, uint8_t quantity) {
         rxBuffer_.clear();
         for (uint8_t i = 0; i < quantity; ++i) {
-            rxBuffer_.push_back(registers_[currentRegister_ + i]);
+            rxBuffer_.push_back(registers_[makeKey(address, currentRegister_ + i)]);
         }
         rxIndex_ = 0;
         return quantity;
@@ -53,13 +52,39 @@ class TwoWire {
         return -1;
     }
 
+    // Host-side helpers — not part of the real Arduino TwoWire API.
+
+    void setRegister(uint8_t address, uint8_t reg, uint8_t value) {
+        registers_[makeKey(address, reg)] = value;
+    }
+
+    uint8_t getRegister(uint8_t address, uint8_t reg) const {
+        auto it = registers_.find(makeKey(address, reg));
+        return (it != registers_.end()) ? it->second : 0x00;
+    }
+
+    struct WriteOp {
+        uint8_t address;
+        uint8_t reg;
+        uint8_t value;
+    };
+
+    const std::vector<WriteOp>& getWrites() const { return writes_; }
+
+    void clearWrites() { writes_.clear(); }
+
    private:
+    static uint16_t makeKey(uint8_t addr, uint8_t reg) {
+        return (static_cast<uint16_t>(addr) << 8) | reg;
+    }
+
     uint8_t currentAddress_ = 0;
     uint8_t currentRegister_ = 0;
     std::vector<uint8_t> txBuffer_;
     std::vector<uint8_t> rxBuffer_;
     size_t rxIndex_ = 0;
-    std::map<uint8_t, uint8_t> registers_;
+    std::map<uint16_t, uint8_t> registers_;
+    std::vector<WriteOp> writes_;
 };
 
 inline TwoWire Wire;

--- a/tests/native/test_wire/test_main.cpp
+++ b/tests/native/test_wire/test_main.cpp
@@ -72,6 +72,31 @@ void test_addresses_are_isolated(void) {
     TEST_ASSERT_EQUAL_HEX8(0xBB, wire.getRegister(0x6B, 0x0F));
 }
 
+void test_multi_byte_write_fills_consecutive_registers(void) {
+    // Auto-increment semantics: one beginTransmission + write(reg) + write(v0)
+    // + write(v1) + write(v2) + endTransmission fills reg, reg+1, reg+2 and
+    // records one WriteOp per byte.
+    wire.beginTransmission(0x5F);
+    wire.write(0x10);
+    wire.write(0xA0);
+    wire.write(0xA1);
+    wire.write(0xA2);
+    wire.endTransmission();
+
+    TEST_ASSERT_EQUAL_HEX8(0xA0, wire.getRegister(0x5F, 0x10));
+    TEST_ASSERT_EQUAL_HEX8(0xA1, wire.getRegister(0x5F, 0x11));
+    TEST_ASSERT_EQUAL_HEX8(0xA2, wire.getRegister(0x5F, 0x12));
+
+    const auto& writes = wire.getWrites();
+    TEST_ASSERT_EQUAL(3, writes.size());
+    TEST_ASSERT_EQUAL_HEX8(0x10, writes[0].reg);
+    TEST_ASSERT_EQUAL_HEX8(0xA0, writes[0].value);
+    TEST_ASSERT_EQUAL_HEX8(0x11, writes[1].reg);
+    TEST_ASSERT_EQUAL_HEX8(0xA1, writes[1].value);
+    TEST_ASSERT_EQUAL_HEX8(0x12, writes[2].reg);
+    TEST_ASSERT_EQUAL_HEX8(0xA2, writes[2].value);
+}
+
 void test_interleaved_register_pointers_are_isolated(void) {
     // Driver A on 0x5F preloads register 0x10; driver B on 0x6B preloads
     // register 0x20. Selecting B's pointer must not clobber A's.
@@ -101,6 +126,7 @@ int main(void) {
     RUN_TEST(test_capture_write_operation);
     RUN_TEST(test_read_multiple_bytes);
     RUN_TEST(test_addresses_are_isolated);
+    RUN_TEST(test_multi_byte_write_fills_consecutive_registers);
     RUN_TEST(test_interleaved_register_pointers_are_isolated);
 
     return UNITY_END();

--- a/tests/native/test_wire/test_main.cpp
+++ b/tests/native/test_wire/test_main.cpp
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <unity.h>
+
+#include "Wire.h"
+
+TwoWire wire;
+
+void setUp(void) {
+    wire = TwoWire();
+}
+
+void tearDown(void) {}
+
+void test_read_preloaded_register(void) {
+    wire.setRegister(0x5F, 0x0F, 0xBC);
+
+    wire.beginTransmission(0x5F);
+    wire.write(0x0F);
+    wire.endTransmission(false);
+
+    wire.requestFrom(0x5F, 1);
+
+    TEST_ASSERT_EQUAL(1, wire.available());
+    TEST_ASSERT_EQUAL_HEX8(0xBC, wire.read());
+}
+
+void test_write_register(void) {
+    wire.beginTransmission(0x5F);
+    wire.write(0x20);
+    wire.write(0x81);
+    wire.endTransmission();
+
+    TEST_ASSERT_EQUAL_HEX8(0x81, wire.getRegister(0x5F, 0x20));
+}
+
+void test_capture_write_operation(void) {
+    wire.beginTransmission(0x5F);
+    wire.write(0x10);
+    wire.write(0xAA);
+    wire.endTransmission();
+
+    const auto& writes = wire.getWrites();
+
+    TEST_ASSERT_EQUAL(1, writes.size());
+    TEST_ASSERT_EQUAL_HEX8(0x5F, writes[0].address);
+    TEST_ASSERT_EQUAL_HEX8(0x10, writes[0].reg);
+    TEST_ASSERT_EQUAL_HEX8(0xAA, writes[0].value);
+}
+
+void test_read_multiple_bytes(void) {
+    wire.setRegister(0x5F, 0x10, 0x01);
+    wire.setRegister(0x5F, 0x11, 0x02);
+    wire.setRegister(0x5F, 0x12, 0x03);
+
+    wire.beginTransmission(0x5F);
+    wire.write(0x10);
+    wire.endTransmission(false);
+
+    wire.requestFrom(0x5F, 3);
+
+    TEST_ASSERT_EQUAL_HEX8(0x01, wire.read());
+    TEST_ASSERT_EQUAL_HEX8(0x02, wire.read());
+    TEST_ASSERT_EQUAL_HEX8(0x03, wire.read());
+}
+
+void test_addresses_are_isolated(void) {
+    wire.setRegister(0x5F, 0x0F, 0xAA);
+    wire.setRegister(0x6B, 0x0F, 0xBB);
+
+    TEST_ASSERT_EQUAL_HEX8(0xAA, wire.getRegister(0x5F, 0x0F));
+    TEST_ASSERT_EQUAL_HEX8(0xBB, wire.getRegister(0x6B, 0x0F));
+}
+
+int main(void) {
+    UNITY_BEGIN();
+
+    RUN_TEST(test_read_preloaded_register);
+    RUN_TEST(test_write_register);
+    RUN_TEST(test_capture_write_operation);
+    RUN_TEST(test_read_multiple_bytes);
+    RUN_TEST(test_addresses_are_isolated);
+
+    return UNITY_END();
+}

--- a/tests/native/test_wire/test_main.cpp
+++ b/tests/native/test_wire/test_main.cpp
@@ -72,6 +72,27 @@ void test_addresses_are_isolated(void) {
     TEST_ASSERT_EQUAL_HEX8(0xBB, wire.getRegister(0x6B, 0x0F));
 }
 
+void test_interleaved_register_pointers_are_isolated(void) {
+    // Driver A on 0x5F preloads register 0x10; driver B on 0x6B preloads
+    // register 0x20. Selecting B's pointer must not clobber A's.
+    wire.setRegister(0x5F, 0x10, 0xA1);
+    wire.setRegister(0x6B, 0x20, 0xB2);
+
+    wire.beginTransmission(0x5F);
+    wire.write(0x10);
+    wire.endTransmission(false);
+
+    wire.beginTransmission(0x6B);
+    wire.write(0x20);
+    wire.endTransmission(false);
+
+    wire.requestFrom(0x5F, 1);
+    TEST_ASSERT_EQUAL_HEX8(0xA1, wire.read());
+
+    wire.requestFrom(0x6B, 1);
+    TEST_ASSERT_EQUAL_HEX8(0xB2, wire.read());
+}
+
 int main(void) {
     UNITY_BEGIN();
 
@@ -80,6 +101,7 @@ int main(void) {
     RUN_TEST(test_capture_write_operation);
     RUN_TEST(test_read_multiple_bytes);
     RUN_TEST(test_addresses_are_isolated);
+    RUN_TEST(test_interleaved_register_pointers_are_isolated);
 
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

Enrich the host-side `TwoWire` mock (under `tests/native/helpers/Wire.h`) so native tests can cover I2C driver logic: per-device register isolation and write-sequence capture, on top of the register read/write simulation that PR #87 landed.

Closes #21

## Design note

Initially proposed as a new `MockWire` class separate from `TwoWire`. During review we folded the improvements into the existing `TwoWire` because the project convention ([CLAUDE.md](../blob/main/CLAUDE.md)) is that drivers accept `TwoWire&`; a parallel `MockWire` class could not be passed to those drivers without either templating, a typedef, or refactoring. Merging keeps a single canonical mock that is drop-in compatible with `TwoWire&`-typed drivers.

## Changes

### Mock (`tests/native/helpers/Wire.h`)

* Register map re-keyed by `(address, reg)` via a private `makeKey(addr, reg)` composite — previously all simulated devices shared a flat register space, which broke as soon as a test needed two peripherals on the same bus.
* `endTransmission()` now records each observed write into `std::vector<WriteOp{address, reg, value}>`, exposed via `getWrites()` / `clearWrites()`. Tests can assert exact driver write sequences, not just end state.
* `setRegister(address, reg, value)` / `getRegister(address, reg)` take an explicit address argument to match the new keying.
* The Arduino-compatible API surface (`begin` / `beginTransmission` / `write` / `endTransmission` / `requestFrom` / `available` / `read`) stays byte-for-byte compatible. The `inline TwoWire Wire;` global remains, so drivers using the default `Wire` argument still work.

### Tests (`tests/native/test_wire/`)

Five Unity tests pinning the mock contract:

* `test_read_preloaded_register` — setRegister → transmission → requestFrom → read
* `test_write_register` — bus write persisted, readable via getRegister
* `test_capture_write_operation` — each endTransmission records exactly one WriteOp
* `test_read_multiple_bytes` — consecutive reads from increasing register indices
* `test_addresses_are_isolated` — same register number on two different addresses does not collide (covers the new per-address feature)

### Documentation (`tests/TESTING.md`)

Rewrite the *Mocking Approach* section to pair each mock with its helper header, list the host-side helpers the Wire mock exposes beyond the real Arduino API, and add a worked example showing how a driver test would instantiate the mock and exercise `begin()`. Drops the "Extend I2C mock" bullet from Future Work now that it is covered.

## Verification

* `pio test -e native` → **8/8 tests passing** in ~1 s (3 LED + 5 Wire)
* `make ci` → lint + build + native tests, clean
* `clang-format --dry-run --Werror` clean on all touched C++ files

## Checklist

* [x] `make lint` passes (clang-format)
* [x] `make build` passes (PlatformIO)
* [x] `make test-native` passes (8/8)
* [ ] `make test-hardware` — not applicable, this PR is native-only
* [x] `tests/TESTING.md` updated
* [x] SPDX headers on new C++ files
* [x] Commit messages follow conventional commits format