### PR TITLE
ci: Lock build workflow GITHUB_TOKEN to contents:read.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Closes #108 — the last of the workflows missing an explicit `permissions` block. Without one, `GITHUB_TOKEN` inherits the repository default, which grants write access on issues, PRs, checks, deployments, and more. The `build` job doesn't need any of that — it checks out the code, runs `make setup`, and runs `make build`.

Add a workflow-level `permissions: contents: read`.

Closes #108

## What's covered

| Workflow | Status |
|----------|--------|
| `lint.yml` | ✓ tightened in PR #89 |
| `check-commits.yml` | ✓ tightened in PR #111 |
| `build.yml` | ✓ this PR |
| `auto-assign-author.yml` | already scoped at job level (`pull-requests: write` — matches what the job does) |
| `tests.yml` | already scoped at workflow level (PR #90) |
| `release.yml` | already scoped at both levels |

After this merges, every workflow in `.github/workflows/` has an explicit permissions block matching the minimum it needs.

## Verification

- No functional change — the `build` job was already only reading content. The block just codifies that.
- `make lint` / `make test-native` clean (unrelated sanity check).

## Checklist

- [x] `make lint` passes
- [x] `make test-native` passes
- [x] Explicit minimum-permissions block on every workflow