### PR TITLE
ci: Auto-label PRs from their conventional-commit type.

### DIFF
--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -1,7 +1,13 @@
 name: "🏷 Auto-label PR"
 
+# pull_request_target (and not pull_request) is used so the workflow can
+# write labels on PRs opened from forks — the GITHUB_TOKEN would be
+# read-only under plain pull_request. This is only safe as long as the
+# job never checks out or executes PR code: we only inspect the title
+# from the event payload and call the issues API. Do not add checkout
+# steps here without switching back to pull_request.
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited
@@ -17,7 +23,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - name: "🏷 Apply label matching the PR title type"
+      - name: "🏷 Sync label with the PR title type"
         uses: actions/github-script@v7
         with:
           script: |
@@ -27,13 +33,6 @@ jobs:
             const match = title.match(
               /^(feat|fix|docs|style|refactor|test|ci|build|chore|perf|revert|tooling)(\([^)]+\))?!?:/i
             );
-
-            if (!match) {
-              core.info(`Title "${title}" doesn't match the conventional-commit pattern; no label applied.`);
-              return;
-            }
-
-            const type = match[1].toLowerCase();
 
             // Map conventional-commit types to repository labels. Every
             // type allowed by commitlint.config.js's type-enum has a
@@ -52,23 +51,41 @@ jobs:
               revert: 'revert',
               tooling: 'tooling',
             };
+            const managedLabels = new Set(Object.values(typeToLabel));
 
-            const label = typeToLabel[type];
-            if (!label) {
-              core.info(`Type "${type}" has no mapped label in this repo; skipping.`);
-              return;
+            const target = match ? typeToLabel[match[1].toLowerCase()] : null;
+            if (!match) {
+              core.info(`Title "${title}" doesn't match the conventional-commit pattern; not touching labels.`);
             }
 
-            // Check whether the label is already applied to keep the operation
-            // idempotent — editing a PR title shouldn't spam label events.
+            // Pull the current labels so we can both remove stale managed
+            // ones (if the title type changed) and skip re-adding when the
+            // target is already there.
             const { data: existing } = await github.rest.issues.listLabelsOnIssue({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
             });
 
-            if (existing.some((l) => l.name === label)) {
-              core.info(`Label "${label}" already present on PR #${context.issue.number}.`);
+            // Remove any managed label that doesn't match the current target.
+            // Editing a title from `docs:` to `fix:` should end with the PR
+            // carrying `bug` only, not both `docs` and `bug`.
+            for (const lbl of existing) {
+              if (managedLabels.has(lbl.name) && lbl.name !== target) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name: lbl.name,
+                });
+                core.info(`Removed stale label "${lbl.name}" from PR #${context.issue.number}.`);
+              }
+            }
+
+            if (!target) return;
+
+            if (existing.some((l) => l.name === target)) {
+              core.info(`Label "${target}" already present on PR #${context.issue.number}.`);
               return;
             }
 
@@ -76,6 +93,6 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              labels: [label],
+              labels: [target],
             });
-            core.info(`Applied label "${label}" to PR #${context.issue.number} (type "${type}").`);
+            core.info(`Applied label "${target}" to PR #${context.issue.number} (type "${match[1].toLowerCase()}").`);

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -35,16 +35,21 @@ jobs:
 
             const type = match[1].toLowerCase();
 
