### PR TITLE
feat(tooling): Add per-example flash- targets and list-examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,8 @@ list-examples: ## List examples, optionally filtered with DRIVER=<driver>
 
 .PHONY: flash
 flash: .venv/bin/pio ## Flash an example (make flash EXAMPLE=<driver>/<example>) and open serial monitor
-	@example='$(EXAMPLE)'
+	@set -e
+	example='$(EXAMPLE)'
 	if [ -z "$$example" ] || ! printf '%s\n' "$$example" | grep -Eq '^[^/]+/[^/]+$$'; then
 		echo "Error: EXAMPLE must be set as <driver>/<example>." >&2
 		echo "Run 'make list-examples' or 'make list-examples DRIVER=<driver>' to see valid values." >&2
@@ -140,11 +141,11 @@ flash: .venv/bin/pio ## Flash an example (make flash EXAMPLE=<driver>/<example>)
 
 .PHONY: test-native
 test-native: .venv/bin/pio ## Run host-side native tests (no board required)
-	pio test -e native
+	$(PIO) test -e native
 
 .PHONY: test-hardware
 test-hardware: .venv/bin/pio ## Run on-board hardware tests (STeaMi required)
-	pio test -e steami
+	$(PIO) test -e steami
 
 # --- CI ---
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@
 
 include env.mk
 
+PIO := .venv/bin/pio
+EXAMPLES_ROOT := lib
+
 # --- Setup ---
 
 # npm install is re-run only when package.json changes
@@ -77,7 +80,7 @@ DRIVER_SOURCES := $(shell find lib -type f -path '*/src/*.cpp')
 # Generated from the native env because host compile handles the STL /
 # headers cleanly (the ARM cross-compile toolchain trips clang-tidy up).
 compile_commands.json: .venv/bin/pio platformio.ini boards/steami.json $(DRIVER_SOURCES)
-	pio run -t compiledb -e native
+	$(PIO) run -t compiledb -e native
 
 .PHONY: tidy
 tidy: .venv/bin/clang-tidy compile_commands.json ## Run clang-tidy on every driver source under lib/*/src/
@@ -94,11 +97,44 @@ lint: format-check check-spdx tidy ## Run all static checks (format + SPDX + sta
 
 .PHONY: build
 build: .venv/bin/pio ## Build with PlatformIO
-	pio run
+	$(PIO) run
 
 .PHONY: upload
 upload: .venv/bin/pio ## Upload to board
-	pio run --target upload --upload-port $(PORT)
+	$(PIO) run --target upload --upload-port $(PORT)
+
+.PHONY: list-examples
+list-examples: ## List examples, optionally filtered with DRIVER=<driver>
+	@if [ -n "$(DRIVER)" ]; then \
+		driver_dir="$(EXAMPLES_ROOT)/$(DRIVER)/examples"; \
+		if [ ! -d "$$driver_dir" ]; then \
+			echo "Error: driver '$(DRIVER)' was not found." >&2; \
+			echo "Run 'make list-examples' to see all available examples." >&2; \
+			exit 1; \
+		fi; \
+		find "$$driver_dir" -mindepth 1 -maxdepth 1 -type d | LC_ALL=C sort; \
+	else \
+		find $(EXAMPLES_ROOT) -mindepth 3 -maxdepth 3 -type d -path '$(EXAMPLES_ROOT)/*/examples/*' | LC_ALL=C sort; \
+	fi
+
+.PHONY: flash
+flash: .venv/bin/pio ## Flash an example (make flash EXAMPLE=<driver>/<example>) and open serial monitor
+	@example='$(EXAMPLE)'
+	if [ -z "$$example" ] || ! printf '%s\n' "$$example" | grep -Eq '^[^/]+/[^/]+$$'; then
+		echo "Error: EXAMPLE must be set as <driver>/<example>." >&2
+		echo "Run 'make list-examples' or 'make list-examples DRIVER=<driver>' to see valid values." >&2
+		exit 1
+	fi
+
+	src_dir="$(EXAMPLES_ROOT)/$${example%/*}/examples/$${example#*/}"
+	if [ ! -d "$$src_dir" ]; then
+		echo "Error: example '$$example' was not found." >&2
+		echo "Run 'make list-examples' or 'make list-examples DRIVER=<driver>' to see valid values." >&2
+		exit 1
+	fi
+
+	PLATFORMIO_SRC_DIR="$$src_dir" $(PIO) run -e steami -t upload
+	$(PIO) device monitor -b 115200
 
 # --- Testing ---
 
