### PR TITLE
ci: Inherit milestone from linked issue on PR open.

### DIFF
--- a/.github/workflows/milestone-from-issue.yml
+++ b/.github/workflows/milestone-from-issue.yml
@@ -1,0 +1,91 @@
+name: "🎯 Inherit milestone from linked issue"
+
+# When a PR is opened or its description edited, look for `Closes #N` /
+# `Fixes #N` / `Resolves #N` references in the body and propagate the
+# milestone of the first referenced issue that has one. Only sets a
+# milestone if the PR has none — never overrides a value set by hand.
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+  issues: read
+
+jobs:
+  inherit-milestone:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "🎯 Copy milestone from linked issue"
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              core.info('No pull_request payload; skipping.');
+              return;
+            }
+
+            // Skip if the PR already carries a milestone — a human choice
+            // wins over any propagation, and re-editing the body should
+            // not clobber a milestone the maintainer set by hand.
+            if (pr.milestone) {
+              core.info(`PR #${pr.number} already has milestone "${pr.milestone.title}"; skipping.`);
+              return;
+            }
+
+            const body = pr.body || '';
+
+            // Extract issue numbers referenced via the GitHub-supported
+            // closing keywords. Cross-repo refs (`owner/repo#N`) are
+            // ignored on purpose — we only propagate within this repo.
+            const pattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*#(\d+)/gi;
+            const numbers = new Set();
+            for (const m of body.matchAll(pattern)) {
+              numbers.add(Number(m[1]));
+            }
+
+            if (numbers.size === 0) {
+              core.info(`PR #${pr.number} body has no Closes/Fixes/Resolves references; nothing to inherit.`);
+              return;
+            }
+
+            core.info(`PR #${pr.number} references issues: ${[...numbers].join(', ')}`);
+
+            // First referenced issue that carries a milestone wins. We
+            // iterate in the order they appear in the body so the author
+            // controls the tiebreak by ordering their Closes lines.
+            let chosen = null;
+            for (const n of numbers) {
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: n,
+                });
+                if (issue.milestone) {
+                  chosen = { number: n, milestone: issue.milestone };
+                  break;
+                }
+              } catch (err) {
+                core.warning(`Could not fetch issue #${n}: ${err.message}`);
+              }
+            }
+
+            if (!chosen) {
+              core.info(`None of the referenced issues has a milestone; leaving PR #${pr.number} unassigned.`);
+              return;
+            }
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              milestone: chosen.milestone.number,
+            });
+            core.info(`Applied milestone "${chosen.milestone.title}" to PR #${pr.number} (inherited from issue #${chosen.number}).`);

--- a/.github/workflows/milestone-from-issue.yml
+++ b/.github/workflows/milestone-from-issue.yml
@@ -15,7 +15,7 @@ on:
 
 permissions:
   pull-requests: write
-  issues: read
+  issues: write
 
 jobs:
   inherit-milestone:
@@ -44,7 +44,7 @@ jobs:
             // Extract issue numbers referenced via the GitHub-supported
             // closing keywords. Cross-repo refs (`owner/repo#N`) are
             // ignored on purpose — we only propagate within this repo.
-            const pattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*#(\d+)/gi;
+            const pattern = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*#(\d+)/gi;
             const numbers = new Set();
             for (const m of body.matchAll(pattern)) {
               numbers.add(Number(m[1]));


### PR DESCRIPTION
## Summary

- New `.github/workflows/milestone-from-issue.yml` that parses the PR body on `opened` / `edited` / `reopened` for `Closes #N`, `Fixes #N`, `Resolves #N` references.
- Fetches each referenced issue and applies the milestone of the first one that has one. Skips if the PR already carries a milestone — manual choices always win.
- Uses `pull_request_target` so it also works on fork PRs (same safety pattern as auto-label-pr.yml: only reads the payload + calls the issues API, never checks out PR code).

## Context

Part of the project automation push — today many PRs close milestoned issues but land with `milestone: -`. This removes the manual step without touching existing workflows.

Next steps (separate PRs):
- Auto-add issues / PRs to the org STeaMi project (needs a PAT secret).
- Status transitions (Backlog → In review → Done) on the project board.
- One-shot backfill of existing closed PRs that should have inherited a milestone.

## Test plan

- [ ] Open a throwaway test PR whose body contains `Closes #117` (which is on milestone "Phase 2"). Verify the workflow runs and stamps the milestone.
- [ ] Edit an existing PR body to add `Fixes #<milestoned-issue>`; verify it picks up the milestone.
- [ ] Set a milestone by hand, edit the body to reference a different milestoned issue, verify the manual milestone is preserved.
- [ ] PR body with no closing refs → workflow logs "nothing to inherit", no-op.