### PR TITLE
tooling: Enforce SPDX-License-Identifier header via make lint and pre-commit.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,8 @@ Run `make help` for the full list of targets. The ones you'll use most:
 |--------|--------------|
 | `make format-check` | Run `clang-format --dry-run` on `lib/ src/ tests/`. |
 | `make format-fix` | Apply `clang-format -i` in place. |
-| `make lint` | Meta-target: `format-check` + `clang-tidy` (tidy is scaffolded, see issue #107). |
+| `make lint` | Meta-target: `format-check` + `check-spdx` + `clang-tidy` (tidy is scaffolded, see issue #107). |
+| `make check-spdx` | Verify every `.h`/`.cpp`/`.ino` carries the SPDX-License-Identifier header. |
 | `make build` | Build the STeaMi firmware (`pio run`; `steami` is the default env). |
 | `make test-native` | Run host-side unit tests (no board required). |
 | `make test-hardware` | Run on-board unit tests (STeaMi required). |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,9 +31,10 @@ Run `make help` for the full list of targets. The ones you'll use most:
 | `make upload` | Flash the firmware to a connected STeaMi. |
 
 Running `make setup` also installs the husky git hooks: they validate the
-branch name, commit message, and clang-format every staged `.h`/`.cpp`/`.ino`
-before each commit. Run `make setup` on a fresh clone so you don't get
-surprised by CI enforcing things your local commit let through.
+branch name, the commit message, and run `clang-format` plus the SPDX
+header check on every staged `.h`/`.cpp`/`.ino` before each commit. Run
+`make setup` on a fresh clone so you don't get surprised by CI enforcing
+things your local commit let through.
 
 ## Driver structure
 

--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,12 @@ tidy: .venv/bin/clang-tidy ## Run clang-tidy static analysis (scaffold — see #
 	@echo "clang-tidy scaffold: full integration tracked in issue #107"
 	@echo "  (needs compile_commands.json via 'pio run -t compiledb' + rule preset)"
 
+.PHONY: check-spdx
+check-spdx: ## Verify every C++ source carries the SPDX license header
+	@scripts/check-spdx.sh
+
 .PHONY: lint
-lint: format-check tidy ## Run all static checks (format + static analysis)
+lint: format-check check-spdx tidy ## Run all static checks (format + SPDX + static analysis)
 
 # --- Build ---
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     }
   },
   "lint-staged": {
-    "*.{h,cpp,ino}": ".venv/bin/clang-format --dry-run --Werror"
+    "*.{h,cpp,ino}": [
+      ".venv/bin/clang-format --dry-run --Werror",
+      "scripts/check-spdx.sh"
+    ]
   }
 }

--- a/scripts/check-spdx.sh
+++ b/scripts/check-spdx.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Fail if any C/C++ source file is missing the SPDX-License-Identifier
+# header. Used by `make lint` (project-wide sweep) and by lint-staged
+# (pre-commit, staged files only).
+#
+# Usage:
+#   scripts/check-spdx.sh                 # scan lib/ src/ tests/
+#   scripts/check-spdx.sh path/to/file    # check only the given files
+
+set -eu
+
+# Only inspect the first few lines so a stray "SPDX-License-Identifier"
+# somewhere in the body doesn't count as a valid header.
+SCAN_LINES=5
+
+missing=0
+missing_files=""
+
+if [ $# -eq 0 ]; then
+    # Default project-wide sweep. Use -print0 + xargs would be safer for
+    # weird filenames, but this repo's tree is known-clean.
+    set -- $(find lib src tests -type f \( -name '*.h' -o -name '*.cpp' -o -name '*.ino' \))
+fi
+
+for file in "$@"; do
+    # Restrict to the file types we actually lint, in case lint-staged
+    # or a contributor passes something else through.
+    case "$file" in
+        *.h|*.cpp|*.ino) ;;
+        *) continue ;;
+    esac
+
+    if [ ! -f "$file" ]; then
+        continue
+    fi
+
+    if ! head -n "$SCAN_LINES" "$file" | grep -q 'SPDX-License-Identifier'; then
+        missing=$((missing + 1))
+        missing_files="$missing_files$file\n"
+    fi
+done
+
+if [ "$missing" -gt 0 ]; then
+    printf '%b' "$missing_files" >&2
+    echo "" >&2
+    echo "$missing file(s) missing the SPDX-License-Identifier header." >&2
+    echo "Add this as the very first line of each file:" >&2
+    echo "  // SPDX-License-Identifier: GPL-3.0-or-later" >&2
+    exit 1
+fi

--- a/scripts/check-spdx.sh
+++ b/scripts/check-spdx.sh
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 # Fail if any C/C++ source file is missing the SPDX-License-Identifier
-# header. Used by `make lint` (project-wide sweep) and by lint-staged
-# (pre-commit, staged files only).
+# header on its very first line. Used by `make lint` (project-wide
+# sweep) and by lint-staged (pre-commit, staged files only).
 #
 # Usage:
 #   scripts/check-spdx.sh                 # scan lib/ src/ tests/