@@ -128,7 +164,7 @@ deepclean: clean ## Remove everything including node_modules and venv
 
 .PHONY: help
 help: ## Show this help
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' Makefile | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' Makefile | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
 # A useful debug Make Target
 .PHONY: printvars

--- a/Makefile
+++ b/Makefile
@@ -103,39 +103,38 @@ build: .venv/bin/pio ## Build with PlatformIO
 upload: .venv/bin/pio ## Upload to board
 	$(PIO) run --target upload --upload-port $(PORT)
 
+# Discovered once at parse time. Each entry is "<driver>/<example>" and
+# becomes a `flash-<driver>/<example>` phony target via the foreach+eval
+# block below. Listed via $(shell) so adding an example only requires a
+# new directory under lib/<driver>/examples/.
+EXAMPLE_KEYS := $(shell find $(EXAMPLES_ROOT) -mindepth 3 -maxdepth 3 -type d -path '$(EXAMPLES_ROOT)/*/examples/*' 2>/dev/null | sed 's|$(EXAMPLES_ROOT)/\([^/]*\)/examples/\([^/]*\)|\1/\2|' | LC_ALL=C sort)
+
 .PHONY: list-examples
-list-examples: ## List examples, optionally filtered with DRIVER=<driver>
+list-examples: ## List ready-to-run flash- targets, optionally filtered with DRIVER=<driver>
 	@if [ -n "$(DRIVER)" ]; then \
-		driver_dir="$(EXAMPLES_ROOT)/$(DRIVER)/examples"; \
-		if [ ! -d "$$driver_dir" ]; then \
-			echo "Error: driver '$(DRIVER)' was not found." >&2; \
+		matches="$$(printf '%s\n' $(EXAMPLE_KEYS) | grep -E '^$(DRIVER)/' || true)"; \
+		if [ -z "$$matches" ]; then \
+			echo "Error: driver '$(DRIVER)' has no examples." >&2; \
 			echo "Run 'make list-examples' to see all available examples." >&2; \
 			exit 1; \
 		fi; \
-		find "$$driver_dir" -mindepth 1 -maxdepth 1 -type d | LC_ALL=C sort; \
+		printf '%s\n' "$$matches" | sed 's|^|flash-|'; \
 	else \
-		find $(EXAMPLES_ROOT) -mindepth 3 -maxdepth 3 -type d -path '$(EXAMPLES_ROOT)/*/examples/*' | LC_ALL=C sort; \
+		printf '%s\n' $(EXAMPLE_KEYS) | sed 's|^|flash-|'; \
 	fi
 
-.PHONY: flash
-flash: .venv/bin/pio ## Flash an example (make flash EXAMPLE=<driver>/<example>) and open serial monitor
+# Per-example flash targets. Pattern rules with `%` don't span `/` in
+# GNU Make, so we generate one explicit phony target per example via
+# foreach+eval — same shape as test-<scenario> in micropython-steami-lib.
+# Usage: `make flash-hts221/dew_point` (the value listed by list-examples).
+define FLASH_RULE
+.PHONY: flash-$(1)
+flash-$(1): .venv/bin/pio
 	@set -e
