### PR TITLE
feat(ble): Add RSSI proximity detector example.

### DIFF
--- a/lib/ble/examples/BleRssiProximity/BleRssiProximity.ino
+++ b/lib/ble/examples/BleRssiProximity/BleRssiProximity.ino
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// BleRssiProximity — scan for a named BLE beacon and display a proximity
+// gauge on the Serial monitor based on the received RSSI.
+//
+// One STeaMi runs the BleBeacon example (broadcaster).
+// This STeaMi scans, filters on the beacon name, reads RSSI, applies a
+// moving-average filter, and displays a 0-100% ASCII gauge.
+//
+// Open the serial monitor at 115200 baud to see the gauge update.
+
+#include <Arduino.h>
+#include <STM32duinoBLE.h>
+
+// === Configuration ===
+static const char* BEACON_NAME = "STeaMi-Beacon";
+static const int RSSI_NEAR = -30;   // dBm — very close
+static const int RSSI_FAR = -90;    // dBm — far away
+static const int RSSI_SAMPLES = 5;  // moving average window
+
+// === RSSI smoothing ===
+static int rssiHistory[RSSI_SAMPLES] = {0};
+static int rssiIndex = 0;
+static int rssiCount = 0;
+
+// =============================================================================
+
+int smoothRssi(int newRssi) {
+    rssiHistory[rssiIndex] = newRssi;
+    rssiIndex = (rssiIndex + 1) % RSSI_SAMPLES;
+    if (rssiCount < RSSI_SAMPLES) {
+        rssiCount++;
+    }
+    int sum = 0;
+    for (int i = 0; i < rssiCount; i++) {
+        sum += rssiHistory[i];
+    }
+    return sum / rssiCount;
+}
+
+int rssiToProximity(int rssi) {
+    if (rssi >= RSSI_NEAR)
+        return 100;
+    if (rssi <= RSSI_FAR)
+        return 0;
+    return (int)((float)(rssi - RSSI_FAR) / (RSSI_NEAR - RSSI_FAR) * 100);
+}
+
+void printGauge(int rssi, int proximity) {
+    // Build ASCII gauge [=========>         ]
+    const int barWidth = 20;
+    int filled = (proximity * barWidth) / 100;
+
+    Serial.print("RSSI: ");
+    Serial.print(rssi);
+    Serial.print(" dBm | [");
+    for (int i = 0; i < barWidth; i++) {
+        if (i < filled - 1)
+            Serial.print("=");
+        else if (i == filled - 1)
+            Serial.print(">");
+        else
+            Serial.print(" ");
+    }
+    Serial.print("] ");
+    Serial.print(proximity);
+    Serial.println("%");
+}
+
+// =============================================================================
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial && millis() < 2000)
+        ;
+
+    Serial.println("BLE RSSI Proximity Scanner");
+    Serial.print("Looking for: ");
+    Serial.println(BEACON_NAME);
+
+    if (!BLE.begin()) {
+        Serial.println("BLE init failed!");
+        while (true)
+            ;
+    }
+
+    BLE.scan(true);  // withDuplicates=true to get continuous RSSI updates
+    Serial.println("Scanning...");
+}
+
+void loop() {
+    BLEDevice device = BLE.available();
+
+    if (device) {
+        String name = device.localName();
+
+        if (name == BEACON_NAME) {
+            int rawRssi = device.rssi();
+            int avgRssi = smoothRssi(rawRssi);
+            int proximity = rssiToProximity(avgRssi);
+            printGauge(avgRssi, proximity);
+        }
+    }
+
+    BLE.poll();
+}

--- a/lib/ble/examples/BleRssiProximity/BleRssiProximity.ino
+++ b/lib/ble/examples/BleRssiProximity/BleRssiProximity.ino
@@ -89,12 +89,14 @@ void setup() {
 }
 
 void loop() {
-    BLEDevice device = BLE.available();
-
-    if (device) {
-        String name = device.localName();
-
-        if (name == BEACON_NAME) {
+    // Drain every advertising packet queued since the last loop tick.
+    // BLE.available() returns the next packet (or an invalid device when
+    // empty) — looping until we hit an empty result keeps the gauge in
+    // sync with the freshest sample even when several packets arrived
+    // between two ticks.
+    BLEDevice device;
+    while ((device = BLE.available())) {
+        if (device.localName() == BEACON_NAME) {
             int rawRssi = device.rssi();
             int avgRssi = smoothRssi(rawRssi);
             int proximity = rssiToProximity(avgRssi);


### PR DESCRIPTION
## Summary
Add a BLE RSSI proximity detector example using STM32duinoBLE. Closes #95

## Changes
- Added `lib/ble/examples/BleRssiProximity/BleRssiProximity.ino`
- Scans for a named beacon (`STeaMi-Beacon`)
- Drains the full BLE packet queue on every loop tick so no advertisement is missed
- Reads RSSI and applies a moving-average filter over 5 samples
- Maps RSSI (-30 dBm close, -90 dBm far) to a 0-100% proximity value
- Displays an ASCII gauge on the Serial monitor

## Notes
The SSD1327 OLED driver is not yet ported to Arduino, so the gauge is rendered
on the Serial monitor for now. Once the SSD1327 driver lands, this example can
be extended to mirror the gauge on the on-board display.

## Checklist
- [x] `make lint` passes (clang-format)
- [x] `make build` passes (PlatformIO)
- [x] `make test-native` passes
- [x] `make test-hardware` passes on a connected STeaMi
- [x] README updated (if adding/changing public API)
- [x] Examples added (`lib/ble/examples/BleRssiProximity/BleRssiProximity.ino`)
- [x] Commit messages follow conventional commits format