-            // Map conventional-commit types to existing repository labels.
-            // Types not listed here (style, refactor, build, chore, perf, revert)
-            // have no repo label yet — add the labels in repo settings and extend
-            // this map if the team wants complete coverage.
+            // Map conventional-commit types to repository labels. Every
+            // type allowed by commitlint.config.js's type-enum has a
+            // corresponding label.
             const typeToLabel = {
               feat: 'enhancement',
               fix: 'bug',
               docs: 'docs',
+              style: 'style',
+              refactor: 'refactor',
               test: 'test',
               ci: 'ci',
+              build: 'build',
+              chore: 'chore',
+              perf: 'perf',
+              revert: 'revert',
               tooling: 'tooling',
             };
 

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -1,0 +1,76 @@
+name: "🏷 Auto-label PR"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "🏷 Apply label matching the PR title type"
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title || '';
+
+            // Extract the conventional-commit type prefix (optionally with scope).
+            const match = title.match(
+              /^(feat|fix|docs|style|refactor|test|ci|build|chore|perf|revert|tooling)(\([^)]+\))?!?:/i
+            );
+
+            if (!match) {
+              core.info(`Title "${title}" doesn't match the conventional-commit pattern; no label applied.`);
+              return;
+            }
+
+            const type = match[1].toLowerCase();
+
+            // Map conventional-commit types to existing repository labels.
+            // Types not listed here (style, refactor, build, chore, perf, revert)
+            // have no repo label yet — add the labels in repo settings and extend
+            // this map if the team wants complete coverage.
+            const typeToLabel = {
+              feat: 'enhancement',
+              fix: 'bug',
+              docs: 'docs',
+              test: 'test',
+              ci: 'ci',
+              tooling: 'tooling',
+            };
+
+            const label = typeToLabel[type];
+            if (!label) {
+              core.info(`Type "${type}" has no mapped label in this repo; skipping.`);
+              return;
+            }
+
+            // Check whether the label is already applied to keep the operation
+            // idempotent — editing a PR title shouldn't spam label events.
+            const { data: existing } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            if (existing.some((l) => l.name === label)) {
+              core.info(`Label "${label}" already present on PR #${context.issue.number}.`);
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: [label],
+            });
+            core.info(`Applied label "${label}" to PR #${context.issue.number} (type "${type}").`);


### PR DESCRIPTION
## Summary

New GitHub Actions workflow `auto-label-pr.yml` that reads the PR title, matches the leading conventional-commit type (e.g. `feat(hts221):`, `ci:`, `docs:`), and applies the corresponding repo label. Also adds the six repo labels that were previously missing so the mapping is complete.

## Why

Every PR title already follows the conventional-commit convention (enforced by #111 now that the commitlint rules are strict). That's a free source of category information — today nobody labels PRs manually, which makes triage and release-notes generation harder than it needs to be.

## Mapping (complete)

| Commit type | Label | Already existed |
|-------------|-------|-----------------|
| `feat` | `enhancement` | ✓ |
| `fix` | `bug` | ✓ |
| `docs` | `docs` | ✓ |
| `style` | `style` | created in this PR |
| `refactor` | `refactor` | created in this PR |
| `test` | `test` | ✓ |
| `ci` | `ci` | ✓ |
| `build` | `build` | created in this PR |
| `chore` | `chore` | created in this PR |
| `perf` | `perf` | created in this PR |
| `revert` | `revert` | created in this PR |
| `tooling` | `tooling` | ✓ |

The mapping is now symmetric with the commitlint type-enum — every commit type that passes validation gets a label.

## Behaviour

- Triggers on `opened`, `edited`, `reopened`, `synchronize` — catches new PRs and title edits.
- Uses `actions/github-script@v7` (same pattern as `auto-assign-author.yml`). No external action dependency.
- `permissions: pull-requests: write` only.
- Idempotent: if the label is already present, the workflow no-ops instead of re-adding.
- Non-conventional titles get logged and skipped without error.

## Verification

- Once merged, this PR itself should get the `ci` label applied (the workflow runs on its own next `synchronize` event).
- Manual test: change a draft PR's title to e.g. `feat(example): ...`, observe the `enhancement` label appear within ~10 s.

## Out of scope

- Labeling by scope (e.g. `fix(hts221):` → `hts221` label) — would create one label per driver. Deferred until there's demand.
- Removing stale labels when a PR title changes type — currently the old label stays so humans can curate; add automatic removal if it becomes a nuisance.