-	example='$(EXAMPLE)'
-	if [ -z "$$example" ] || ! printf '%s\n' "$$example" | grep -Eq '^[^/]+/[^/]+$$'; then
-		echo "Error: EXAMPLE must be set as <driver>/<example>." >&2
-		echo "Run 'make list-examples' or 'make list-examples DRIVER=<driver>' to see valid values." >&2
-		exit 1
-	fi
-
-	src_dir="$(EXAMPLES_ROOT)/$${example%/*}/examples/$${example#*/}"
-	if [ ! -d "$$src_dir" ]; then
-		echo "Error: example '$$example' was not found." >&2
-		echo "Run 'make list-examples' or 'make list-examples DRIVER=<driver>' to see valid values." >&2
-		exit 1
-	fi
-
-	PLATFORMIO_SRC_DIR="$$src_dir" $(PIO) run -e steami -t upload
-	$(PIO) device monitor -b 115200
+	PLATFORMIO_SRC_DIR="$(EXAMPLES_ROOT)/$(subst /,/examples/,$(1))" $$(PIO) run -e steami -t upload
+	$$(PIO) device monitor -b 115200
+endef
+$(foreach k,$(EXAMPLE_KEYS),$(eval $(call FLASH_RULE,$(k))))
 
 # --- Testing ---
 

--- a/README.md
+++ b/README.md
@@ -51,36 +51,34 @@ pio run --target upload
 
 ### List available examples
 
-List all examples:
-
 ```bash
 make list-examples
 ```
 
-List examples for a specific driver:
+This prints one ready-to-run target per example, e.g.:
+
+```
+flash-hts221/comfort_index
+flash-hts221/dew_point
+flash-hts221/read_temperature_humidity
+flash-hts221/temperature_alarm
+```
+
+Filter by driver:
 
 ```bash
 make list-examples DRIVER=hts221
 ```
 
-This prints all available examples under `lib/*/examples/*`, or only those under a specific driver when `DRIVER` is provided.
-
 ### Flash an example
 
+Copy any line from `make list-examples` and run it:
+
 ```bash
-make flash EXAMPLE=hts221/dew_point
+make flash-hts221/dew_point
 ```
 
