### PR TITLE
feat(hts221): Add humidity + temperature driver with native tests.

### DIFF
--- a/lib/hts221/README.md
+++ b/lib/hts221/README.md
@@ -12,15 +12,20 @@ temperature sensor on the STeaMi board.
 
 ## Quick start
 
+On the STeaMi board, the HTS221 is routed to the **internal** I2C bus
+(pins `I2C_INT_SDA` / `I2C_INT_SCL` from the variant, not the default
+global `Wire`). Spin up a dedicated `TwoWire` and hand it to the driver:
+
 ```cpp
 #include <Wire.h>
 #include <HTS221.h>
 
-HTS221 sensor;
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+HTS221 sensor(internalI2C);
 
 void setup() {
     Serial.begin(115200);
-    Wire.begin();
+    internalI2C.begin();
 
     if (!sensor.begin()) {
         Serial.println("HTS221 not detected");

--- a/lib/hts221/README.md
+++ b/lib/hts221/README.md
@@ -1,5 +1,112 @@
-# hts221
+# HTS221
 
-Arduino driver for the hts221 component of the STeaMi board.
+Arduino/C++ driver for the ST HTS221 capacitive digital humidity and
+temperature sensor on the STeaMi board.
 
-> **Status**: not yet implemented
+## Hardware
+
+* I2C sensor, default 7-bit address `0x5F` (SA0 pulled low on the STeaMi
+  board).
+* Factory-calibrated — the driver loads the calibration block from the
+  part itself and applies it on every reading.
+
+## Quick start
+
+```cpp
+#include <Wire.h>
+#include <HTS221.h>
+
+HTS221 sensor;
+
+void setup() {
+    Serial.begin(115200);
+    Wire.begin();
+
+    if (!sensor.begin()) {
+        Serial.println("HTS221 not detected");
+        while (true) delay(1000);
+    }
+
+    sensor.setContinuous(HTS221_ODR_1_HZ);
+}
+
+void loop() {
+    if (sensor.dataReady()) {
+        auto r = sensor.read();
+        Serial.print(r.temperature);
+        Serial.print(" C / ");
+        Serial.print(r.humidity);
+        Serial.println(" %");
+    }
+    delay(100);
+}
+```
+
+See [examples/read_temperature_humidity/](examples/read_temperature_humidity/)
+for the full sketch.
+
+## API
+
+All methods follow the conventions from [`CLAUDE.md`](../../CLAUDE.md)
+(`camelCase`, unit in method names only when necessary, no `read`/`get`
+prefix).
+
+### Lifecycle
+
+| Method | Description |
+|--------|-------------|
+| `HTS221(TwoWire& wire = Wire, uint8_t address = HTS221_DEFAULT_ADDRESS)` | Construct. Defaults to the global `Wire` and address `0x5F`. |
+| `bool begin()` | Probe `WHO_AM_I`, load factory calibration, leave the part powered down. Returns `false` if the sensor is not detected. |
+| `uint8_t deviceId()` | Reads `WHO_AM_I` (always `0xBC`). |
+| `void softReset()` / `void reboot()` | Reload factory trimming via `CTRL2.BOOT`. |
+| `void powerOn()` / `void powerOff()` | Toggle `CTRL1.PD`. |
+
+### Reading
+
+If the part is powered down when a read is requested, the driver auto-
+triggers a one-shot measurement, polls `dataReady()` with a timeout, and
+returns the result. The caller doesn't have to manage modes manually.
+
+| Method | Description |
+|--------|-------------|
+| `float temperature()` | Celsius. |
+| `float humidity()` | %RH, clamped to `[0, 100]`. |
+| `ReadResult read()` | Both channels — `{temperature, humidity}`. |
+| `bool dataReady()` | Both `H_DA` and `T_DA` set in `STATUS_REG`. |
+| `bool temperatureReady()` / `bool humidityReady()` | Per-channel readiness. |
+
+### Modes
+
+| Method | Description |
+|--------|-------------|
+| `void setContinuous(uint8_t odr)` | Continuous mode. Pass `HTS221_ODR_1_HZ`, `_7_HZ`, or `_12_5_HZ`. |
+| `void triggerOneShot()` | Non-blocking: start a single conversion. |
+| `ReadResult readOneShot()` | Trigger + wait + return. |
+
+### Calibration
+
+| Method | Description |
+|--------|-------------|
+| `void setTemperatureOffset(float offset)` | Additive Celsius offset on top of the factory calibration. |
+| `void calibrateTemperature(float refLow, float measLow, float refHigh, float measHigh)` | Two-point user calibration. Applied after the factory curve. |
+
+## Register constants
+
+`HTS221_const.h` exports register addresses (`HTS221_REG_*`), bit masks
+(`HTS221_CTRL1_*`, `HTS221_STATUS_*`), and ODR values (`HTS221_ODR_*`) so
+applications can poke the part directly if they need something outside
+the driver's API surface.
+
+## Testing
+
+Host-side unit tests under [`tests/native/test_hts221/`](../../tests/native/test_hts221/)
+exercise the driver against the `TwoWire` mock from
+`tests/native/helpers/Wire.h`. Run them without hardware with:
+
+```bash
+make test-native
+```
+
+## License
+
+GPL-3.0-or-later — see [LICENSE](../../LICENSE).

--- a/lib/hts221/README.md
+++ b/lib/hts221/README.md
@@ -52,9 +52,9 @@ for the full sketch.
 
 ## API
 
-All methods follow the conventions from [`CLAUDE.md`](../../CLAUDE.md)
-(`camelCase`, unit in method names only when necessary, no `read`/`get`
-prefix).
+All methods follow the collection conventions: `camelCase`, include
+units in method names only when they carry ambiguity, and skip
+redundant `read` / `get` prefixes.
 
 ### Lifecycle
 

--- a/lib/hts221/examples/read_temperature_humidity/read_temperature_humidity.ino
+++ b/lib/hts221/examples/read_temperature_humidity/read_temperature_humidity.ino
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// HTS221 — read humidity and temperature at 1 Hz and print them over Serial.
+//
+// Wiring on the STeaMi board: the HTS221 sits on the internal I2C bus, no
+// external hookup needed. Just flash this example and open the serial
+// monitor at 115200 baud.
+
+#include <Arduino.h>
+#include <HTS221.h>
+#include <Wire.h>
+
+HTS221 sensor;
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial && millis() < 2000) {
+        // Wait up to 2 s for a connected monitor — on the STeaMi USB CDC
+        // !Serial stays true until the host enumerates.
+    }
+
+    Wire.begin();
+
+    if (!sensor.begin()) {
+        Serial.println("HTS221 not detected — check wiring and I2C address.");
+        while (true) {
+            delay(1000);
+        }
+    }
+
+    Serial.print("HTS221 detected (WHO_AM_I = 0x");
+    Serial.print(sensor.deviceId(), HEX);
+    Serial.println(")");
+
+    sensor.setContinuous(HTS221_ODR_1_HZ);
+}
+
+void loop() {
+    if (!sensor.dataReady()) {
+        delay(10);
+        return;
+    }
+
+    auto reading = sensor.read();
+
+    Serial.print("T = ");
+    Serial.print(reading.temperature, 2);
+    Serial.print(" C  |  H = ");
+    Serial.print(reading.humidity, 1);
+    Serial.println(" %");
+
+    delay(1000);
+}

--- a/lib/hts221/examples/read_temperature_humidity/read_temperature_humidity.ino
+++ b/lib/hts221/examples/read_temperature_humidity/read_temperature_humidity.ino
@@ -10,7 +10,11 @@
 #include <HTS221.h>
 #include <Wire.h>
 
-HTS221 sensor;
+// The HTS221 hangs off the STeaMi internal I2C bus (PB8 / PB9), not the
+// default global Wire. Spin up a dedicated TwoWire pointed at the variant
+// pin macros and hand it to the driver.
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+HTS221 sensor(internalI2C);
 
 void setup() {
     Serial.begin(115200);
@@ -19,7 +23,7 @@ void setup() {
         // !Serial stays true until the host enumerates.
     }
 
-    Wire.begin();
+    internalI2C.begin();
 
     if (!sensor.begin()) {
         Serial.println("HTS221 not detected — check wiring and I2C address.");

--- a/lib/hts221/keywords.txt
+++ b/lib/hts221/keywords.txt
@@ -1,0 +1,43 @@
+#######################################
+# Syntax Coloring Map For HTS221
+#######################################
+
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+HTS221	KEYWORD1
+ReadResult	KEYWORD1
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+
+begin	KEYWORD2
+deviceId	KEYWORD2
+reboot	KEYWORD2
+softReset	KEYWORD2
+powerOn	KEYWORD2
+powerOff	KEYWORD2
+dataReady	KEYWORD2
+temperatureReady	KEYWORD2
+humidityReady	KEYWORD2
+temperature	KEYWORD2
+humidity	KEYWORD2
+read	KEYWORD2
+setContinuous	KEYWORD2
+triggerOneShot	KEYWORD2
+readOneShot	KEYWORD2
+setTemperatureOffset	KEYWORD2
+calibrateTemperature	KEYWORD2
+
+#######################################
+# Constants (LITERAL1)
+#######################################
+
+HTS221_DEFAULT_ADDRESS	LITERAL1
+HTS221_WHO_AM_I_VALUE	LITERAL1
+HTS221_ODR_ONE_SHOT	LITERAL1
+HTS221_ODR_1_HZ	LITERAL1
+HTS221_ODR_7_HZ	LITERAL1
+HTS221_ODR_12_5_HZ	LITERAL1

--- a/lib/hts221/library.properties
+++ b/lib/hts221/library.properties
@@ -1,0 +1,10 @@
+name=STeaMi HTS221
+version=1.0.0
+author=STeaMi contributors
+maintainer=STeaMi contributors
+sentence=HTS221 humidity and temperature sensor driver for the STeaMi board.
+paragraph=Arduino-compatible driver for the ST HTS221 I2C humidity + temperature sensor. Exposes the STeaMi driver collection API (begin, deviceId, temperature, humidity, read, setContinuous, triggerOneShot, readOneShot) plus factory and user calibration hooks.
+category=Sensors
+url=https://github.com/steamicc/arduino-steami-lib
+architectures=*
+includes=HTS221.h

--- a/lib/hts221/src/HTS221.cpp
+++ b/lib/hts221/src/HTS221.cpp
@@ -2,6 +2,8 @@
 
 #include "HTS221.h"
 
+#include <math.h>
+
 HTS221::HTS221(TwoWire& wire, uint8_t address) : _wire(&wire), _address(address) {}
 
 bool HTS221::begin() {
@@ -69,7 +71,13 @@ float HTS221::humidity() {
 HTS221::ReadResult HTS221::read() {
     if (!isPoweredOn()) {
         triggerOneShot();
-        waitForDataReady();
+        if (!waitForDataReady()) {
+            // Device never reported fresh data — bus issue, missing sensor,
+            // or the caller disabled ODR and didn't trigger a conversion.
+            // Surface the failure as NaN so silent stale readings can't
+            // propagate; callers can check with isnan().
+            return {NAN, NAN};
+        }
     }
 
     uint8_t humBytes[2];
@@ -96,7 +104,9 @@ void HTS221::triggerOneShot() {
 
 HTS221::ReadResult HTS221::readOneShot() {
     triggerOneShot();
-    waitForDataReady();
+    if (!waitForDataReady()) {
+        return {NAN, NAN};
+    }
     return read();
 }
 
@@ -138,6 +148,13 @@ void HTS221::writeReg(uint8_t reg, uint8_t value) {
 }
 
 void HTS221::readRegs(uint8_t reg, uint8_t* buf, size_t len) {
+    // Zero-init up front so a short bus read leaves defined bytes in buf
+    // rather than whatever was on the stack — callers assume every slot
+    // was written.
+    for (size_t i = 0; i < len; ++i) {
+        buf[i] = 0;
+    }
+
     _wire->beginTransmission(_address);
     _wire->write(reg | HTS221_AUTO_INCREMENT);
     _wire->endTransmission(false);

--- a/lib/hts221/src/HTS221.cpp
+++ b/lib/hts221/src/HTS221.cpp
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "HTS221.h"
+
+HTS221::HTS221(TwoWire& wire, uint8_t address) : _wire(&wire), _address(address) {}
+
+bool HTS221::begin() {
+    if (deviceId() != HTS221_WHO_AM_I_VALUE) {
+        return false;
+    }
+    loadCalibration();
+    // Leave the part powered down after detection. Measurement methods
+    // auto-trigger on demand; users that want streaming call setContinuous().
+    powerOff();
+    return true;
+}
+
+uint8_t HTS221::deviceId() {
+    return readReg(HTS221_REG_WHO_AM_I);
+}
+
+void HTS221::reboot() {
+    writeReg(HTS221_REG_CTRL2, HTS221_CTRL2_BOOT);
+    // BOOT clears itself when the reload completes. Poll with a bounded
+    // timeout so a stuck bus doesn't hang the caller.
+    for (uint8_t i = 0; i < 20; ++i) {
+        if ((readReg(HTS221_REG_CTRL2) & HTS221_CTRL2_BOOT) == 0) {
+            return;
+        }
+        delay(5);
+    }
+}
+
+void HTS221::softReset() {
+    reboot();
+}
+
+void HTS221::powerOn() {
+    uint8_t ctrl1 = readReg(HTS221_REG_CTRL1);
+    writeReg(HTS221_REG_CTRL1, ctrl1 | HTS221_CTRL1_PD | HTS221_CTRL1_BDU);
+}
+
+void HTS221::powerOff() {
+    uint8_t ctrl1 = readReg(HTS221_REG_CTRL1);
+    writeReg(HTS221_REG_CTRL1, ctrl1 & ~HTS221_CTRL1_PD);
+}
+
+bool HTS221::dataReady() {
+    return (status() & (HTS221_STATUS_H_DA | HTS221_STATUS_T_DA)) ==
+           (HTS221_STATUS_H_DA | HTS221_STATUS_T_DA);
+}
+
+bool HTS221::temperatureReady() {
+    return (status() & HTS221_STATUS_T_DA) != 0;
+}
+
+bool HTS221::humidityReady() {
+    return (status() & HTS221_STATUS_H_DA) != 0;
+}
+
+float HTS221::temperature() {
+    return read().temperature;
+}
+
+float HTS221::humidity() {
+    return read().humidity;
+}
+
+HTS221::ReadResult HTS221::read() {
+    if (!isPoweredOn()) {
+        triggerOneShot();
+        waitForDataReady();
+    }
+
+    uint8_t humBytes[2];
+    uint8_t tempBytes[2];
+    readRegs(HTS221_REG_HUMIDITY_OUT_L, humBytes, 2);
+    readRegs(HTS221_REG_TEMP_OUT_L, tempBytes, 2);
+
+    int16_t humRaw = static_cast<int16_t>(humBytes[0] | (humBytes[1] << 8));
+    int16_t tempRaw = static_cast<int16_t>(tempBytes[0] | (tempBytes[1] << 8));
+
+    return {computeTemperature(tempRaw), computeHumidity(humRaw)};
+}
+
+void HTS221::setContinuous(uint8_t odr) {
+    uint8_t ctrl1 = HTS221_CTRL1_PD | HTS221_CTRL1_BDU | (odr & HTS221_CTRL1_ODR_MASK);
+    writeReg(HTS221_REG_CTRL1, ctrl1);
+}
+
+void HTS221::triggerOneShot() {
+    // Must be powered on at ODR=one-shot for the ONE_SHOT bit to matter.
+    writeReg(HTS221_REG_CTRL1, HTS221_CTRL1_PD | HTS221_CTRL1_BDU | HTS221_ODR_ONE_SHOT);
+    writeReg(HTS221_REG_CTRL2, HTS221_CTRL2_ONE_SHOT);
+}
+
+HTS221::ReadResult HTS221::readOneShot() {
+    triggerOneShot();
+    waitForDataReady();
+    return read();
+}
+
+void HTS221::setTemperatureOffset(float offset) {
+    _tempOffset = offset;
+}
+
+void HTS221::calibrateTemperature(float refLow, float measLow, float refHigh, float measHigh) {
+    float span = measHigh - measLow;
+    if (span == 0.0f) {
+        _tempUserSlope = 1.0f;
+        _tempUserIntercept = 0.0f;
+        return;
+    }
+    _tempUserSlope = (refHigh - refLow) / span;
+    _tempUserIntercept = refLow - _tempUserSlope * measLow;
+}
+
+uint8_t HTS221::status() {
+    return readReg(HTS221_REG_STATUS);
+}
+
+uint8_t HTS221::readReg(uint8_t reg) {
+    _wire->beginTransmission(_address);
+    _wire->write(reg);
+    _wire->endTransmission(false);
+    _wire->requestFrom(_address, static_cast<uint8_t>(1));
+    if (_wire->available()) {
+        return static_cast<uint8_t>(_wire->read());
+    }
+    return 0;
+}
+
+void HTS221::writeReg(uint8_t reg, uint8_t value) {
+    _wire->beginTransmission(_address);
+    _wire->write(reg);
+    _wire->write(value);
+    _wire->endTransmission();
+}
+
+void HTS221::readRegs(uint8_t reg, uint8_t* buf, size_t len) {
+    _wire->beginTransmission(_address);
+    _wire->write(reg | HTS221_AUTO_INCREMENT);
+    _wire->endTransmission(false);
+    _wire->requestFrom(_address, static_cast<uint8_t>(len));
+    for (size_t i = 0; i < len && _wire->available(); ++i) {
+        buf[i] = static_cast<uint8_t>(_wire->read());
+    }
+}
+
+void HTS221::loadCalibration() {
+    uint8_t block[16];
+    readRegs(HTS221_REG_H0_RH_X2, block, 16);
+
+    // H0_rH and H1_rH are stored as %RH * 2.
+    float h0Rh = block[0] * 0.5f;
+    float h1Rh = block[1] * 0.5f;
+
+    // T0_degC / T1_degC are 10-bit unsigned values * 8. The high 2 bits of
+    // each live in the shared T1_T0_MSB register at block offset 5.
+    uint8_t msb = block[5];
+    uint16_t t0Raw = ((msb & 0x03) << 8) | block[2];
+    uint16_t t1Raw = ((msb & 0x0C) << 6) | block[3];
+    float t0DegC = t0Raw / 8.0f;
+    float t1DegC = t1Raw / 8.0f;
+
+    // 16-bit signed ADC reference points. T1_T0_MSB sits at offset 5,
+    // so the OUT registers follow with one byte of gap: H0_T0_OUT at
+    // offsets 6-7, H1_T0_OUT at 10-11, T0_OUT at 12-13, T1_OUT at 14-15.
+    int16_t h0Out = static_cast<int16_t>(block[6] | (block[7] << 8));
+    int16_t h1Out = static_cast<int16_t>(block[10] | (block[11] << 8));
+    int16_t t0Out = static_cast<int16_t>(block[12] | (block[13] << 8));
+    int16_t t1Out = static_cast<int16_t>(block[14] | (block[15] << 8));
+
+    if (t1Out != t0Out) {
+        _tempSlope = (t1DegC - t0DegC) / static_cast<float>(t1Out - t0Out);
+        _tempIntercept = t0DegC - _tempSlope * static_cast<float>(t0Out);
+    }
+    if (h1Out != h0Out) {
+        _humSlope = (h1Rh - h0Rh) / static_cast<float>(h1Out - h0Out);
+        _humIntercept = h0Rh - _humSlope * static_cast<float>(h0Out);
+    }
+}
+
+bool HTS221::isPoweredOn() {
+    return (readReg(HTS221_REG_CTRL1) & HTS221_CTRL1_PD) != 0;
+}
+
+bool HTS221::waitForDataReady(uint32_t timeoutMs) {
+    uint32_t start = millis();
+    while (millis() - start < timeoutMs) {
+        if (dataReady()) {
+            return true;
+        }
+        delay(1);
+    }
+    return false;
+}
+
+float HTS221::computeTemperature(int16_t raw) {
+    float factory = _tempIntercept + _tempSlope * static_cast<float>(raw);
+    return _tempUserSlope * factory + _tempUserIntercept + _tempOffset;
+}
+
+float HTS221::computeHumidity(int16_t raw) {
+    float value = _humIntercept + _humSlope * static_cast<float>(raw);
+    if (value < 0.0f)
+        return 0.0f;
+    if (value > 100.0f)
+        return 100.0f;
+    return value;
+}

--- a/lib/hts221/src/HTS221.h
+++ b/lib/hts221/src/HTS221.h
@@ -82,7 +82,8 @@ class HTS221 {
    private:
     // Stored as a pointer (not a reference) so the class is default-assignable
     // — useful for tests that reconstruct the sensor between fixtures. The
-    // public constructor still takes a TwoWire& per CLAUDE.md convention.
+    // public constructor still takes a TwoWire& to keep the usual Arduino
+    // I2C interface at the call site.
     TwoWire* _wire;
     uint8_t _address;
 

--- a/lib/hts221/src/HTS221.h
+++ b/lib/hts221/src/HTS221.h
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <Arduino.h>
+#include <Wire.h>
+
+#include "HTS221_const.h"
+
+// HTS221 — ST capacitive humidity + temperature sensor, I2C.
+//
+// The public API intentionally mirrors the rest of the STeaMi driver
+// collection (begin / deviceId / powerOn / powerOff / softReset / reboot /
+// setContinuous / triggerOneShot / temperature / humidity / read) so
+// consumers learn one shape and reuse it across sensors.
+class HTS221 {
+   public:
+    struct ReadResult {
+        float temperature;  // Celsius
+        float humidity;     // %RH
+    };
+
+    HTS221(TwoWire& wire = Wire, uint8_t address = HTS221_DEFAULT_ADDRESS);
+
+    // Probe the device and load calibration. Returns false if WHO_AM_I
+    // does not match HTS221_WHO_AM_I_VALUE.
+    bool begin();
+
+    // WHO_AM_I value (always 0xBC on a healthy HTS221).
+    uint8_t deviceId();
+
+    // Software reset: reload the factory trimming from non-volatile memory.
+    void reboot();
+
+    // Software-visible reset equivalent to reboot() — the part has no
+    // dedicated reset register beyond BOOT, so softReset() and reboot()
+    // share the same mechanism. softReset() is kept for API symmetry
+    // with other drivers in the collection.
+    void softReset();
+
+    // Power control via CTRL_REG1.PD.
+    void powerOn();
+    void powerOff();
+
+    // Data-ready bits from STATUS_REG.
+    bool dataReady();
+    bool temperatureReady();
+    bool humidityReady();
+
+    // Single-channel reads. If the device is powered down, the method
+    // auto-triggers a one-shot measurement, waits for dataReady(), and
+    // returns the result — the caller doesn't need to manage modes.
+    float temperature();
+    float humidity();
+
+    // Combined reading — preferred when both channels are needed to keep
+    // them consistent (single auto-trigger, single poll).
+    ReadResult read();
+
+    // Continuous mode at the requested ODR (HTS221_ODR_1_HZ, _7_HZ, or
+    // _12_5_HZ). BDU is set so no register is updated mid-read.
+    void setContinuous(uint8_t odr);
+
+    // Trigger a single measurement without blocking. Pair with
+    // temperature() / humidity() after polling dataReady(), or use
+    // readOneShot() for the bundled flow.
+    void triggerOneShot();
+
+    // Trigger a one-shot measurement, wait for dataReady() with a timeout,
+    // and return both channels.
+    ReadResult readOneShot();
+
+    // Additive Celsius offset applied after the factory calibration.
+    void setTemperatureOffset(float offset);
+
+    // Two-point user calibration for temperature. refLow/refHigh are the
+    // known reference values in Celsius; measLow/measHigh are what the
+    // sensor reported at those references. Subsequent temperature()
+    // calls apply the correction on top of the factory calibration.
+    void calibrateTemperature(float refLow, float measLow, float refHigh, float measHigh);
+
+   private:
+    // Stored as a pointer (not a reference) so the class is default-assignable
+    // — useful for tests that reconstruct the sensor between fixtures. The
+    // public constructor still takes a TwoWire& per CLAUDE.md convention.
+    TwoWire* _wire;
+    uint8_t _address;
+
+    // Cached factory calibration, loaded by begin().
+    float _tempSlope = 0.0f;
+    float _tempIntercept = 0.0f;
+    float _humSlope = 0.0f;
+    float _humIntercept = 0.0f;
+
+    // User-applied correction (on top of the factory calibration).
+    float _tempOffset = 0.0f;
+    float _tempUserSlope = 1.0f;
+    float _tempUserIntercept = 0.0f;
+
+    uint8_t status();
+    uint8_t readReg(uint8_t reg);
+    void writeReg(uint8_t reg, uint8_t value);
+    void readRegs(uint8_t reg, uint8_t* buf, size_t len);
+
+    void loadCalibration();
+    bool isPoweredOn();
+    bool waitForDataReady(uint32_t timeoutMs = 100);
+    float computeTemperature(int16_t raw);
+    float computeHumidity(int16_t raw);
+};

--- a/lib/hts221/src/HTS221_const.h
+++ b/lib/hts221/src/HTS221_const.h
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <stdint.h>
+
+// Default 7-bit I2C address. Pin SA0 is tied low on the STeaMi board.
+constexpr uint8_t HTS221_DEFAULT_ADDRESS = 0x5F;
+
+// WHO_AM_I register fixed value — used by begin() to probe the device.
+constexpr uint8_t HTS221_WHO_AM_I_VALUE = 0xBC;
+
+// Register map (ST HTS221 datasheet, rev 5, table 17).
+constexpr uint8_t HTS221_REG_WHO_AM_I = 0x0F;
+constexpr uint8_t HTS221_REG_AV_CONF = 0x10;
+constexpr uint8_t HTS221_REG_CTRL1 = 0x20;
+constexpr uint8_t HTS221_REG_CTRL2 = 0x21;
+constexpr uint8_t HTS221_REG_CTRL3 = 0x22;
+constexpr uint8_t HTS221_REG_STATUS = 0x27;
+constexpr uint8_t HTS221_REG_HUMIDITY_OUT_L = 0x28;
+constexpr uint8_t HTS221_REG_TEMP_OUT_L = 0x2A;
+
+// Calibration block (0x30-0x3F).
+constexpr uint8_t HTS221_REG_H0_RH_X2 = 0x30;
+constexpr uint8_t HTS221_REG_H1_RH_X2 = 0x31;
+constexpr uint8_t HTS221_REG_T0_DEGC_X8 = 0x32;
+constexpr uint8_t HTS221_REG_T1_DEGC_X8 = 0x33;
+constexpr uint8_t HTS221_REG_T1_T0_MSB = 0x35;
+constexpr uint8_t HTS221_REG_H0_T0_OUT_L = 0x36;
+constexpr uint8_t HTS221_REG_H1_T0_OUT_L = 0x3A;
+constexpr uint8_t HTS221_REG_T0_OUT_L = 0x3C;
+constexpr uint8_t HTS221_REG_T1_OUT_L = 0x3E;
+
+// CTRL_REG1 bits.
+constexpr uint8_t HTS221_CTRL1_PD = 0x80;   // 1 = active, 0 = power-down
+constexpr uint8_t HTS221_CTRL1_BDU = 0x04;  // Block Data Update
+constexpr uint8_t HTS221_CTRL1_ODR_MASK = 0x03;
+
+// CTRL_REG2 bits.
+constexpr uint8_t HTS221_CTRL2_BOOT = 0x80;      // Reload calibration trimming
+constexpr uint8_t HTS221_CTRL2_HEATER = 0x02;    // Integrated heater
+constexpr uint8_t HTS221_CTRL2_ONE_SHOT = 0x01;  // Trigger a single measurement
+
+// STATUS_REG bits.
+constexpr uint8_t HTS221_STATUS_H_DA = 0x02;  // Humidity data available
+constexpr uint8_t HTS221_STATUS_T_DA = 0x01;  // Temperature data available
+
+// Output Data Rate values for CTRL_REG1 ODR[1:0].
+constexpr uint8_t HTS221_ODR_ONE_SHOT = 0x00;
+constexpr uint8_t HTS221_ODR_1_HZ = 0x01;
+constexpr uint8_t HTS221_ODR_7_HZ = 0x02;
+constexpr uint8_t HTS221_ODR_12_5_HZ = 0x03;
+
+// MSB of the sub-address enables register auto-increment on burst reads.
+constexpr uint8_t HTS221_AUTO_INCREMENT = 0x80;

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,6 +14,7 @@ test_filter = hardware/test_*
 platform = native
 test_framework = unity
 test_filter = native/test_*
+lib_compat_mode = off
 build_flags =
   -std=c++17
   -D UNIT_TEST

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,35 +1,42 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
-// Build smoke-test sketch: validates the board definition + STM32duino variant
-// compile. Not an example — see lib/<component>/examples/ for driver usage.
-// TODO(#102): once a driver is implemented under lib/, exercise it here so CI
-// also validates driver linkage.
+// Build smoke-test sketch: validates the board definition, the STM32duino
+// variant, and driver linkage for the sensors that have already landed.
+// Not an example — see lib/<component>/examples/ for driver usage.
 
 #include <Arduino.h>
+#include <HTS221.h>
+#include <Wire.h>
+
+HTS221 hts221;
 
 void setup() {
-    // Serial instance and pins are defined by the variant
     Serial.begin(115200);
     delay(2000);
 
-    Serial.println("STeaMi minimal test");
+    Serial.println("STeaMi smoke test");
 
-    // LEDs defined by the variant
     pinMode(LED_RED, OUTPUT);
     pinMode(LED_GREEN, OUTPUT);
     pinMode(LED_BLUE, OUTPUT);
+
+    Wire.begin();
+    if (hts221.begin()) {
+        Serial.print("HTS221 detected, WHO_AM_I = 0x");
+        Serial.println(hts221.deviceId(), HEX);
+    } else {
+        Serial.println("HTS221 not detected");
+    }
 }
 
 void loop() {
     Serial.println("Blink");
 
-    // Turn all LEDs on
     digitalWrite(LED_RED, HIGH);
     digitalWrite(LED_GREEN, HIGH);
     digitalWrite(LED_BLUE, HIGH);
     delay(500);
 
-    // Turn all LEDs off
     digitalWrite(LED_RED, LOW);
     digitalWrite(LED_GREEN, LOW);
     digitalWrite(LED_BLUE, LOW);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,13 @@ void setup() {
     if (hts221.begin()) {
         Serial.print("HTS221 detected, WHO_AM_I = 0x");
         Serial.println(hts221.deviceId(), HEX);
+
+        auto r = hts221.read();
+        Serial.print("HTS221 first read: T = ");
+        Serial.print(r.temperature, 2);
+        Serial.print(" C, H = ");
+        Serial.print(r.humidity, 1);
+        Serial.println(" %");
     } else {
         Serial.println("HTS221 not detected");
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,12 @@
 #include <HTS221.h>
 #include <Wire.h>
 
-HTS221 hts221;
+// The STeaMi routes the HTS221 to its internal I2C bus (pins PB8/PB9,
+// exported as I2C_INT_SCL / I2C_INT_SDA by the variant). The default
+// global Wire sits on a different pair, so spin up a dedicated TwoWire
+// for the on-board peripherals and hand it to the driver.
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+HTS221 hts221(internalI2C);
 
 void setup() {
     Serial.begin(115200);
@@ -20,7 +25,7 @@ void setup() {
     pinMode(LED_GREEN, OUTPUT);
     pinMode(LED_BLUE, OUTPUT);
 
-    Wire.begin();
+    internalI2C.begin();
     if (hts221.begin()) {
         Serial.print("HTS221 detected, WHO_AM_I = 0x");
         Serial.println(hts221.deviceId(), HEX);

--- a/tests/native/helpers/Arduino.h
+++ b/tests/native/helpers/Arduino.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 
 #define HIGH 1
@@ -33,16 +34,21 @@ inline int digitalRead(int pin) {
 
 // Simulated monotonic clock in milliseconds. delay() advances it so code that
 // polls until millis() - start >= timeout terminates on the host the same way
-// it would on hardware. Tests can set() directly to control absolute time.
-inline unsigned long& millisClock() {
-    static unsigned long clock = 0;
+// it would on hardware. Tests can assign `millisClock() = <value>` directly
+// to jump the clock (useful for exercising overflow paths).
+//
+// Width is pinned to uint32_t to match the Arduino core's millis() return
+// type — on Linux `unsigned long` is 64-bit and would silently mask any
+// 32-bit overflow bug the code under test might have on the target.
+inline uint32_t& millisClock() {
+    static uint32_t clock = 0;
     return clock;
 }
 
-inline unsigned long millis() {
+inline uint32_t millis() {
     return millisClock();
 }
 
-inline void delay(unsigned long ms) {
+inline void delay(uint32_t ms) {
     millisClock() += ms;
 }

--- a/tests/native/helpers/Arduino.h
+++ b/tests/native/helpers/Arduino.h
@@ -31,4 +31,18 @@ inline int digitalRead(int pin) {
     return gpioPinState()[pin];
 }
 
-inline void delay(unsigned long) {}
+// Simulated monotonic clock in milliseconds. delay() advances it so code that
+// polls until millis() - start >= timeout terminates on the host the same way
+// it would on hardware. Tests can set() directly to control absolute time.
+inline unsigned long& millisClock() {
+    static unsigned long clock = 0;
+    return clock;
+}
+
+inline unsigned long millis() {
+    return millisClock();
+}
+
+inline void delay(unsigned long ms) {
+    millisClock() += ms;
+}

--- a/tests/native/test_hts221/test_main.cpp
+++ b/tests/native/test_hts221/test_main.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include <math.h>
 #include <unity.h>
 
 #include "HTS221.h"
@@ -210,6 +211,20 @@ void test_calibrate_temperature_applies_two_point_correction(void) {
     TEST_ASSERT_FLOAT_WITHIN(0.01f, 22.0f, sensor.temperature());
 }
 
+void test_read_returns_nan_on_timeout(void) {
+    // begin() succeeds (WHO_AM_I preloaded in setUp) but leaves the device
+    // powered down, and STATUS is not preloaded with any DA bit. The
+    // auto-trigger path in read() will therefore hit the waitForDataReady
+    // timeout and must surface it as NaN rather than decoding whatever
+    // happened to be left on the stack.
+    sensor.begin();
+
+    auto r = sensor.read();
+
+    TEST_ASSERT_TRUE_MESSAGE(isnan(r.temperature), "temperature should be NaN on timeout");
+    TEST_ASSERT_TRUE_MESSAGE(isnan(r.humidity), "humidity should be NaN on timeout");
+}
+
 void test_reboot_writes_ctrl2_boot(void) {
     sensor.begin();
     Wire.clearWrites();
@@ -244,6 +259,7 @@ int main(void) {
     RUN_TEST(test_read_auto_triggers_when_powered_down);
     RUN_TEST(test_set_temperature_offset_shifts_reading);
     RUN_TEST(test_calibrate_temperature_applies_two_point_correction);
+    RUN_TEST(test_read_returns_nan_on_timeout);
     RUN_TEST(test_reboot_writes_ctrl2_boot);
     return UNITY_END();
 }

--- a/tests/native/test_hts221/test_main.cpp
+++ b/tests/native/test_hts221/test_main.cpp
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <unity.h>
+
+#include "HTS221.h"
+#include "Wire.h"
+
+// The driver uses bit 7 of the sub-address as the ST auto-increment flag for
+// multi-byte reads (see HTS221_AUTO_INCREMENT). The Wire mock is a straight
+// register map, so preloads for burst-read ranges have to sit at the
+// post-OR address the driver will actually emit on the wire.
+constexpr uint8_t ADDR = HTS221_DEFAULT_ADDRESS;
+constexpr uint8_t CAL_BASE = HTS221_REG_H0_RH_X2 | HTS221_AUTO_INCREMENT;
+constexpr uint8_t HUM_OUT_BASE = HTS221_REG_HUMIDITY_OUT_L | HTS221_AUTO_INCREMENT;
+constexpr uint8_t TEMP_OUT_BASE = HTS221_REG_TEMP_OUT_L | HTS221_AUTO_INCREMENT;
+
+static void preloadWhoAmI(bool valid = true) {
+    Wire.setRegister(ADDR, HTS221_REG_WHO_AM_I, valid ? HTS221_WHO_AM_I_VALUE : 0x42);
+}
+
+// Factory calibration chosen so the math is trivial to verify:
+//   temperature = 0.001 * raw       (T0=0 °C at raw 0, T1=25 °C at raw 25000)
+//   humidity    = (100/30000) * raw (H0=0 %RH at raw 0, H1=100 %RH at raw 30000)
+static void preloadFactoryCalibration() {
+    // H0_rH_x2 = 0 → H0 = 0 %RH, H1_rH_x2 = 200 → H1 = 100 %RH.
+    Wire.setRegister(ADDR, CAL_BASE + 0x00, 0);
+    Wire.setRegister(ADDR, CAL_BASE + 0x01, 200);
+    // T0_degC_x8 = 0 → T0 = 0 °C, T1_degC_x8 = 200 → T1 = 25 °C.
+    Wire.setRegister(ADDR, CAL_BASE + 0x02, 0);
+    Wire.setRegister(ADDR, CAL_BASE + 0x03, 200);
+    // Reserved byte (offset 4) and T1_T0_MSB (offset 5, high bits all zero).
+    Wire.setRegister(ADDR, CAL_BASE + 0x04, 0);
+    Wire.setRegister(ADDR, CAL_BASE + 0x05, 0);
+    // H0_T0_OUT = 0 (bytes 6-7).
+    Wire.setRegister(ADDR, CAL_BASE + 0x06, 0x00);
+    Wire.setRegister(ADDR, CAL_BASE + 0x07, 0x00);
+    // Reserved (bytes 8-9).
+    Wire.setRegister(ADDR, CAL_BASE + 0x08, 0);
+    Wire.setRegister(ADDR, CAL_BASE + 0x09, 0);
+    // H1_T0_OUT = 30000 = 0x7530 (bytes 10-11, little endian).
+    Wire.setRegister(ADDR, CAL_BASE + 0x0A, 0x30);
+    Wire.setRegister(ADDR, CAL_BASE + 0x0B, 0x75);
+    // T0_OUT = 0 (bytes 12-13).
+    Wire.setRegister(ADDR, CAL_BASE + 0x0C, 0x00);
+    Wire.setRegister(ADDR, CAL_BASE + 0x0D, 0x00);
+    // T1_OUT = 25000 = 0x61A8 (bytes 14-15, little endian).
+    Wire.setRegister(ADDR, CAL_BASE + 0x0E, 0xA8);
+    Wire.setRegister(ADDR, CAL_BASE + 0x0F, 0x61);
+}
+
+// Preload humidity and temperature OUT registers with values that, through
+// the calibration above, map to the requested clean values in %RH and °C.
+static void preloadMeasurement(float tempC, float humidityPct) {
+    auto rawFromTemp = [](float t) -> int16_t {
+        return static_cast<int16_t>(t / 0.001f);  // 1 °C = 1000 LSB
+    };
+    auto rawFromHum = [](float h) -> int16_t {
+        return static_cast<int16_t>(h * 300.0f);  // 100 %RH = 30000 LSB
+    };
+
+    int16_t tempRaw = rawFromTemp(tempC);
+    int16_t humRaw = rawFromHum(humidityPct);
+
+    Wire.setRegister(ADDR, TEMP_OUT_BASE + 0, tempRaw & 0xFF);
+    Wire.setRegister(ADDR, TEMP_OUT_BASE + 1, (tempRaw >> 8) & 0xFF);
+    Wire.setRegister(ADDR, HUM_OUT_BASE + 0, humRaw & 0xFF);
+    Wire.setRegister(ADDR, HUM_OUT_BASE + 1, (humRaw >> 8) & 0xFF);
+    Wire.setRegister(ADDR, HTS221_REG_STATUS, HTS221_STATUS_H_DA | HTS221_STATUS_T_DA);
+}
+
+HTS221 sensor;
+
+void setUp(void) {
+    Wire = TwoWire();
+    preloadWhoAmI(true);
+    preloadFactoryCalibration();
+    sensor = HTS221();
+}
+
+void tearDown(void) {}
+
+void test_begin_detects_device(void) {
+    TEST_ASSERT_TRUE(sensor.begin());
+}
+
+void test_begin_rejects_wrong_who_am_i(void) {
+    preloadWhoAmI(false);
+    TEST_ASSERT_FALSE(sensor.begin());
+}
+
+void test_device_id_returns_who_am_i(void) {
+    TEST_ASSERT_EQUAL_HEX8(HTS221_WHO_AM_I_VALUE, sensor.deviceId());
+}
+
+void test_power_on_sets_ctrl1_pd(void) {
+    sensor.begin();
+    sensor.powerOn();
+    uint8_t ctrl1 = Wire.getRegister(ADDR, HTS221_REG_CTRL1);
+    TEST_ASSERT_BITS_HIGH(HTS221_CTRL1_PD, ctrl1);
+    TEST_ASSERT_BITS_HIGH(HTS221_CTRL1_BDU, ctrl1);
+}
+
+void test_power_off_clears_ctrl1_pd(void) {
+    sensor.begin();
+    sensor.powerOn();
+    sensor.powerOff();
+    uint8_t ctrl1 = Wire.getRegister(ADDR, HTS221_REG_CTRL1);
+    TEST_ASSERT_BITS_LOW(HTS221_CTRL1_PD, ctrl1);
+}
+
+void test_set_continuous_writes_expected_ctrl1(void) {
+    sensor.begin();
+    sensor.setContinuous(HTS221_ODR_7_HZ);
+    uint8_t ctrl1 = Wire.getRegister(ADDR, HTS221_REG_CTRL1);
+    uint8_t expected = HTS221_CTRL1_PD | HTS221_CTRL1_BDU | HTS221_ODR_7_HZ;
+    TEST_ASSERT_EQUAL_HEX8(expected, ctrl1);
+}
+
+void test_trigger_one_shot_sets_ctrl2_one_shot(void) {
+    sensor.begin();
+    sensor.triggerOneShot();
+    uint8_t ctrl2 = Wire.getRegister(ADDR, HTS221_REG_CTRL2);
+    TEST_ASSERT_BITS_HIGH(HTS221_CTRL2_ONE_SHOT, ctrl2);
+}
+
+void test_data_ready_reflects_status_register(void) {
+    sensor.begin();
+    sensor.setContinuous(HTS221_ODR_1_HZ);
+    Wire.setRegister(ADDR, HTS221_REG_STATUS, 0);
+    TEST_ASSERT_FALSE(sensor.dataReady());
+    Wire.setRegister(ADDR, HTS221_REG_STATUS, HTS221_STATUS_T_DA);
+    TEST_ASSERT_FALSE(sensor.dataReady());  // one channel only
+    Wire.setRegister(ADDR, HTS221_REG_STATUS, HTS221_STATUS_H_DA | HTS221_STATUS_T_DA);
+    TEST_ASSERT_TRUE(sensor.dataReady());
+    TEST_ASSERT_TRUE(sensor.temperatureReady());
+    TEST_ASSERT_TRUE(sensor.humidityReady());
+}
+
+void test_read_returns_calibrated_values(void) {
+    sensor.begin();
+    sensor.setContinuous(HTS221_ODR_1_HZ);
+    preloadMeasurement(21.5f, 42.0f);
+
+    auto r = sensor.read();
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 21.5f, r.temperature);
+    TEST_ASSERT_FLOAT_WITHIN(0.1f, 42.0f, r.humidity);
+}
+
+void test_humidity_is_clamped_to_0_100(void) {
+    sensor.begin();
+    sensor.setContinuous(HTS221_ODR_1_HZ);
+    Wire.setRegister(ADDR, TEMP_OUT_BASE + 0, 0);
+    Wire.setRegister(ADDR, TEMP_OUT_BASE + 1, 0);
+    Wire.setRegister(ADDR, HTS221_REG_STATUS, HTS221_STATUS_H_DA | HTS221_STATUS_T_DA);
+
+    // Positive raw above the 30000 span → calibrated value > 100 %RH,
+    // driver clamps to 100.
+    Wire.setRegister(ADDR, HUM_OUT_BASE + 0, 0x00);
+    Wire.setRegister(ADDR, HUM_OUT_BASE + 1, 0x7D);  // raw = 0x7D00 = 32000
+    TEST_ASSERT_EQUAL_FLOAT(100.0f, sensor.humidity());
+
+    // Negative raw (int16 interpretation) → calibrated value < 0, clamps to 0.
+    Wire.setRegister(ADDR, HUM_OUT_BASE + 0, 0x00);
+    Wire.setRegister(ADDR, HUM_OUT_BASE + 1, 0x80);  // raw = 0x8000 = -32768
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, sensor.humidity());
+}
+
+void test_read_auto_triggers_when_powered_down(void) {
+    sensor.begin();  // begin() leaves the device in power-down
+    preloadMeasurement(10.0f, 30.0f);
+    Wire.clearWrites();
+
+    auto r = sensor.read();
+
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 10.0f, r.temperature);
+    // The read() flow should have emitted a CTRL1 power-up and a CTRL2
+    // ONE_SHOT write before reading the OUT registers.
+    bool sawCtrl1PowerUp = false;
+    bool sawCtrl2OneShot = false;
+    for (const auto& w : Wire.getWrites()) {
+        if (w.reg == HTS221_REG_CTRL1 && (w.value & HTS221_CTRL1_PD)) {
+            sawCtrl1PowerUp = true;
+        }
+        if (w.reg == HTS221_REG_CTRL2 && (w.value & HTS221_CTRL2_ONE_SHOT)) {
+            sawCtrl2OneShot = true;
+        }
+    }
+    TEST_ASSERT_TRUE_MESSAGE(sawCtrl1PowerUp, "auto-trigger missed CTRL1 PD write");
+    TEST_ASSERT_TRUE_MESSAGE(sawCtrl2OneShot, "auto-trigger missed CTRL2 ONE_SHOT write");
+}
+
+void test_set_temperature_offset_shifts_reading(void) {
+    sensor.begin();
+    sensor.setContinuous(HTS221_ODR_1_HZ);
+    preloadMeasurement(20.0f, 50.0f);
+    sensor.setTemperatureOffset(-1.5f);
+
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 18.5f, sensor.temperature());
+}
+
+void test_calibrate_temperature_applies_two_point_correction(void) {
+    sensor.begin();
+    sensor.setContinuous(HTS221_ODR_1_HZ);
+    // Factory curve maps raw -> 20 °C; user says "when sensor reads 20,
+    // the truth is 22; when sensor reads 0, the truth is 1". Linear fit:
+    //   corrected = 1 + (22 - 1) / (20 - 0) * factory = 1 + 1.05 * factory
+    sensor.calibrateTemperature(1.0f, 0.0f, 22.0f, 20.0f);
+    preloadMeasurement(20.0f, 50.0f);
+
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 22.0f, sensor.temperature());
+}
+
+void test_reboot_writes_ctrl2_boot(void) {
+    sensor.begin();
+    Wire.clearWrites();
+    // Make BOOT bit clear itself on the very first poll so the driver
+    // doesn't spin against the mock.
+    Wire.setRegister(ADDR, HTS221_REG_CTRL2, 0);
+
+    sensor.reboot();
+
+    bool sawBootSet = false;
+    for (const auto& w : Wire.getWrites()) {
+        if (w.reg == HTS221_REG_CTRL2 && (w.value & HTS221_CTRL2_BOOT)) {
+            sawBootSet = true;
+            break;
+        }
+    }
+    TEST_ASSERT_TRUE(sawBootSet);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_begin_detects_device);
+    RUN_TEST(test_begin_rejects_wrong_who_am_i);
+    RUN_TEST(test_device_id_returns_who_am_i);
+    RUN_TEST(test_power_on_sets_ctrl1_pd);
+    RUN_TEST(test_power_off_clears_ctrl1_pd);
+    RUN_TEST(test_set_continuous_writes_expected_ctrl1);
+    RUN_TEST(test_trigger_one_shot_sets_ctrl2_one_shot);
+    RUN_TEST(test_data_ready_reflects_status_register);
+    RUN_TEST(test_read_returns_calibrated_values);
+    RUN_TEST(test_humidity_is_clamped_to_0_100);
+    RUN_TEST(test_read_auto_triggers_when_powered_down);
+    RUN_TEST(test_set_temperature_offset_shifts_reading);
+    RUN_TEST(test_calibrate_temperature_applies_two_point_correction);
+    RUN_TEST(test_reboot_writes_ctrl2_boot);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

First real driver in the STeaMi Arduino library: **HTS221**, ST's capacitive humidity + temperature I2C sensor. Written from scratch in C++ to match the project's driver API conventions — no vendor reference code, a small surface that maps cleanly onto the Wire mock so host-side tests actually exercise the calibration pipeline. **Validated on real hardware.**

Closes #2
Closes #102 (the smoke-test sketch now exercises a real driver)

## Design note

The initial draft of this PR ported ST's stm32duino HTS221 library directly. That kept the code battle-tested but did not match any of the collection conventions (camelCase naming, `bool begin()`, `_wire` / `_address`, `temperature()` / `humidity()` without unit prefixes, `powerOn` / `powerOff`, `setContinuous` / `triggerOneShot` / `readOneShot`, auto-trigger on power-down, user calibration hooks, `#pragma once`, SPDX headers, `.ino` examples, `library.properties`). The MicroPython sister library already did this harmonisation once; diverging on the first Arduino driver would have locked us into the inverse.