@@ -11,41 +11,60 @@
 
 set -eu
 
-# Only inspect the first few lines so a stray "SPDX-License-Identifier"
-# somewhere in the body doesn't count as a valid header.
-SCAN_LINES=5
+# Required literal form on line 1 of every C++ source. The SPDX spec is
+# more permissive, but the project convention (see CONTRIBUTING.md) is
+# this exact comment on the first line — matching strictly avoids
+# accepting near-misses that drift further over time.
+EXPECTED_LINE_PREFIX='// SPDX-License-Identifier:'
 
 missing=0
 missing_files=""
 
-if [ $# -eq 0 ]; then
-    # Default project-wide sweep. Use -print0 + xargs would be safer for
-    # weird filenames, but this repo's tree is known-clean.
-    set -- $(find lib src tests -type f \( -name '*.h' -o -name '*.cpp' -o -name '*.ino' \))
-fi
+check_file() {
+    file=$1
 
-for file in "$@"; do
     # Restrict to the file types we actually lint, in case lint-staged
     # or a contributor passes something else through.
     case "$file" in
         *.h|*.cpp|*.ino) ;;
-        *) continue ;;
+        *) return ;;
     esac
 
-    if [ ! -f "$file" ]; then
-        continue
-    fi
+    [ -f "$file" ] || return
 
-    if ! head -n "$SCAN_LINES" "$file" | grep -q 'SPDX-License-Identifier'; then
-        missing=$((missing + 1))
-        missing_files="$missing_files$file\n"
-    fi
-done
+    first_line=$(head -n 1 "$file")
+    case "$first_line" in
+        "$EXPECTED_LINE_PREFIX"*) ;;
+        *)
+            missing=$((missing + 1))
+            missing_files="${missing_files}${file}
+"
+            ;;
+    esac
+}
+
+if [ $# -eq 0 ]; then
+    # Project-wide sweep. Iterate line by line with IFS=newline so
+    # filenames containing spaces survive unscathed. Newlines in
+    # filenames aren't supported — they're absurd and the tree has
+    # none.
+    OLD_IFS=$IFS
+    IFS='
+'
+    for file in $(find lib src tests -type f \( -name '*.h' -o -name '*.cpp' -o -name '*.ino' \)); do
+        check_file "$file"
+    done
+    IFS=$OLD_IFS
+else
+    for file in "$@"; do
+        check_file "$file"
+    done
+fi
 
 if [ "$missing" -gt 0 ]; then
-    printf '%b' "$missing_files" >&2
+    printf '%s' "$missing_files" >&2
     echo "" >&2
-    echo "$missing file(s) missing the SPDX-License-Identifier header." >&2
+    echo "$missing file(s) missing the SPDX-License-Identifier header on line 1." >&2
     echo "Add this as the very first line of each file:" >&2
     echo "  // SPDX-License-Identifier: GPL-3.0-or-later" >&2
     exit 1


### PR DESCRIPTION
## Summary

Turns the SPDX-License-Identifier convention (documented in CONTRIBUTING.md from PR #109) from a paragraph into a mechanical check. New `.h`/`.cpp`/`.ino` files without the header fail the pre-commit hook and the `lint` CI workflow.

Closes #104

## What landed

### `scripts/check-spdx.sh`

Small POSIX-sh script that scans the first 5 lines of each file for `SPDX-License-Identifier`. Exits 1 with the full list of offenders when anything is missing. Defaults to scanning `lib/ src/ tests/` when called with no args, accepts explicit paths so `lint-staged` can pass only the staged subset.

### Wiring

- **Makefile**: `make check-spdx` runs the script; `make lint` (and by extension `make ci`) now chains `format-check` + `check-spdx` + `tidy`.
- **lint-staged** (`package.json`): staged `.h`/`.cpp`/`.ino` files now go through the script after clang-format, so a missing header is caught at commit time with a clear message pointing at the fix.
- **CI** (`.github/workflows/lint.yml`): no change needed — the workflow already calls `make lint`, so the new check runs for free.

### Docs

CONTRIBUTING.md's target table now lists the new `check-spdx` command and the updated `lint` meta-target contents. The SPDX requirement itself was already documented in PR #109.

## Verification

- `make lint` → clean (audit shows 0 files missing SPDX across `lib/` + `src/` + `tests/`).
- Manual negative test: scripted a throwaway `.cpp` without the header, `scripts/check-spdx.sh /tmp/x.cpp` exits 1 with the expected error.
- `make test-native` → 25/25 (unrelated, just a sanity check nothing else broke).

## Checklist

- [x] `make lint` passes (format + SPDX + tidy scaffold)
- [x] `make build` passes
- [x] `make test-native` passes (25/25)
- [x] CONTRIBUTING.md reflects the new target
- [x] Existing tree is already compliant (audit)