### PR TITLE
feat(hts221): Add basic examples

### DIFF
--- a/lib/hts221/README.md
+++ b/lib/hts221/README.md
@@ -50,6 +50,29 @@ void loop() {
 See [examples/read_temperature_humidity/](examples/read_temperature_humidity/)
 for the full sketch.
 
+## Examples
+
+| Example | What it does |
+|---------|--------------|
+| [`read_temperature_humidity`](examples/read_temperature_humidity/) | Baseline sketch: print temperature and humidity every second. |
+| [`comfort_index`](examples/comfort_index/) | Classify ambient conditions as *comfortable*, *too dry*, *too humid*, *cold*, or *hot* using simple thresholds. |
+| [`dew_point`](examples/dew_point/) | Compute the dew point from T + %RH via the Magnus formula, and warn when the current temperature comes within 2 °C of it (condensation risk). |
+| [`temperature_alarm`](examples/temperature_alarm/) | Monitor temperature continuously and buzz the on-board `SPEAKER` whenever it crosses a configurable high threshold. |
+
+### Building an example
+
+PlatformIO builds the directory pointed at by `src_dir`. To flash an
+example instead of the default smoke-test under `src/`, override
+`src_dir` via the `PLATFORMIO_SRC_DIR` environment variable for a
+single invocation:
+
+```bash
+PLATFORMIO_SRC_DIR=lib/hts221/examples/dew_point pio run -e steami -t upload
+pio device monitor -b 115200
+```
+
+(`pio run` without the override keeps building the project's smoke-test.)
+
 ## API
 
 All methods follow the collection conventions: `camelCase`, include

--- a/lib/hts221/examples/comfort_index/comfort_index.ino
+++ b/lib/hts221/examples/comfort_index/comfort_index.ino
@@ -33,6 +33,10 @@ const char* comfortLabel(float temperature, float humidity) {
 
 void setup() {
     Serial.begin(115200);
+    while (!Serial && millis() < 2000) {
+        // Wait up to 2 s for the host USB CDC to enumerate so the
+        // "not detected" diagnostic below isn't silently dropped.
+    }
     internalI2C.begin();
 
     if (!sensor.begin()) {

--- a/lib/hts221/examples/comfort_index/comfort_index.ino
+++ b/lib/hts221/examples/comfort_index/comfort_index.ino
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// HTS221 — classify ambient conditions as comfortable, too dry, too humid,
+// too cold, or too hot, using simple humidity and temperature thresholds.
+// Useful as a starting point for climate-aware UI or HVAC logic.
+
+#include <Arduino.h>
+#include <HTS221.h>
+#include <Wire.h>
+
+// HTS221 sits on the STeaMi internal I2C bus (PB8 / PB9 via the variant
+// macros), not the default global Wire.
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+HTS221 sensor(internalI2C);
+
+// Thresholds chosen for indoor "office" conditions; tune to taste.
+constexpr float HUMIDITY_DRY = 40.0f;
+constexpr float HUMIDITY_HUMID = 60.0f;
+constexpr float TEMPERATURE_COLD = 18.0f;
+constexpr float TEMPERATURE_HOT = 26.0f;
+
+const char* comfortLabel(float temperature, float humidity) {
+    if (humidity < HUMIDITY_DRY)
+        return "Too dry";
+    if (humidity > HUMIDITY_HUMID)
+        return "Too humid";
+    if (temperature < TEMPERATURE_COLD)
+        return "Cold";
+    if (temperature > TEMPERATURE_HOT)
+        return "Hot";
+    return "Comfortable";
+}
+
+void setup() {
+    Serial.begin(115200);
+    internalI2C.begin();
+
+    if (!sensor.begin()) {
+        Serial.println("HTS221 not detected — check wiring.");
+        while (true) {
+            delay(1000);
+        }
+    }
+
+    sensor.setContinuous(HTS221_ODR_1_HZ);
+}
+
+void loop() {
+    if (!sensor.dataReady()) {
+        delay(10);
+        return;
+    }
+
+    auto reading = sensor.read();
+
+    Serial.print("T=");
+    Serial.print(reading.temperature, 2);
+    Serial.print(" C  H=");
+    Serial.print(reading.humidity, 1);
+    Serial.print(" %  -> ");
+    Serial.println(comfortLabel(reading.temperature, reading.humidity));
+
+    delay(1000);
+}

--- a/lib/hts221/examples/dew_point/dew_point.ino
+++ b/lib/hts221/examples/dew_point/dew_point.ino
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// HTS221 — compute the dew point from temperature and humidity using the
+// Magnus formula, and warn when the measured temperature comes within
+// 2 degrees of it (visible condensation risk on cold surfaces).
+
+#include <Arduino.h>
+#include <HTS221.h>
+#include <Wire.h>
+#include <math.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+HTS221 sensor(internalI2C);
+
+// Magnus formula constants for water over a flat surface, good over the
+// 0-60 C / 1-100 %RH range with <0.4 C error.
+constexpr float MAGNUS_A = 17.62f;
+constexpr float MAGNUS_B = 243.12f;
+
+// Temperatures within this margin of the dew point are reported as a
+// condensation risk.
+constexpr float CONDENSATION_MARGIN_C = 2.0f;
+
+float dewPoint(float temperatureC, float humidityPct) {
+    float gamma = (MAGNUS_A * temperatureC) / (MAGNUS_B + temperatureC) + log(humidityPct / 100.0f);
+    return (MAGNUS_B * gamma) / (MAGNUS_A - gamma);
+}
+
+void setup() {
+    Serial.begin(115200);
+    internalI2C.begin();
+
+    if (!sensor.begin()) {
+        Serial.println("HTS221 not detected — check wiring.");
+        while (true) {
+            delay(1000);
+        }
+    }
+
+    sensor.setContinuous(HTS221_ODR_1_HZ);
+}
+
+void loop() {
+    if (!sensor.dataReady()) {
+        delay(10);
+        return;
+    }
+
+    auto reading = sensor.read();
+    float dp = dewPoint(reading.temperature, reading.humidity);
+
+    Serial.print("T=");
+    Serial.print(reading.temperature, 2);
+    Serial.print(" C  H=");
+    Serial.print(reading.humidity, 1);
+    Serial.print(" %  DewPoint=");
+    Serial.print(dp, 2);
+    Serial.print(" C");
+
+    if (fabs(reading.temperature - dp) < CONDENSATION_MARGIN_C) {
+        Serial.print("  -> condensation risk");
+    }
+    Serial.println();
+
+    delay(1000);
+}

--- a/lib/hts221/examples/dew_point/dew_point.ino
+++ b/lib/hts221/examples/dew_point/dew_point.ino
@@ -22,6 +22,12 @@ constexpr float MAGNUS_B = 243.12f;
 constexpr float CONDENSATION_MARGIN_C = 2.0f;
 
 float dewPoint(float temperatureC, float humidityPct) {
+    // log(0) is -infinity and the Magnus inverse below would propagate
+    // NaN / inf into the caller. Humidity reaches 0 at the driver's
+    // clamp boundary, so guard explicitly.
+    if (humidityPct <= 0.0f) {
+        return NAN;
+    }
     float gamma = (MAGNUS_A * temperatureC) / (MAGNUS_B + temperatureC) + log(humidityPct / 100.0f);
     return (MAGNUS_B * gamma) / (MAGNUS_A - gamma);
 }

--- a/lib/hts221/examples/dew_point/dew_point.ino
+++ b/lib/hts221/examples/dew_point/dew_point.ino
@@ -28,6 +28,10 @@ float dewPoint(float temperatureC, float humidityPct) {
 
 void setup() {
     Serial.begin(115200);
+    while (!Serial && millis() < 2000) {
+        // Wait up to 2 s for the host USB CDC to enumerate so the
+        // "not detected" diagnostic below isn't silently dropped.
+    }
     internalI2C.begin();
 
     if (!sensor.begin()) {

--- a/lib/hts221/examples/temperature_alarm/temperature_alarm.ino
+++ b/lib/hts221/examples/temperature_alarm/temperature_alarm.ino
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// HTS221 — monitor temperature continuously and buzz the on-board SPEAKER
+// pin whenever it crosses a configurable high threshold. A short beep
+// (100 ms on / 100 ms off) repeats while the temperature stays above the
+// limit; silence resumes as soon as it drops back.
+
+#include <Arduino.h>
+#include <HTS221.h>
+#include <Wire.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+HTS221 sensor(internalI2C);
+
+// Tune to the use case. 30 C triggers indoors in most climates; lower it
+// for refrigeration alarms, raise it for heat-soak warnings.
+constexpr float ALARM_THRESHOLD_C = 30.0f;
+
+// SPEAKER is exported by the STeaMi variant; on the board it's a
+// piezo-style buzzer on PA11.
+constexpr int BUZZER_PIN = SPEAKER;
+
+constexpr unsigned int BEEP_FREQUENCY_HZ = 2000;
+constexpr uint32_t BEEP_ON_MS = 100;
+constexpr uint32_t BEEP_OFF_MS = 100;
+
+void setup() {
+    Serial.begin(115200);
+    internalI2C.begin();
+    pinMode(BUZZER_PIN, OUTPUT);
+
+    if (!sensor.begin()) {
+        Serial.println("HTS221 not detected — check wiring.");
+        while (true) {
+            delay(1000);
+        }
+    }
+
+    sensor.setContinuous(HTS221_ODR_1_HZ);
+}
+
+void loop() {
+    if (!sensor.dataReady()) {
+        delay(10);
+        return;
+    }
+
+    float temperatureC = sensor.temperature();
+
+    Serial.print("Temperature: ");
+    Serial.print(temperatureC, 2);
+    Serial.println(" C");
+
+    if (temperatureC > ALARM_THRESHOLD_C) {
+        Serial.println("ALARM");
+        tone(BUZZER_PIN, BEEP_FREQUENCY_HZ);
+        delay(BEEP_ON_MS);
+        noTone(BUZZER_PIN);
+        delay(BEEP_OFF_MS);
+    } else {
+        noTone(BUZZER_PIN);
+        delay(500);
+    }
+}

--- a/lib/hts221/examples/temperature_alarm/temperature_alarm.ino
+++ b/lib/hts221/examples/temperature_alarm/temperature_alarm.ino
@@ -26,6 +26,10 @@ constexpr uint32_t BEEP_OFF_MS = 100;
 
 void setup() {
     Serial.begin(115200);
+    while (!Serial && millis() < 2000) {
+        // Wait up to 2 s for the host USB CDC to enumerate so the
+        // "not detected" diagnostic below isn't silently dropped.
+    }
     internalI2C.begin();
     pinMode(BUZZER_PIN, OUTPUT);
 

--- a/lib/hts221/examples/temperature_alarm/temperature_alarm.ino
+++ b/lib/hts221/examples/temperature_alarm/temperature_alarm.ino
@@ -43,26 +43,53 @@ void setup() {
     sensor.setContinuous(HTS221_ODR_1_HZ);
 }
 
-void loop() {
-    if (!sensor.dataReady()) {
-        delay(10);
+// Alarm state, updated whenever a fresh reading lands.
+bool alarmActive = false;
+
+// Non-blocking beep state — the buzzer toggles independently of the
+// sensor polling so the 100/100 ms pattern stays audible even though
+// the sensor only delivers one sample per second.
+bool beepOn = false;
+uint32_t beepChangedAt = 0;
+
+void updateBuzzer() {
+    uint32_t now = millis();
+
+    if (!alarmActive) {
+        if (beepOn) {
+            noTone(BUZZER_PIN);
+            beepOn = false;
+        }
         return;
     }
 
-    float temperatureC = sensor.temperature();
-
-    Serial.print("Temperature: ");
-    Serial.print(temperatureC, 2);
-    Serial.println(" C");
-
-    if (temperatureC > ALARM_THRESHOLD_C) {
-        Serial.println("ALARM");
+    uint32_t elapsed = now - beepChangedAt;
+    if (beepOn && elapsed >= BEEP_ON_MS) {
+        noTone(BUZZER_PIN);
+        beepOn = false;
+        beepChangedAt = now;
+    } else if (!beepOn && elapsed >= BEEP_OFF_MS) {
         tone(BUZZER_PIN, BEEP_FREQUENCY_HZ);
-        delay(BEEP_ON_MS);
-        noTone(BUZZER_PIN);
-        delay(BEEP_OFF_MS);
-    } else {
-        noTone(BUZZER_PIN);
-        delay(500);
+        beepOn = true;
+        beepChangedAt = now;
     }
+}
+
+void loop() {
+    if (sensor.dataReady()) {
+        float temperatureC = sensor.temperature();
+
+        Serial.print("Temperature: ");
+        Serial.print(temperatureC, 2);
+        Serial.println(" C");
+
+        bool aboveThreshold = temperatureC > ALARM_THRESHOLD_C;
+        if (aboveThreshold && !alarmActive) {
+            Serial.println("ALARM");
+        }
+        alarmActive = aboveThreshold;
+    }
+
+    updateBuzzer();
+    delay(10);
 }


### PR DESCRIPTION
## Summary

Three practical Arduino examples on top of the HTS221 driver, covering common humidity + temperature use cases. Built on the pattern laid down by `read_temperature_humidity` (the driver's baseline example merged in #91): `TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL)`, `HTS221` bound to that bus, `setContinuous(HTS221_ODR_1_HZ)` in `setup()`, `dataReady()` + `read()` in `loop()`.

Closes #68

## Changes

| Example | What it demonstrates |
|---------|----------------------|
| [`comfort_index`](../blob/feat/hts221-examples/lib/hts221/examples/comfort_index/comfort_index.ino) | Classify ambient conditions as *comfortable*, *too dry*, *too humid*, *cold*, or *hot* using simple humidity and temperature thresholds. |
| [`dew_point`](../blob/feat/hts221-examples/lib/hts221/examples/dew_point/dew_point.ino) | Compute the dew point via the Magnus formula and warn when the current temperature comes within 2 °C of it (visible condensation risk). |
| [`temperature_alarm`](../blob/feat/hts221-examples/lib/hts221/examples/temperature_alarm/temperature_alarm.ino) | Monitor temperature continuously and buzz the on-board `SPEAKER` pin whenever it crosses a configurable high threshold. |

### README

Add an **Examples** section listing the four sketches (existing + three new) with one-line descriptions, and a short blurb on how to build any example via `PLATFORMIO_SRC_DIR=lib/hts221/examples/<name>` env override rather than editing `platformio.ini` in place.

### Deferred (outside this PR)

Two examples Charly's original PR description mentioned are blocked on drivers that don't exist yet:

- `DataLogger` — needs the `daplink_flash` driver
- `ClimateDisplay` — needs the `ssd1327` driver

## Verification

- `make format-check` → clean across all new sketches.
- `make test-native` → 25/25 still passing (examples don't affect host tests).
- `PLATFORMIO_SRC_DIR=lib/hts221/examples/<name> pio run -e steami` → all three examples compile cleanly for the STeaMi target.
- `dew_point` flashed on a real STeaMi board. Serial output at 1 Hz:
  ```
  T=33.00 C  H=32.4 %  DewPoint=14.27 C
  ```
  Dew point math checks out (at 32 %RH / 33 °C the Magnus formula gives ~14 °C).

The default smoke-test under `src/main.cpp` is unchanged; the examples live entirely under `lib/hts221/examples/`.

## Checklist

- [x] `make lint` passes (clang-format)
- [x] `make build` passes (smoke-test)
- [x] Each example compiles for `steami` (verified via `PLATFORMIO_SRC_DIR` override)
- [x] `dew_point` flashed and validated on hardware (plausible readings at 1 Hz)
- [x] README updated with the example index and build instructions
- [x] Commit messages follow conventional commits format
- [x] SPDX headers on every new `.ino`