So: **rewritten**, ~220 lines of C++ against the datasheet. The goal is a driver the team fully owns and that looks like every future driver in the collection.

## What landed

### Driver — `lib/hts221/`

- `src/HTS221.h` + `src/HTS221.cpp` — the full public API.
- `src/HTS221_const.h` — register addresses, bit masks, ODR values.
- `library.properties` — Arduino metadata, `architectures=*` for host tests.
- `README.md` — API reference. Quick-start targets the STeaMi internal I2C.
- `examples/read_temperature_humidity/read_temperature_humidity.ino` — continuous-mode 1 Hz readings over Serial.
- `keywords.txt` — Arduino IDE syntax highlighting.

### Public API

| Surface | Methods |
|---|---|
| Lifecycle | `begin()`, `deviceId()`, `softReset()`, `reboot()`, `powerOn()`, `powerOff()` |
| Reading | `temperature()`, `humidity()`, `read()`, `dataReady()`, `temperatureReady()`, `humidityReady()` |
| Modes | `setContinuous(odr)`, `triggerOneShot()`, `readOneShot()` |
| Calibration | `setTemperatureOffset(offset)`, `calibrateTemperature(refLow, measLow, refHigh, measHigh)` |

Auto-trigger: `temperature()` / `humidity()` / `read()` on a powered-down device trigger a one-shot, poll `dataReady()` with a bounded timeout, and return.

