### PR TITLE
tooling: Stop pip install from re-firing on every make invocation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,14 +19,22 @@ node_modules/.package-lock.json: package.json package-lock.json
 	python3 -m venv .venv
 	.venv/bin/pip install --upgrade pip
 
+# Touch the target after pip install so make's mtime comparison stops
+# re-firing — pip install of an already-satisfied package is a no-op
+# that doesn't refresh the installed binary's timestamp, and without
+# the touch the "requirements.txt newer than target" check stays true
+# forever and pip runs on every make invocation.
 .venv/bin/pio: requirements.txt | .venv
 	.venv/bin/pip install -c requirements.txt platformio
+	@touch .venv/bin/pio
 
 .venv/bin/clang-format: requirements.txt | .venv
 	.venv/bin/pip install -c requirements.txt clang-format
+	@touch .venv/bin/clang-format
 
 .venv/bin/clang-tidy: requirements.txt | .venv
 	.venv/bin/pip install -c requirements.txt clang-tidy
+	@touch .venv/bin/clang-tidy
 
 .PHONY: install-pio
 install-pio: .venv/bin/pio ## Install PlatformIO in the local venv

--- a/Makefile
+++ b/Makefile
@@ -26,15 +26,15 @@ node_modules/.package-lock.json: package.json package-lock.json
 # forever and pip runs on every make invocation.
 .venv/bin/pio: requirements.txt | .venv
 	.venv/bin/pip install -c requirements.txt platformio
-	@touch .venv/bin/pio
+	@test -x $@ && touch $@
 
 .venv/bin/clang-format: requirements.txt | .venv
 	.venv/bin/pip install -c requirements.txt clang-format
-	@touch .venv/bin/clang-format
+	@test -x $@ && touch $@
 
 .venv/bin/clang-tidy: requirements.txt | .venv
 	.venv/bin/pip install -c requirements.txt clang-tidy
-	@touch .venv/bin/clang-tidy
+	@test -x $@ && touch $@
 
 .PHONY: install-pio
 install-pio: .venv/bin/pio ## Install PlatformIO in the local venv


### PR DESCRIPTION
## Summary

Touch the venv tool binaries after `pip install` so Make's mtime comparison stops retriggering. Before: every `make tidy` / `make build` / `make test-native` started with 20+ "Requirement already satisfied" lines. After: silent.

Closes #114

## Context

The issue has the full story, but in short: `pip install <already-satisfied>` is a quick no-op that doesn't refresh the installed binary's timestamp, so the rule `target: requirements.txt` kept firing forever after any edit to the pins file.

## Fix

```diff
 .venv/bin/pio: requirements.txt | .venv
 	.venv/bin/pip install -c requirements.txt platformio
+	@touch .venv/bin/pio
```

Applied to all three venv targets (`pio`, `clang-format`, `clang-tidy`). The recipe still runs pip install when `requirements.txt` is newer than the binary — that's the right trigger, and the `@touch` only runs if pip completed successfully, so genuine version bumps still refresh the binary.

## Verification

```bash
touch requirements.txt
make tidy          # pre-fix: 22 "Requirement already satisfied" lines
                   # post-fix: 22 (first run rebuilds)
make tidy          # pre-fix: 22 (again)
                   # post-fix: 0 ✓
```

## Checklist

- [x] `make ci` passes
- [x] First run after `touch requirements.txt` still re-installs (prereq still fires correctly)
- [x] Subsequent runs skip pip entirely