### PR TITLE
ci: Add Lint workflow (format-check today, clang-tidy scaffold).

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,23 @@
+name: Clang Format
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install clang-format and make
+        run: sudo apt-get update && sudo apt-get install -y clang-format make
+
+      - name: Run formatting check
+        run: make lint

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -16,8 +16,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install clang-format and make
-        run: sudo apt-get update && sudo apt-get install -y clang-format make
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
 
       - name: Run formatting check
         run: make lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Clang Format
+name: Lint
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  clang-format:
+  lint:
     runs-on: ubuntu-latest
 
     steps:
@@ -21,5 +21,5 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Run formatting check
+      - name: Run lint checks
         run: make lint

--- a/Makefile
+++ b/Makefile
@@ -11,22 +11,22 @@ node_modules/.package-lock.json: package.json package-lock.json
 	npm install
 	@touch $@
 
-# Python-based tooling (PlatformIO, clang-format) is installed in a local
-# virtualenv so versions are pinned per-repo and nothing pollutes the system
-# Python. Tools take the venv as an order-only prerequisite so its creation
-# happens once even when multiple tools depend on it.
+# Python-based tooling (PlatformIO, clang-format, clang-tidy) is installed
+# in a local virtualenv so nothing pollutes the system Python. Versions are
+# pinned in requirements.txt; each tool target depends on that file so a
+# version bump re-triggers pip install on the next make invocation.
 .venv:
 	python3 -m venv .venv
 	.venv/bin/pip install --upgrade pip
 
-.venv/bin/pio: | .venv
-	.venv/bin/pip install platformio
+.venv/bin/pio: requirements.txt | .venv
+	.venv/bin/pip install -c requirements.txt platformio
 
-.venv/bin/clang-format: | .venv
-	.venv/bin/pip install clang-format
+.venv/bin/clang-format: requirements.txt | .venv
+	.venv/bin/pip install -c requirements.txt clang-format
 
-.venv/bin/clang-tidy: | .venv
-	.venv/bin/pip install clang-tidy
+.venv/bin/clang-tidy: requirements.txt | .venv
+	.venv/bin/pip install -c requirements.txt clang-tidy
 
 .PHONY: install-pio
 install-pio: .venv/bin/pio ## Install PlatformIO in the local venv

--- a/Makefile
+++ b/Makefile
@@ -11,22 +11,32 @@ node_modules/.package-lock.json: package.json package-lock.json
 	npm install
 	@touch $@
 
-# PlatformIO is installed in a local Python virtualenv so the toolchain
-# is reproducible and doesn't pollute the system Python.
-.venv/bin/pio:
+# Python-based tooling (PlatformIO, clang-format) is installed in a local
+# virtualenv so versions are pinned per-repo and nothing pollutes the system
+# Python. Tools take the venv as an order-only prerequisite so its creation
+# happens once even when multiple tools depend on it.
+.venv:
 	python3 -m venv .venv
 	.venv/bin/pip install --upgrade pip
+
+.venv/bin/pio: | .venv
 	.venv/bin/pip install platformio
 
+.venv/bin/clang-format: | .venv
+	.venv/bin/pip install clang-format
+
 .PHONY: install-pio
-install-pio: .venv/bin/pio ## Install PlatformIO in a local Python venv
+install-pio: .venv/bin/pio ## Install PlatformIO in the local venv
+
+.PHONY: install-lint
+install-lint: .venv/bin/clang-format ## Install clang-format in the local venv
 
 .PHONY: prepare
 prepare: node_modules/.package-lock.json ## Install git hooks
 	husky
 
 .PHONY: setup
-setup: install install-pio prepare ## Full dev environment setup
+setup: install install-pio install-lint prepare ## Full dev environment setup
 
 .PHONY: install
 install: node_modules/.package-lock.json ## Install dev tools (npm)

--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,12 @@ install: node_modules/.package-lock.json ## Install dev tools (npm)
 # --- Formatting ---
 
 .PHONY: lint
-lint: ## Check formatting with clang-format
-	find lib/ -name '*.h' -o -name '*.cpp' -o -name '*.ino' | xargs clang-format --dry-run --Werror
+lint: .venv/bin/clang-format ## Check formatting with clang-format
+	find lib/ src/ tests/ -name '*.h' -o -name '*.cpp' -o -name '*.ino' | xargs clang-format --dry-run --Werror
 
 .PHONY: lint-fix
-lint-fix: ## Auto-fix formatting
-	find lib/ -name '*.h' -o -name '*.cpp' -o -name '*.ino' | xargs clang-format -i
+lint-fix: .venv/bin/clang-format ## Auto-fix formatting
+	find lib/ src/ tests/ -name '*.h' -o -name '*.cpp' -o -name '*.ino' | xargs clang-format -i
 
 # --- Build ---
 

--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,14 @@ node_modules/.package-lock.json: package.json package-lock.json
 .venv/bin/clang-format: | .venv
 	.venv/bin/pip install clang-format
 
+.venv/bin/clang-tidy: | .venv
+	.venv/bin/pip install clang-tidy
+
 .PHONY: install-pio
 install-pio: .venv/bin/pio ## Install PlatformIO in the local venv
 
 .PHONY: install-lint