-This will:
-
-* build and upload the example to the STeaMi board
-* open the serial monitor at 115200 baud after a successful upload
-
-The `EXAMPLE` argument must follow the format:
-
-```
-<driver>/<example>
-```
+This builds the example, uploads it to the STeaMi board, and opens the serial monitor at 115200 baud on success.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,41 @@ pio run
 pio run --target upload
 ```
 
+## Examples
+
+### List available examples
+
+List all examples:
+
+```bash
+make list-examples
+```
+
+List examples for a specific driver:
+
+```bash
+make list-examples DRIVER=hts221
+```
+
+This prints all available examples under `lib/*/examples/*`, or only those under a specific driver when `DRIVER` is provided.
+
+### Flash an example
+
+```bash
+make flash EXAMPLE=hts221/dew_point
+```
+
+This will:
+
+* build and upload the example to the STeaMi board
+* open the serial monitor at 115200 baud after a successful upload
+
+The `EXAMPLE` argument must follow the format:
+
+```
+<driver>/<example>
+```
+
 ## Development
 
 ### Setup

--- a/lib/hts221/README.md
+++ b/lib/hts221/README.md
@@ -61,17 +61,19 @@ for the full sketch.
 
 ### Building an example
 
-PlatformIO builds the directory pointed at by `src_dir`. To flash an
-example instead of the default smoke-test under `src/`, override
-`src_dir` via the `PLATFORMIO_SRC_DIR` environment variable for a
-single invocation:
+List available examples:
 
 ```bash
-PLATFORMIO_SRC_DIR=lib/hts221/examples/dew_point pio run -e steami -t upload
-pio device monitor -b 115200
+make list-examples
 ```
 
-(`pio run` without the override keeps building the project's smoke-test.)
+Then flash one:
+
+```bash
+make flash EXAMPLE=hts221/dew_point
+```
+
+This builds, uploads, and opens the serial monitor at 115200 baud.
 
 ## API
 

--- a/lib/hts221/README.md
+++ b/lib/hts221/README.md
@@ -61,16 +61,16 @@ for the full sketch.
 
 ### Building an example
 
-List available examples:
+List available examples (each line is a runnable Make target):
 
 ```bash
 make list-examples
 ```
 
-Then flash one:
+Then flash one — copy a line from the listing:
 
 ```bash
-make flash EXAMPLE=hts221/dew_point
+make flash-hts221/dew_point
 ```
 
 This builds, uploads, and opens the serial monitor at 115200 baud.


### PR DESCRIPTION
## Summary

Make running a driver example a one-liner you can copy-paste straight from a listing, removing the `PLATFORMIO_SRC_DIR` trick and the two-command monitor dance.

Closes #117

```bash
$ make list-examples
flash-hts221/comfort_index
flash-hts221/dew_point
flash-hts221/read_temperature_humidity
flash-hts221/temperature_alarm

$ make flash-hts221/dew_point
```

The shape mirrors `test-<scenario>` in [micropython-steami-lib](https://github.com/steamicc/micropython-steami-lib): one phony target per example, generated dynamically from the filesystem via `foreach + eval`. Tab-completion on zsh/bash works for free.

## Changes

* `make list-examples` enumerates every `lib/*/examples/*/` directory and prints them as ready-to-run `flash-<driver>/<example>` targets.
* `DRIVER=<driver>` filters the listing to a single driver; an unknown driver prints a helpful error pointing back to `make list-examples`.
* `make flash-<driver>/<example>` builds the example, uploads it to the STeaMi board, and opens the serial monitor at 115200 baud — but **only when the upload succeeds** (`set -e` under `.ONESHELL`, otherwise the monitor would open on a stale or empty firmware).
* The flash targets are auto-discovered each invocation, so adding a new example only requires creating its directory under `lib/<driver>/examples/`.
* `PIO := .venv/bin/pio` introduced and used by every target that calls `pio` (`build`, `upload`, `compile_commands.json`, `test-native`, `test-hardware`, generated `flash-*`) — uniform behaviour, no reliance on PATH ordering.
* `make help` lists `list-examples`; the per-example `flash-*` targets are intentionally not enumerated there since `make list-examples` is their canonical index.
* `README.md` and `lib/hts221/README.md` rewritten to use the new syntax.

## Why not a pattern rule `flash-%:` ?

It was the obvious first try. GNU Make's `%` does **not** span `/` inside the stem, so `flash-%:` matching `flash-hts221/dew_point` does not work (verified with `make -d`). `foreach + eval` generates explicit phony targets and sidesteps the limitation — same approach micropython-steami-lib uses for its `test-<scenario>` family.

## Acceptance criteria

- [x] `make flash-<driver>/<example>` exists for every directory under `lib/*/examples/*` (auto-discovered) and:
  1. redirects `src_dir` at the matching example path via `PLATFORMIO_SRC_DIR`
  2. runs `pio run -e steami -t upload`
  3. opens `pio device monitor -b 115200` only when the upload succeeds
- [x] `make list-examples` prints one ready-to-run target per example, one per line (no headers, pipeable).
- [x] `make list-examples DRIVER=<driver>` filters to a single driver; unknown driver → helpful error.
- [x] Invalid target (`make flash-hts221/bogus`) falls through to Make's standard "no rule" error.
- [x] `make help` mentions `list-examples`.
- [x] `lib/hts221/README.md` — section *Building an example* rewritten to use `make flash-…`.
- [x] Top-level `README.md` — *Examples* section explains both targets.

## Validated end-to-end on hardware

- `make help` clean, `list-examples` and `list-examples DRIVER=hts221` both correct.
- `make list-examples DRIVER=nope` → explicit error + exit 1.
- `make flash-hts221/dew_point` → board flashed in ~10 s, serial output `T=26.32 C  H=51.6 %  DewPoint=15.57 C` at 1 Hz.
- `make flash-hts221/comfort_index` → board flashed, serial output `T=28.56 C  H=45.5 %  -> Hot` at 1 Hz.
- `make flash-hts221/bogus` → Make's "no rule" error, exit 2.
- The `set -e` guard fired (validated accidentally when running the monitor in a non-TTY shell — the monitor errored, `set -e` propagated, `make` exited 2 instead of silently succeeding).