### PR TITLE
test(tooling): Generate one test-native- target per suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,9 +154,25 @@ $(foreach k,$(EXAMPLE_KEYS),$(eval $(call CAPTURE_RULE,$(k))))
 
 # --- Testing ---
 
+# Discovered once at parse time. Each entry is the suite name (without
+# the test_ prefix) and becomes a `test-native-<name>` phony target via
+# the foreach+eval block below — same shape as the flash- and capture-
+# families. Adding a new tests/native/test_<name>/ directory picks up
+# automatically.
+NATIVE_TEST_KEYS := $(patsubst tests/native/test_%,%,$(wildcard tests/native/test_*))
+
 .PHONY: test-native
-test-native: .venv/bin/pio ## Run host-side native tests (no board required)
+test-native: .venv/bin/pio ## Run all host-side native tests (no board required)
 	$(PIO) test -e native
+
+# Per-suite native test targets — `make test-native-<name>` runs only
+# that suite via PlatformIO's --filter flag.
+define NATIVE_TEST_RULE
+.PHONY: test-native-$(1)
+test-native-$(1): .venv/bin/pio
+	$$(PIO) test -e native --filter native/test_$(1)
+endef
+$(foreach k,$(NATIVE_TEST_KEYS),$(eval $(call NATIVE_TEST_RULE,$(k))))
 
 .PHONY: test-hardware
 test-hardware: .venv/bin/pio ## Run on-board hardware tests (STeaMi required)

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -65,21 +65,29 @@ pio test -e native
 ### Run a specific test suite
 
 ```bash
-pio test -e steami -f hardware/test_led
-pio test -e native -f native/test_led
+pio test -e steami --filter hardware/test_led
+pio test -e native --filter native/test_led
 ```
 
 ---
 
 ### Using Makefile
 
+The `make` wrappers route through the venv `pio` installed by `make setup`,
+and one phony target is generated per suite under `tests/native/test_*`
+(via `foreach + eval`, same shape as `flash-<driver>/<example>`):
+
 ```bash
-make test-native      # Host-side tests, no board required
-make test-hardware    # On-board tests, STeaMi required
+make test-native              # all native suites
+make test-native-hts221       # one suite — auto-discovered from tests/native/test_hts221/
+make test-native-led
+make test-native-wire
+make test-hardware            # all hardware suites (board required)
 ```
 
-Each target is a thin wrapper around `pio test -e <env>`, pinned to
-the venv pio installed by `make setup`.
+Tab-completion on zsh/bash works for `make test-native-<TAB>`. Adding a new
+suite directory under `tests/native/test_<name>/` picks up automatically on
+the next `make` invocation — no Makefile edits.
 
 ---
 


### PR DESCRIPTION
## Summary

Mirror the `flash-<driver>/<example>` and `capture-<driver>/<example>` families landed in #133 / #138: each directory under `tests/native/test_*/` becomes a `make test-native-<name>` phony target via `foreach + eval`, so adding a new suite is just creating the directory.

Closes #119

```bash
make test-native              # all native suites
make test-native-hts221       # one suite — auto-discovered from tests/native/test_hts221/
make test-native-led
make test-native-wire
```

Tab-completion on zsh/bash works for `make test-native-<TAB>`.

## Why per-target instead of `driver=<name>`?

The earlier proposal in this branch used `make test-native driver=<name>` plus a `test-native-list` helper. Switching to per-target generation:

* aligns with `flash-<driver>/<example>` (#133) and `capture-<driver>/<example>` (#138) — same pattern across the whole "operate on one item from a discovered list" surface;
* enables tab-completion natively (Make exposes phony targets to the shell completion);
* lets users discover suites the same way they already do for examples (`make test-native-<TAB>` in zsh/bash);
* keeps the Makefile mechanically uniform — copy-paste the foreach+eval block when adding a new test family (e.g. `test-hardware-<name>` in #144).

The previous `test-native-list` helper drops out: tab-completion + `make help` are sufficient. An invalid name (`make test-native-bogus`) falls through to Make's standard "no rule" error.

## Changes

* `Makefile` — `NATIVE_TEST_KEYS` discovered via `$(wildcard tests/native/test_*)` + `$(patsubst …)`, then a `define / foreach / eval` block emits one `test-native-<name>` per suite. `make test-native` (no arg) still runs everything.
* `tests/TESTING.md` — *Using Makefile* section rewritten around the per-target shape. Also fixes `pio test -f` → `pio test --filter` since the long flag matches the rest of the doc.

The earlier "Install PlatformIO" CI step from this branch is dropped — `make test-native` already installs `pio` into the venv via the `.venv/bin/pio` prerequisite, and the workflow runs that target directly.

## Validated locally

```
$ make test-native-hts221       # 15/15 pass
$ make test-native-led          # 3/3 pass
$ make test-native-wire         # 7/7 pass
$ make test-native-bogus        # make: *** No rule to make target — exit 2
```