-install-lint: .venv/bin/clang-format ## Install clang-format in the local venv
+install-lint: .venv/bin/clang-format .venv/bin/clang-tidy ## Install lint tools in the local venv
 
 .PHONY: prepare
 prepare: node_modules/.package-lock.json ## Install git hooks
@@ -53,10 +56,15 @@ format-fix: .venv/bin/clang-format ## Auto-fix formatting in place
 
 # --- Linting ---
 # lint is a meta-target — it aggregates every static check we run on the
-# source tree. Today that's just format-check; tidy lands via issue #107.
+# source tree. Each sub-target is runnable on its own.
+
+.PHONY: tidy
+tidy: .venv/bin/clang-tidy ## Run clang-tidy static analysis (scaffold — see #107)
+	@echo "clang-tidy scaffold: full integration tracked in issue #107"
+	@echo "  (needs compile_commands.json via 'pio run -t compiledb' + rule preset)"
 
 .PHONY: lint
-lint: format-check ## Run all static checks (format + future static analysis)
+lint: format-check tidy ## Run all static checks (format + static analysis)
 
 # --- Build ---
 

--- a/Makefile
+++ b/Makefile
@@ -43,13 +43,20 @@ install: node_modules/.package-lock.json ## Install dev tools (npm)
 
 # --- Formatting ---
 
-.PHONY: lint
-lint: .venv/bin/clang-format ## Check formatting with clang-format
+.PHONY: format-check
+format-check: .venv/bin/clang-format ## Check formatting with clang-format
 	find lib/ src/ tests/ -name '*.h' -o -name '*.cpp' -o -name '*.ino' | xargs clang-format --dry-run --Werror
 
-.PHONY: lint-fix
-lint-fix: .venv/bin/clang-format ## Auto-fix formatting
+.PHONY: format-fix
+format-fix: .venv/bin/clang-format ## Auto-fix formatting in place
 	find lib/ src/ tests/ -name '*.h' -o -name '*.cpp' -o -name '*.ino' | xargs clang-format -i
+
+# --- Linting ---
+# lint is a meta-target — it aggregates every static check we run on the
+# source tree. Today that's just format-check; tidy lands via issue #107.
+
+.PHONY: lint
+lint: format-check ## Run all static checks (format + future static analysis)
 
 # --- Build ---
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     }
   },
   "lint-staged": {
-    "*.{h,cpp,ino}": "clang-format --dry-run --Werror"
+    "*.{h,cpp,ino}": ".venv/bin/clang-format --dry-run --Werror"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+# Python-based development tooling, installed into the local .venv/ by
+# `make setup` (see Makefile). Versions are pinned so every contributor
+# and the CI runner resolve to the exact same binaries — bump with care
+# and verify make ci still passes.
+
+platformio==6.1.19
+clang-format==22.1.3
+clang-tidy==22.1.0.1


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow that runs the static-check meta-target `make lint` on every push to `main` and every PR. Restructure the Makefile to separate formatting from linting (they are distinct concerns), install both `clang-format` and `clang-tidy` in the local `.venv/` so every contributor and the CI runner use the same pinned binaries, and scaffold `make tidy` as a placeholder wired into `make lint` — full clang-tidy integration tracked in a follow-up issue.

Closes #17
Closes #103

## Changes

### CI workflow (`.github/workflows/lint.yml`)

- Triggered on `push` to `main` and `pull_request` targeting `main`.
- Runs `make lint` — no `apt-get install clang-format`; the tools are installed on-demand in the venv by `make lint`'s own prerequisites.
- Only external setup is `actions/setup-python@v5` so `python3 -m venv` is available.

### Makefile restructure

- `.venv/` creation extracted as a shared target; `pio`, `clang-format`, `clang-tidy` are all installed via order-only prerequisites on it (single venv, single `pip upgrade`).
- `make format-check` / `make format-fix` — run `clang-format --dry-run --Werror` and `clang-format -i` on `lib/ + src/ + tests/` (scope broadened from `lib/` only).
- `make tidy` — scaffold that prints a pointer to issue #107 for the full integration (rule preset, `compile_commands.json` via `pio run -t compiledb`, real analysis invocation).
- `make lint` — meta-target that now chains `format-check + tidy`. When issue #107 replaces the `tidy` scaffold with a real invocation, `make lint`, `make ci`, and the workflow benefit for free.
- `make install-lint` — meta that installs both `clang-format` and `clang-tidy` via the venv.
- `make setup` still bootstraps the full dev environment on a fresh clone in one command.

### Husky / lint-staged (`package.json`)

- Pre-commit hook points at `.venv/bin/clang-format --dry-run --Werror` explicitly.

## Follow-ups

- **#107** — flesh out `make tidy` (rule preset, compilation database, rollout).

## Verification

- `make install-lint` → installs `clang-format` 22.1.3 + `clang-tidy` 22.1.0.1 in `.venv/` ✅
- `make format-check` → no drift across `lib/ src/ tests/` ✅
- `make tidy` → prints scaffold notice, exits 0 ✅
- `make lint` → runs both in order ✅

## Checklist

- [x] `make lint` passes (format-check + tidy scaffold)
- [x] `make build` still passes
- [x] `make test-native` still passes
- [x] Fresh-clone `make setup` bootstraps everything automatically