### PR TITLE
tooling: Enforce commit and branch conventions instead of warning.

### DIFF
--- a/.github/workflows/check-commits.yml
+++ b/.github/workflows/check-commits.yml
@@ -1,4 +1,4 @@
-name: "📜 Check Commit Messages"
+name: "📜 Check PR Conventions"
 
 on:
   pull_request:
@@ -9,6 +9,9 @@ on:
       - synchronize
     branches:
       - "main"
+
+permissions:
+  contents: read
 
 jobs:
   check-commit-messages:
@@ -27,6 +30,23 @@ jobs:
 
       - name: "🛠 Install commitlint"
         run: npm ci --ignore-scripts
+
+      - name: "🌿 Validate branch name"
+        env:
+          BRANCH: ${{ github.head_ref }}
+        run: |
+          node -e "
+            const config = require('./.validate-branch-namerc.js');
+            const branch = process.env.BRANCH;
+            const regex = new RegExp(config.pattern);
+            if (!regex.test(branch)) {
+              console.error('✗ Branch name not allowed: ' + branch);
+              console.error('Pattern: ' + config.pattern);
+              console.error(config.errorMsg);
+              process.exit(1);
+            }
+            console.log('✓ Branch name OK: ' + branch);
+          "
 
       - name: "📜 Validate commit messages"
         run: npx --no-install commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -6,7 +6,7 @@ module.exports = {
     },
   },
   rules: {
-    'subject-case': [2, 'always', 'sentence-case'],
+    'subject-case': [2, 'always', ['sentence-case']],
     'subject-full-stop': [2, 'always', '.'],
     'header-max-length': [2, 'always', 78],
     'scope-enum': [

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -6,11 +6,11 @@ module.exports = {
     },
   },
   rules: {
-    'subject-case': [0],
-    'subject-full-stop': [0],
+    'subject-case': [2, 'always', 'sentence-case'],
+    'subject-full-stop': [2, 'always', '.'],
     'header-max-length': [2, 'always', 78],
     'scope-enum': [
-      1,
+      2,
       'always',
       [
         'apds9960',


### PR DESCRIPTION
## Summary

Closes the enforcement gaps documented in #105. The project's conventions (commit message shape, branch name pattern) were **stated** in CONTRIBUTING.md but **not enforced** end-to-end — commitlint silently dropped three of its own rules, and branch-name validation only ran in the local husky hook. Contributors who skipped `make setup` could ship non-conforming PRs (PR #84 and #85 both did exactly that).

Tightens the config so the rules actually bite.

Closes #105

## What landed

### A. Commitlint rules promoted to error (`commitlint.config.js`)

| Rule | Before | After |
|------|--------|-------|
| `subject-case` | `[0]` (disabled) | `[2, 'always', 'sentence-case']` |
| `subject-full-stop` | `[0]` (disabled) | `[2, 'always', '.']` |
| `scope-enum` | `[1, 'always', [...]]` (warning) | `[2, 'always', [...]]` (error) |

"feat: add driver" (lowercase) and "docs: update README" (missing period) — valid before, rejected now. Custom scopes like `fix(board)` that used to show a yellow triangle and ship now fail the commit-msg hook and the CI step.

### B. CI branch-name validation (`.github/workflows/check-commits.yml`)

Added a Node inline step that reads `.validate-branch-namerc.js` (single source of truth with the local pre-commit hook) and tests `github.head_ref` against the regex. Fails the workflow with the project's error message on mismatch.

- Workflow renamed from "Check Commit Messages" to "Check PR Conventions" so the identity matches what it now does.
- Added `permissions: contents: read` while in the file (partial fix for #108 — `build.yml` still needs the same treatment).

### Intentionally not here

- **D** (npm `prepare` script) — already in place: `package.json` has `"prepare": "make prepare"` which auto-runs on `npm install` (npm v7+) and installs husky. No change needed.
- **C** (branch protection on `main`) — requires repo admin access via GitHub Settings, can't be done in a PR. Once this merges and the two CI checks go green on a round-trip PR, the admin action is: in Settings → Branches → Branch protection → require `Check PR Conventions`, `Build`, `Tests`, `Lint` to pass before merge.

## Verification

- `make test-native` → 25/25 (unrelated, sanity check).
- `make lint` → clean.
- Smoke-tested the Node branch-name check locally:
  - `BRANCH=tooling/enforce-conventions` → PASS ✓
  - `BRANCH=build/platformio-steami` → FAIL as expected ✓

## Checklist

- [x] `make lint` passes
- [x] `make test-native` passes
- [x] Commit messages follow the *new* (stricter) rules — dogfooded the change
- [x] CONTRIBUTING.md unchanged (already described the behaviour; config now matches)