### PR TITLE
feat(ble): Add BLE beacon advertising example with WSEN-HIDS sensor.

### DIFF
--- a/lib/ble/examples/BleBeacon/BleBeacon.ino
+++ b/lib/ble/examples/BleBeacon/BleBeacon.ino
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// BleBeacon — advertise the board name and a live temperature reading.
+//
+// The HTS221 temperature is encoded as int16 x100 in the manufacturer-
+// specific data field (company ID 0x0059). The beacon is visible from
+// any BLE scanner app (nRF Connect, LightBlue, etc.).
+//
+// Wiring: no external hookup needed. The HTS221 sits on the STeaMi
+// internal I2C bus. Flash and open the serial monitor at 115200 baud.
+
+#include <Arduino.h>
+#include <HTS221.h>
+#include <STM32duinoBLE.h>
+#include <Wire.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+HTS221 sensor(internalI2C);
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial && millis() < 2000)
+        ;
+
+    // Init sensor
+    internalI2C.begin();
+    if (!sensor.begin()) {
+        Serial.println("HTS221 not detected — check wiring.");
+        while (true)
+            ;
+    }
+    sensor.setContinuous(HTS221_ODR_1_HZ);
+    Serial.println("HTS221 ready.");
+
+    // Init BLE
+    if (!BLE.begin()) {
+        Serial.println("BLE init failed!");
+        while (true)
+            ;
+    }
+
+    BLE.setLocalName("STeaMi-Beacon");
+    BLE.setDeviceName("STeaMi-Beacon");
+    BLE.setAdvertisingInterval(160);  // 100 ms
+    BLE.setConnectable(false);
+
+    Serial.println("BLE Beacon ready.");
+}
+
+void loop() {
+    // Read temperature and encode as int16 x100
+    float temp = sensor.temperature();
+    int16_t tempRaw = (int16_t)(temp * 100);
+    uint8_t data[2] = {
+        (uint8_t)(tempRaw >> 8),    // MSB
+        (uint8_t)(tempRaw & 0xFF),  // LSB
+    };
+
+    // Update manufacturer data and re-advertise
+    BLE.stopAdvertise();
+    BLE.setManufacturerData(0x0059, data, sizeof(data));
+    BLE.advertise();
+
+    Serial.print("Advertising — T = ");
+    Serial.print(temp, 2);
+    Serial.println(" C");
+
+    BLE.poll();
+    delay(1000);
+}

--- a/lib/ble/examples/BleBeacon/BleBeacon.ino
+++ b/lib/ble/examples/BleBeacon/BleBeacon.ino
@@ -2,20 +2,20 @@
 //
 // BleBeacon — advertise the board name and a live temperature reading.
 //
-// The HTS221 temperature is encoded as int16 x100 in the manufacturer-
+// The WSEN-HIDS temperature is encoded as int16 x100 in the manufacturer-
 // specific data field (company ID 0x0059). The beacon is visible from
 // any BLE scanner app (nRF Connect, LightBlue, etc.).
 //
-// Wiring: no external hookup needed. The HTS221 sits on the STeaMi
+// Wiring: no external hookup needed. The WSEN-HIDS sits on the STeaMi
 // internal I2C bus. Flash and open the serial monitor at 115200 baud.
 
 #include <Arduino.h>
-#include <HTS221.h>
 #include <STM32duinoBLE.h>
+#include <WsenHids.h>
 #include <Wire.h>
 
 TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
-HTS221 sensor(internalI2C);
+WsenHids sensor(internalI2C);
 
 void setup() {
     Serial.begin(115200);
@@ -25,12 +25,12 @@ void setup() {
     // Init sensor
     internalI2C.begin();
     if (!sensor.begin()) {
-        Serial.println("HTS221 not detected — check wiring.");
+        Serial.println("WSEN-HIDS not detected — check wiring.");
         while (true)
             ;
     }
-    sensor.setContinuous(HTS221_ODR_1_HZ);
-    Serial.println("HTS221 ready.");
+    sensor.setContinuous(WSEN_HIDS_ODR_1_HZ);
+    Serial.println("WSEN-HIDS ready.");
 
     // Init BLE
     if (!BLE.begin()) {


### PR DESCRIPTION
## Summary
Add a BLE beacon advertising example using STM32duinoBLE and the WSEN-HIDS
temperature sensor. Closes #94

## Changes
- Added `lib/ble/examples/BleBeacon/BleBeacon.ino`
- Reads live temperature from the WSEN-HIDS sensor (internal I2C bus)
- Encodes temperature as `int16 x100` in manufacturer-specific data (company ID `0x0059`)
- Advertises as `STeaMi-Beacon`, non-connectable, 100ms interval
- Updates payload and re-advertises every second
- Beacon visible on nRF Connect and LightBlue

## Checklist
- [x] `make lint` passes (clang-format)
- [x] `make build` passes (PlatformIO)
- [x] `make test-native` passes (if native tests exist)
- [x] `make test-hardware` passes on a connected STeaMi (if hardware tests exist)
- [x] README updated (if adding/changing public API)
- [x] Examples added/updated (`lib/ble/examples/BleBeacon/BleBeacon.ino`)
- [x] Commit messages follow conventional commits format
