### PR TITLE
docs: Refresh CONTRIBUTING.md with the full project conventions.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Run `make help` for the full list of targets. The ones you'll use most:
 | `make format-check` | Run `clang-format --dry-run` on `lib/ src/ tests/`. |
 | `make format-fix` | Apply `clang-format -i` in place. |
 | `make lint` | Meta-target: `format-check` + `clang-tidy` (tidy is scaffolded, see issue #107). |
-| `make build` | Build the STeaMi firmware (`pio run -e steami`). |
+| `make build` | Build the STeaMi firmware (`pio run`; `steami` is the default env). |
 | `make test-native` | Run host-side unit tests (no board required). |
 | `make test-hardware` | Run on-board unit tests (STeaMi required). |
 | `make ci` | `lint + build + test-native` — the quick pre-push check. |
@@ -54,8 +54,12 @@ lib/<component>/
 
 ### Requirements
 
-- The directory name is lower snake-case matching the component
-  (`hts221`, `wsen-hids`, `mcp23009e`, …).
+- The directory name is lowercase, using either hyphens or underscores
+  as separators, and should match how the part is referred to in the
+  datasheet. Current drivers mix both for historical reasons
+  (`wsen-hids`, `wsen-pads` vs `daplink_flash`, `steami_config`) — pick
+  whichever reads most naturally for the new driver and stay consistent
+  within its own tree.
 - The class name is `PascalCase` (`HTS221`, `Mcp23009e`) and lives in
   `src/<DriverName>.h`.
 - Each driver is self-contained — no cross-driver dependencies.
@@ -83,8 +87,10 @@ lib/<component>/
 ## Coding conventions
 
 - **Naming**: `camelCase` for methods and variables, `UPPER_SNAKE_CASE`
-  for constants, `PascalCase` for class names, lower snake-case for
-  file and directory names except the driver header/source.
+  for constants, `PascalCase` for class names (and the driver's
+  header/source files that match the class, e.g. `HTS221.h`), lower
+  snake-case for example and test folders, and lowercase (with either
+  hyphens or underscores) for driver folders.
 - **Constants**: `constexpr uint8_t` (preferred) or `#define` in
   `*_const.h`, never inside the public header file body.
 - **Formatting**: enforced by `clang-format` (config in `.clang-format`).
@@ -232,7 +238,7 @@ restricted to the subset allowed for working branches:
 
 ```
 main
-feat|fix|docs|tooling|ci|test|style|chore|refactor / <lowercase-with-hyphens>
+feat|fix|docs|tooling|ci|test|style|chore|refactor/<lowercase-with-hyphens>
 release/vX.Y.Z
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,52 @@
 # Contributing
 
-This repository provides Arduino/C++ drivers for the STeaMi board.
-The goal is to maintain a consistent, reliable, and maintainable codebase across all drivers.
+This repository provides Arduino/C++ drivers for the STeaMi board. Every
+driver in the collection is expected to look and behave like every other —
+one shape, one set of naming rules, one testing pattern — so that learning
+one driver teaches you the whole library.
+
+The source of truth for conventions is this document. When in doubt, take
+[`lib/hts221/`](lib/hts221/) as a reference implementation: it exercises
+almost every rule listed below.
+
+## Getting started
+
+```bash
+make setup   # creates .venv/, installs PlatformIO + clang-format + clang-tidy,
+             # runs npm install for the git hooks
+```
+
+Run `make help` for the full list of targets. The ones you'll use most:
+
+| Target | What it does |
+|--------|--------------|
+| `make format-check` | Run `clang-format --dry-run` on `lib/ src/ tests/`. |
+| `make format-fix` | Apply `clang-format -i` in place. |
+| `make lint` | Meta-target: `format-check` + `clang-tidy` (tidy is scaffolded, see issue #107). |
+| `make build` | Build the STeaMi firmware (`pio run -e steami`). |
+| `make test-native` | Run host-side unit tests (no board required). |
+| `make test-hardware` | Run on-board unit tests (STeaMi required). |
+| `make ci` | `lint + build + test-native` — the quick pre-push check. |
+| `make upload` | Flash the firmware to a connected STeaMi. |
+
+Running `make setup` also installs the husky git hooks: they validate the
+branch name, commit message, and clang-format every staged `.h`/`.cpp`/`.ino`
+before each commit. Run `make setup` on a fresh clone so you don't get
+surprised by CI enforcing things your local commit let through.
 
 ## Driver structure
 
-Each driver must follow this layout:
+Each driver lives in its own directory under `lib/`:
 
 ```
 lib/<component>/
 ├── README.md
-├── library.properties      # Arduino library metadata
+├── library.properties        # Arduino Library Manager metadata
+├── keywords.txt              # Arduino IDE syntax highlighting
 ├── src/
-│   ├── <DriverName>.h      # Public header
-│   ├── <DriverName>.cpp    # Implementation
-│   └── <DriverName>_const.h # Register constants
+│   ├── <DriverName>.h        # Public header
+│   ├── <DriverName>.cpp      # Implementation
+│   └── <DriverName>_const.h  # Register addresses, bit masks, mode values
 └── examples/
     └── <example_name>/
         └── <example_name>.ino
@@ -22,44 +54,167 @@ lib/<component>/
 
 ### Requirements
 
-* The directory name must match the driver name (e.g. `mcp23009e`, `wsen-hids`)
-* The main class must be declared in `src/<DriverName>.h`
-* Drivers must be self-contained (no cross-driver dependencies)
-* Each driver must have a `library.properties` file for Arduino Library Manager compatibility
+- The directory name is lower snake-case matching the component
+  (`hts221`, `wsen-hids`, `mcp23009e`, …).
+- The class name is `PascalCase` (`HTS221`, `Mcp23009e`) and lives in
+  `src/<DriverName>.h`.
+- Each driver is self-contained — no cross-driver dependencies.
+- Every new C/C++ source (`.h`, `.cpp`, `.ino`) carries the SPDX license
+  header on the very first line (see issue #104):
+  ```
+  // SPDX-License-Identifier: GPL-3.0-or-later
+  ```
+- Include guards use `#pragma once`, not `#ifndef`/`#define` wrappers.
+- `library.properties` declares `architectures=*` so host-side tests can
+  pull the library in (the native platform has no "framework").
+
+### Example folders
+
+- One folder per example, folder name in lower snake-case.
+- The `.ino` file inside has the exact same name as the folder.
+- Every sketch targets the STeaMi **internal** I2C bus when talking to
+  on-board peripherals: `TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);`
+  and pass it to the driver. The default global `Wire` sits on different
+  pins and will silently fail to detect on-board sensors.
+- Wait for USB CDC enumeration before printing diagnostics:
+  `while (!Serial && millis() < 2000) {}` — otherwise early output
+  vanishes.
 
 ## Coding conventions
 
-- **Naming**: `camelCase` for methods, `UPPER_SNAKE_CASE` for constants, `PascalCase` for class names
-- **Constants**: use `constexpr` or `#define` in `*_const.h` files
-- **Class style**: classes inherit from nothing (no Arduino `Stream` unless needed)
-- **I2C**: use `TwoWire&` reference, default to `Wire`
-- **Constructor**: `DriverName(TwoWire& wire = Wire, uint8_t address = DEFAULT_ADDR)`
-- **Attributes**: `_wire` for I2C bus, `_address` for the device address
-- **I2C helpers**: private `readReg()`, `writeReg()` methods
-- **Formatting**: enforced by clang-format (config in `.clang-format`)
-- **No `Serial.print()`** in library code (only in examples)
+- **Naming**: `camelCase` for methods and variables, `UPPER_SNAKE_CASE`
+  for constants, `PascalCase` for class names, lower snake-case for
+  file and directory names except the driver header/source.
+- **Constants**: `constexpr uint8_t` (preferred) or `#define` in
+  `*_const.h`, never inside the public header file body.
+- **Formatting**: enforced by `clang-format` (config in `.clang-format`).
+  Google-based style, 4-space indent, column limit 100.
+- **I2C**: accept a `TwoWire&` reference, default to the global `Wire`.
+  Private helpers `readReg(reg)`, `writeReg(reg, value)`, and
+  `readRegs(reg, buf, len)` are expected for any register-bank sensor.
+  `readRegs` zero-fills its buffer before the bus access so a short
+  read leaves defined bytes.
+- **Constructor**:
+  `DriverName(TwoWire& wire = Wire, uint8_t address = <DRIVER>_DEFAULT_ADDRESS)`.
+- **Attributes**: `_wire` for the I2C bus, `_address` for the device
+  address. Store `_wire` as a pointer internally (`TwoWire* _wire`) so
+  the class stays default-assignable — the public constructor still
+  accepts a `TwoWire&`.
+- **No `Serial.print()` in library code**. Diagnostics go in examples,
+  not in the driver itself.
 
 ## Driver API conventions
 
-- **Initialization**: `bool begin()` — returns false if device not found
-- **Device identification**: `uint8_t deviceId()` — returns WHO_AM_I register value
-- **Reset methods**: `void reset()` for hardware reset, `void softReset()` for software reset, `void reboot()` for memory reboot
-- **Power methods**: `void powerOn()` / `void powerOff()`
-- **Status methods**: `uint8_t status()` returns raw status register, `bool dataReady()` returns true when all channels have new data, `bool temperatureReady()` etc. for per-channel readiness
-- **Measurement methods**: `float temperature()` (°C), `float humidity()` (%RH), `float pressureHpa()`, `uint16_t distanceMm()`, `uint16_t voltageMv()`, etc.
-- **Mode methods**: `void setContinuous(uint8_t odr)`, `void triggerOneShot()`, `std::tuple<float,float> readOneShot()`
+Every driver in the collection exposes the same shape. A user who
+learned one driver should be able to guess the methods of another.
+These were harmonised with the MicroPython sister library
+([`steamicc/micropython-steami-lib`](https://github.com/steamicc/micropython-steami-lib))
+so the Python and Arduino APIs match.
+
+### Lifecycle
+
+- `bool begin()` — probe the part (typically via WHO_AM_I), load any
+  factory calibration, leave the device in a sensible default state.
+  Returns `false` if the device can't be detected. **No** custom error
+  enum.
+- `uint8_t deviceId()` — returns the WHO_AM_I register value. The name
+  is `deviceId()`, not `whoAmI()` or `readModelId()`.
+- `void reset()` — hardware reset (toggle a reset pin). Skip if the
+  part has no reset pin.
+- `void softReset()` — software reset (write to the reset bit in a
+  control register).
+- `void reboot()` — reload trimming / calibration from non-volatile
+  memory.
+- `void powerOn()` / `void powerOff()` — flip the device's power-down
+  bit. Both always implemented.
+
+### Reading
+
+- Bare-noun method per channel when the unit is obvious and standard:
+  `temperature()` (°C), `humidity()` (%RH).
+- Unit suffix for everything else: `pressureHpa()`, `distanceMm()`,
+  `voltageMv()`, `accelerationG()`. Integers for raw counts, floats for
+  physical units.
+- **No** `read` / `get` prefix: `temperature()`, not `readTemperature()`
+  or `getTemperature()`.
+- `ReadResult read()` — combined reading returning a struct with every
+  channel the sensor produces. Preferred when the caller needs several
+  channels consistently.
+- Readiness: `uint8_t status()` (private in most cases) returns the raw
+  status register, `bool dataReady()` returns `true` when *all* the
+  relevant channels are fresh, `bool temperatureReady()` / `bool
+  humidityReady()` / … per-channel.
+
+### Auto-trigger contract
+
+If a measurement method is called while the device is powered down,
+the driver **must** automatically trigger a one-shot conversion, poll
+`dataReady()` with a bounded timeout, and return the result. Callers
+should not have to manage modes to read a single value.
+
+On timeout (bus failure, missing sensor), measurement methods return
+`NAN` so a silent read of uninitialised bytes can't propagate stale
+data. Callers can detect with `isnan()`.
+
+### Modes
+
+- `void setContinuous(uint8_t odr)` — continuous mode at the given
+  Output Data Rate. ODR values live in `<driver>_const.h` as named
+  constants (e.g. `HTS221_ODR_1_HZ`).
+- `void triggerOneShot()` — non-blocking: kick a single conversion.
+- `ReadResult readOneShot()` — trigger + wait + return.
+
+### Calibration hooks
+
+Any driver that exposes a physical quantity (temperature, pressure,
+humidity, …) provides:
+
+- `void setXxxOffset(float offset)` — additive offset on top of the
+  factory calibration (e.g. `setTemperatureOffset`).
+- `void calibrateXxx(float refLow, float measLow, float refHigh, float measHigh)`
+  — two-point linear correction applied after the factory curve.
+
+Temperature-capable parts always implement `setTemperatureOffset` and
+`calibrateTemperature`. Extend the same pattern to other channels when
+it makes physical sense.
+
+## Testing
+
+Two complementary environments, both wired into PlatformIO:
+
+- **Native tests** under `tests/native/test_<driver>/` run on the host
+  using the Arduino + Wire mocks in
+  [`tests/native/helpers/`](tests/native/helpers/). They're fast,
+  hardware-free, and required for every new driver — they pin the
+  contract (calibration math, auto-trigger, register writes, timeout
+  handling) so future refactors don't regress silently.
+- **Hardware tests** under `tests/hardware/test_<driver>/` run on a
+  real STeaMi via `pio test -e steami` when you need to validate bus
+  timing or interrupt behaviour.
+
+See [`tests/TESTING.md`](tests/TESTING.md) for the mock Wire API
+(`setRegister`, `getWrites`, `clearWrites`, per-address keying). The
+HTS221 suite ([`tests/native/test_hts221/`](tests/native/test_hts221/))
+is a good reference.
 
 ## Commit messages
 
-Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format, enforced by commitlint via a git hook:
+Format enforced by [commitlint](https://commitlint.js.org/) via a git
+hook (and the `check-commits` workflow on every PR):
 
 ```
 <type>[(<scope>)]: <Description starting with a capital letter ending with a period.>
 ```
 
-**Types**: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `ci`, `build`, `chore`, `perf`, `revert`, `tooling`
+**Types**: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `ci`,
+`build`, `chore`, `perf`, `revert`, `tooling`.
 
-**Scopes** (optional): driver names (`hts221`, `ism330dl`, `wsen-pads`...) or domains (`ci`, `docs`, `style`, `tests`, `tooling`). The scope is recommended for driver-specific changes but can be omitted for cross-cutting changes.
+**Scopes** (optional): driver names (`hts221`, `ism330dl`, `wsen-pads`, …)
+or domains (`ci`, `docs`, `style`, `tests`, `tooling`). Recommended for
+driver-specific changes, omit for cross-cutting ones.
+
+Header length capped at 78 characters. Body optional but encouraged —
+explain the *why*, not the *what* (the diff shows the what).
 
 ### Examples
 
@@ -70,29 +225,60 @@ docs: Update README driver table.
 test(mcp23009e): Add unit tests for GPIO read.
 ```
 
+## Branches
+
+Branch names must match `<type>/<kebab-case-description>`, with `type`
+restricted to the subset allowed for working branches:
+
+```
+main
+feat|fix|docs|tooling|ci|test|style|chore|refactor / <lowercase-with-hyphens>
+release/vX.Y.Z
+```
+
+Uppercase, underscores, or other types will be rejected by the local
+pre-commit hook (`validate-branch-name`). Examples:
+
+- `feat/hts221-driver` ✓
+- `docs/add-gplv3-license` ✓
+- `build/platformio-steami` ✗ (`build` isn't in the branch-name
+  whitelist even though it's a valid commit type)
+- `docs/add-GPLV3-license` ✗ (uppercase `GPLV3`)
+
 ## Workflow
 
-1. Set up your environment: `make setup`
-2. Create a branch from main (format: `feat/`, `fix/`, `docs/`, `tooling/`, `ci/`, `test/`, `style/`, `chore/`, `refactor/`)
-3. Write your code and add tests
-4. Run `make lint` to check formatting
-5. Commit — the git hooks will automatically check your commit message and format staged files
-6. Push your branch and open a Pull Request
+1. `make setup` on a fresh clone so the hooks are active.
+2. Branch from `main`, matching the branch-name rule above.
+3. Write the code, add or extend the native test suite, update the
+   driver README and `keywords.txt`.
+4. `make ci` locally — catches format drift, build breaks, and native
+   test regressions before they hit the CI runner.
+5. Commit. The pre-commit hook runs clang-format on staged files and
+   validates the branch name; the commit-msg hook runs commitlint.
+6. Push and open a PR. Fill the PR template checklist honestly — leave
+   the "Tested on hardware" box unchecked if you didn't flash your
+   branch.
 
-## Continuous Integration
+## Continuous integration
 
-All pull requests must pass these checks:
+Every PR runs four GitHub Actions workflows in parallel:
 
-| Check | Description |
-|-------|-------------|
-| Commit messages | Validates commit message format (commitlint) |
-| Formatting | Runs clang-format check |
-| Build | Builds with PlatformIO |
-| Tests | Runs unit tests |
+| Workflow | Runs |
+|----------|------|
+| `build.yml` | `make setup` + `make build` — firmware compile check. |
+| `tests.yml` | `make test-native` — host-side test suite. |
+| `lint.yml` | `make lint` — clang-format + (scaffolded) clang-tidy. |
+| `check-commits.yml` | `commitlint` on every commit in the PR range. |
+
+All four need to go green before a merge.
 
 ## Notes
 
-* Keep implementations simple and readable
-* Follow existing drivers as reference
-* Ensure documentation (`README.md`) and examples are included for each driver
-* Match the MicroPython driver API as closely as possible for consistency across the project
+- Keep implementations simple and readable; the reference drivers
+  deliberately skip clever tricks.
+- Follow the existing drivers — when a new situation isn't covered
+  here, look at how `hts221` handled the equivalent.
+- Every driver ships a README with an API table, at least one example
+  sketch, and a `keywords.txt` for Arduino IDE syntax highlighting.
+- Match the MicroPython sister-library API wherever possible for
+  cross-language consistency.


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md` had the bones of the driver conventions but lagged behind the rules the recent PRs (driver, tests, CI, tooling) actually settled. Today there's no single public source of truth a contributor (or automated reviewer) can point at — issues like #10 even call out "CONTRIBUTING.md conventions" that weren't written down. Fold the whole convention set into the one doc.

## What's new

- **Licensing**: SPDX header requirement on every new `.h`/`.cpp`/`.ino`
  (from #104) + `#pragma once` guards + column limit 100.
- **Example folder convention**: snake-case name, `.ino` name matches
  folder, `internalI2C(I2C_INT_SDA, I2C_INT_SCL)` for on-board
  peripherals, USB CDC enumeration wait before the first println.
- **Driver API shape** expanded with the whole surface:
  `begin/deviceId/reset/softReset/reboot/powerOn/powerOff`, reading
  (bare-noun + unit-suffix rule, no `read`/`get` prefix, `ReadResult`
  struct), readiness bits, **auto-trigger-on-power-down** contract
  with NaN-on-timeout, modes (`setContinuous/triggerOneShot/readOneShot`),
  calibration hooks (`setXxxOffset`/`calibrateXxx` two-point).
- **Testing**: native suite required for every new driver, hardware
  suite optional, pointer at `tests/TESTING.md` and the HTS221 suite
  as the reference.
- **Makefile targets** table refreshed to match the current Makefile
  (`format-check`, `format-fix`, `lint` meta, `test-native`,
  `test-hardware`, `ci`).
- **Branch-name rule** made explicit with valid/invalid examples —
  previous wording said "format: `feat/`, `fix/`…" but didn't mention
  that `build/` is a valid commit type but **not** a valid branch
  type, nor that uppercase is rejected (both hit this year: PR #84
  and PR #85).
- **CI** section lists the four parallel workflows (`build`, `tests`,
  `lint`, `check-commits`).

## What's preserved

Driver layout, naming rules, commit message format, workflow steps,
notes at the bottom.

## Why

Two concrete payoffs:

- Issue #10 (MCP23009E port) references "`CONTRIBUTING.md` conventions"
  — now those actually cover what a new driver needs.
- Automated reviewers (Copilot, human reviewers) can link directly to
  a specific section instead of discovering rules PR-by-PR.

## Checklist

- [x] `make lint` passes
- [x] `make build` passes
- [x] `make test-native` passes (25/25)
- [x] No code changes — pure docs
- [x] Commit messages follow conventional commits format