### PR TITLE
feat(tooling): Add capture-<driver>/<example> for boot serial capture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,22 @@ flash-$(1): .venv/bin/pio
 endef
 $(foreach k,$(EXAMPLE_KEYS),$(eval $(call FLASH_RULE,$(k))))
 
+# Per-example capture targets — same shape as the flash- family but
+# routes serial through scripts/capture-serial.py: the script opens the
+# port, flushes, asks OpenOCD to reset, and reads for DURATION seconds.
+# Useful for boot-time logs that the interactive monitor misses (the
+# board prints before pio device monitor finishes its handshake).
+# DURATION defaults to 10; override with DURATION=N.
+DURATION ?= 10
+define CAPTURE_RULE
+.PHONY: capture-$(1)
+capture-$(1): .venv/bin/pio
+	@set -e
+	PLATFORMIO_SRC_DIR="$(EXAMPLES_ROOT)/$(subst /,/examples/,$(1))" $$(PIO) run -e steami -t upload
+	.venv/bin/python scripts/capture-serial.py --duration $$(DURATION)
+endef
+$(foreach k,$(EXAMPLE_KEYS),$(eval $(call CAPTURE_RULE,$(k))))
+
 # --- Testing ---
 
 .PHONY: test-native

--- a/README.md
+++ b/README.md
@@ -80,6 +80,26 @@ make flash-hts221/dew_point
 
 This builds the example, uploads it to the STeaMi board, and opens the serial monitor at 115200 baud on success.
 
+### Capture early serial output
+
+`make flash-…` opens an interactive monitor, which often misses the first lines printed at boot (the monitor finishes its handshake while the board has already moved past `setup()`). When you need those lines — e.g. to see whether `begin()` returned `false` — swap `flash-` for `capture-`:
+
+```bash
+make capture-hts221/dew_point
+```
+
+This builds and uploads the example like `flash-…`, but instead of opening miniterm it opens the serial port first, asks OpenOCD to reset the board over CMSIS-DAP, and prints whatever the board sends on stdout for 10 seconds. The output is unbuffered and pipeable:
+
+```bash
+make capture-hts221/dew_point | grep -i "HTS221"
+```
+
+Override the duration with `DURATION=N` (in seconds):
+
+```bash
+make capture-hts221/dew_point DURATION=30
+```
+
 ## Development
 
 ### Setup

--- a/lib/hts221/README.md
+++ b/lib/hts221/README.md
@@ -75,6 +75,13 @@ make flash-hts221/dew_point
 
 This builds, uploads, and opens the serial monitor at 115200 baud.
 
+To reliably capture the first lines printed at boot (which the interactive monitor often misses), swap `flash-` for `capture-`:
+
+```bash
+make capture-hts221/dew_point             # 10 seconds, OpenOCD reset, stdout
+make capture-hts221/dew_point DURATION=30 # longer window
+```
+
 ## API
 
 All methods follow the collection conventions: `camelCase`, include

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@
 platformio==6.1.19
 clang-format==22.1.3
 clang-tidy==22.1.0.1
+pyserial==3.5