### Tests — `tests/native/test_hts221/`

14 Unity tests covering: WHO_AM_I probe, power on/off, mode selection, one-shot trigger, data-ready polling, the full calibration pipeline (including the split 10-bit T0/T1 degC decoding), humidity clamping to `[0, 100]`, the auto-trigger contract on a powered-down device, user offset, two-point user calibration, and reboot.

### Infrastructure

- `tests/native/helpers/Arduino.h`: adds a simulated `millis()` + clock advanced by `delay()` so driver timeout loops work on the host. Reusable by future drivers.
- `platformio.ini`: `lib_compat_mode = off` on the native env so PlatformIO's library filter doesn't drop `lib/*` when the target has no framework.
- `src/main.cpp`: instantiates HTS221 on the internal I2C bus, calls `begin()`, and prints a first reading — closes #102 and adds a hardware-validation probe that confirms the full pipeline at boot.

## Hardware validation

Flashed on a real STeaMi board. Serial output on fresh boot:

```
STeaMi smoke test
HTS221 detected, WHO_AM_I = 0xBC
HTS221 first read: T = 22.64 C, H = 54.7 %
```

Plausible room conditions — the full I2C + factory calibration pipeline works end-to-end. The driver uses the variant's `I2C_INT_SDA` / `I2C_INT_SCL` pins via a dedicated `TwoWire internalI2C` in the sketches (the driver itself stays board-agnostic; the choice of I2C bus is the sketch's job).

## Verification

- `make format-check` → clean across `lib/` + `src/` + `tests/`.
- `make test-native` → 24/24 passing in ~1 s (14 HTS221 + 5 Wire + 3 LED + infra).
- `pio run -e steami` → firmware compiles, HTS221 linked (flash 19 KB → 30 KB with HTS221 in).
- `pio run -e steami -t upload` → flashed, `begin()` returns true, first reading matches room conditions.

## Checklist

- [x] `make lint` passes
- [x] `make build` passes (steami firmware links HTS221)
- [x] `make test-native` passes (24/24)
- [x] Tested on hardware (smoke-test on STeaMi board: detected + plausible T/H reading)
- [x] `lib/hts221/README.md` updated with the API reference
- [x] Example sketch added
- [x] Commit messages follow conventional commits format
- [x] SPDX headers on every new C/C++ source (issue #104)