--- a/scripts/capture-serial.py
+++ b/scripts/capture-serial.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Reset the board via OpenOCD and capture serial output for a fixed duration.
+
+Designed to land boot-time logs that miniterm misses on STeaMi: the
+serial port is opened *before* the reset, the input buffer is flushed,
+and only then is OpenOCD asked to reset. Reading happens against a
+post-reset deadline so DURATION reflects actual capture time rather
+than wall-clock time including the reset itself.
+"""
+import argparse
+import subprocess
+import sys
+import time
+
+import serial
+from serial.tools import list_ports
+
+
+DEFAULT_PORT = "/dev/ttyACM0"
+DEFAULT_BAUDRATE = 115200
+DEFAULT_DURATION = 10
+
+
+def steami_port(default_port: str) -> str | None:
+    ports = list(list_ports.comports())
+
+    if not ports:
+        return None
+
+    for port in ports:
+        if port.device == default_port:
+            return port.device
+
+    for port in ports:
+        if port.device.startswith("/dev/ttyACM"):
+            return port.device
+
+    return None
+
+
+def reset_board() -> None:
+    cmd = [
+        "openocd",
+        "-f",
+        "interface/cmsis-dap.cfg",
+        "-f",
+        "target/stm32wbx.cfg",
+        "-c",
+        "init; reset; shutdown",
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    if result.returncode != 0:
+        if result.stdout:
+            print(result.stdout, file=sys.stderr, end="")
+        if result.stderr:
+            print(result.stderr, file=sys.stderr, end="")
+        raise SystemExit("Error: OpenOCD reset failed.")
+
+def capture_serial(port_name: str, baudrate: int, duration: float) -> int:
+    try:
+        with serial.Serial(port_name, baudrate=baudrate, timeout=0.1) as ser:
+            time.sleep(0.2)
+            ser.reset_input_buffer()
+
+            # Reset first, then start the deadline. Otherwise the ~1-2 s
+            # OpenOCD takes eats into the requested duration and short
+            # captures (DURATION=2) end up empty.
+            reset_board()
+            deadline = time.monotonic() + duration
+
+            while time.monotonic() < deadline:
+                line = ser.readline()
+                if not line:
+                    continue
+
+                text = line.decode("utf-8", errors="replace")
+                print(text, end="", flush=True)
+
+    except serial.SerialException as exc:
+        print(f"Error: failed to open serial port {port_name}: {exc}", file=sys.stderr)
+        return 1
+
+    return 0
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Reset the board via OpenOCD and capture serial output."
+    )
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=DEFAULT_DURATION,
+        help=f"Capture duration in seconds (default: {DEFAULT_DURATION})",
+    )
+    parser.add_argument(
+        "--port",
+        default=DEFAULT_PORT,
+        help=f"Serial port to use (default: {DEFAULT_PORT})",
+    )
+    parser.add_argument(
+        "--baudrate",
+        type=int,
+        default=DEFAULT_BAUDRATE,
+        help=f"Serial baudrate (default: {DEFAULT_BAUDRATE})",
+    )
+    args = parser.parse_args()
+
+    port_name = steami_port(args.port)
+    if port_name is None:
+        print(
+            "Error: no STeaMi serial device detected. "
+            "Check that the board is connected and visible as /dev/ttyACM*.",
+            file=sys.stderr,
+        )
+        return 1
+
+    return capture_serial(port_name, args.baudrate, args.duration)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a `capture-<driver>/<example>` family parallel to the `flash-<driver>/<example>` targets, routing serial through a non-interactive Python helper instead of `pio device monitor`. The helper opens the port first, flushes stale buffer, asks OpenOCD to reset over CMSIS-DAP, then reads for `DURATION` seconds and prints to stdout unbuffered. The first lines printed at boot — which the interactive monitor often misses while it's still handshaking — actually land on stdout.

Closes #118

```bash
$ make capture-hts221/dew_point
$ make capture-hts221/dew_point DURATION=30
$ make capture-hts221/dew_point | grep "HTS221"
```

## Changes

* `scripts/capture-serial.py` — opens `/dev/ttyACM0` (or first matching port), flushes the input buffer, runs `openocd -f interface/cmsis-dap.cfg -f target/stm32wbx.cfg -c "init; reset; shutdown"`, reads `DURATION` seconds and prints lines as they arrive. Exits non-zero if no STeaMi device is detected or if OpenOCD fails.
* `Makefile` — `capture-<driver>/<example>` targets generated from the same `EXAMPLE_KEYS` list as `flash-`, via a parallel `foreach + eval` block. `DURATION ?= 10` makes the duration overridable per invocation.
* `requirements.txt` — pinned `pyserial==3.5`, pulled in transparently by `make setup`.
* `README.md` and `lib/hts221/README.md` — document the `flash-`/`capture-` pairing and call out when each is the right tool.

## Acceptance criteria

- [x] Per-example `make capture-<driver>/<example>` exists for every directory under `lib/*/examples/*` (auto-discovered).
- [x] Optional variable `DURATION=N` (default 10 seconds).
- [x] Implementation under `scripts/capture-serial.py`:
  - [x] Opens `/dev/ttyACM0` via `pyserial`.
  - [x] Triggers an OpenOCD reset on the connected CMSIS-DAP probe (`-f interface/cmsis-dap.cfg -f target/stm32wbx.cfg -c 'init; reset; shutdown'`).
  - [x] Reads from the serial port for `DURATION` seconds (deadline starts *after* the reset, so short captures aren't eaten by reset latency).
  - [x] Prints each line to stdout as it arrives (unbuffered).
  - [x] Exits cleanly with status 0 on normal completion.
- [x] The Makefile target flashes the example first (same mechanism as `flash-<driver>/<example>` from #117), then calls the capture script.
- [x] If no STeaMi is detected, the script prints a clear message and exits non-zero.
- [x] HTS221 README points at `make capture-…` as the scripted complement to `make flash-…`.

## Validated end-to-end on hardware

```
$ make capture-hts221/dew_point DURATION=8
…
========================= [SUCCESS] Took 9.09 seconds =========================
T=28.87 C  H=43.6 %  DewPoint=15.27 C
T=28.86 C  H=43.6 %  DewPoint=15.25 C
T=28.91 C  H=43.6 %  DewPoint=15.29 C
T=28.91 C  H=43.6 %  DewPoint=15.29 C
T=28.87 C  H=43.6 %  DewPoint=15.26 C
T=28.89 C  H=43.5 %  DewPoint=15.25 C
T=28.89 C  H=43.5 %  DewPoint=15.24 C
T=28.87 C  H=43.7 %  DewPoint=15.28 C
```

8 lines captured in 8 seconds — the deadline tracks post-reset wall-clock as expected.