### PR TITLE
feat(ble): Add BLE RSSI room mapper example with CSV export.

### DIFF
--- a/lib/ble/examples/BleRssiMapper/BleRssiMapper.ino
+++ b/lib/ble/examples/BleRssiMapper/BleRssiMapper.ino
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// BleRssiMapper — record RSSI measurements at different positions in a room.
+//
+// Place 2-3 STeaMi boards running BleBeacon at known positions.
+// Move around the room with this board and send 'r' via Serial to record
+// the current RSSI of all visible beacons as a CSV row.
+// Send 's' to stop and print the full CSV.
+//
+// CSV format: point_id,beacon_name,rssi
+//
+// Open the serial monitor at 115200 baud.
+// Commands:
+//   r → record current RSSI for all visible beacons
+//   s → stop and print full CSV
+//   h → print help
+
+#include <Arduino.h>
+#include <STM32duinoBLE.h>
+
+// === Configuration ===
+static const char* BEACON_NAMES[] = {
+    "Beacon_M1",
+    "Beacon_M2",
+    "Beacon_M3",
+};
+static const int BEACON_COUNT = 3;
+static const int RSSI_SAMPLES = 5;
+static const int MAX_POINTS = 50;  // max measurement points
+static const int MAX_ROWS = MAX_POINTS * BEACON_COUNT;
+
+// === RSSI smoothing per beacon ===
+static int rssiHistory[3][RSSI_SAMPLES] = {{0}};
+static int rssiIndex[3] = {0};
+static int rssiCount[3] = {0};
+static int currentRssi[3];
+static bool beaconSeen[3] = {false};
+
+// === CSV storage (in RAM) ===
+struct CsvRow {
+    int pointId;
+    char beaconName[16];
+    int rssi;
+};
+static CsvRow csvData[MAX_ROWS];
+static int rowCount = 0;
+static int pointId = 0;
+static bool recording = true;
+
+// =============================================================================
+// === HELPERS =================================================================
+// =============================================================================
+
+int beaconIndex(const String& name) {
+    for (int i = 0; i < BEACON_COUNT; i++) {
+        if (name == BEACON_NAMES[i])
+            return i;
+    }
+    return -1;
+}
+
+void smoothRssi(int idx, int newRssi) {
+    rssiHistory[idx][rssiIndex[idx]] = newRssi;
+    rssiIndex[idx] = (rssiIndex[idx] + 1) % RSSI_SAMPLES;
+    if (rssiCount[idx] < RSSI_SAMPLES)
+        rssiCount[idx]++;
+    int sum = 0;
+    for (int i = 0; i < rssiCount[idx]; i++)
+        sum += rssiHistory[idx][i];
+    currentRssi[idx] = sum / rssiCount[idx];
+}
+
+void printHelp() {
+    Serial.println("=== BLE RSSI Room Mapper ===");
+    Serial.println("r → record current point");
+    Serial.println("s → stop and print CSV");
+    Serial.println("h → help");
+    Serial.println("============================");
+}
+
+void printCurrentScan() {
+    Serial.print("Point #");
+    Serial.print(pointId + 1);
+    Serial.print(" | Beacons: ");
+    for (int i = 0; i < BEACON_COUNT; i++) {
+        if (beaconSeen[i]) {
+            Serial.print(BEACON_NAMES[i]);
+            Serial.print("=");
+            Serial.print(currentRssi[i]);
+            Serial.print("dBm  ");
+        }
+    }
+    Serial.println();
+}
+
+void recordPoint() {
+    int seen = 0;
+    for (int i = 0; i < BEACON_COUNT; i++) {
+        if (beaconSeen[i])
+            seen++;
+    }
+
+    if (seen == 0) {
+        Serial.println("No beacon seen — move closer and retry.");
+        return;
+    }
+
+    pointId++;
+    Serial.print("Recording point #");
+    Serial.print(pointId);
+    Serial.print(" (");
+    Serial.print(seen);
+    Serial.println(" beacons)");
+
+    for (int i = 0; i < BEACON_COUNT; i++) {
+        if (beaconSeen[i] && rowCount < MAX_ROWS) {
+            csvData[rowCount].pointId = pointId;
+            strncpy(csvData[rowCount].beaconName, BEACON_NAMES[i], 15);
+            csvData[rowCount].rssi = currentRssi[i];
+            rowCount++;
+
+            Serial.print("  ");
+            Serial.print(BEACON_NAMES[i]);
+            Serial.print(", ");
+            Serial.println(currentRssi[i]);
+        }
+    }
+}
+
+void printCsv() {
+    Serial.println();
+    Serial.println("=== CSV OUTPUT — copy and save as rssi_map.csv ===");
+    Serial.println("point_id,beacon_name,rssi");
+    for (int i = 0; i < rowCount; i++) {
+        Serial.print(csvData[i].pointId);
+        Serial.print(",");
+        Serial.print(csvData[i].beaconName);
+        Serial.print(",");
+        Serial.println(csvData[i].rssi);
+    }
+    Serial.println("=== END OF CSV ===");
+    Serial.print("Total: ");
+    Serial.print(pointId);
+    Serial.print(" points, ");
+    Serial.print(rowCount);
+    Serial.println(" rows.");
+}
+
+// =============================================================================
+// === SETUP / LOOP ============================================================
+// =============================================================================
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial && millis() < 2000)
+        ;
+
+    if (!BLE.begin()) {
+        Serial.println("BLE init failed!");
+        while (true)
+            ;
+    }
+
+    BLE.scan(true);
+    printHelp();
+    Serial.println("Scanning for beacons...");
+}
+
+void loop() {
+    // Handle Serial commands
+    if (Serial.available()) {
+        char cmd = Serial.read();
+        if (cmd == 'r' && recording) {
+            recordPoint();
+        } else if (cmd == 's') {
+            recording = false;
+            BLE.stopScan();
+            printCsv();
+        } else if (cmd == 'h') {
+            printHelp();
+        } else if (cmd != '\n' && cmd != '\r') {
+            Serial.println("Unknown command. Send 'h' for help.");
+        }
+    }
+
+    // Update RSSI from scan results
+    if (recording) {
+        BLEDevice device = BLE.available();
+        if (device) {
+            int idx = beaconIndex(device.localName());
+            if (idx >= 0) {
+                smoothRssi(idx, device.rssi());
+                beaconSeen[idx] = true;
+            }
+        }
+
+        // Print current scan status every 2s
+        static unsigned long lastPrint = 0;
+        if (millis() - lastPrint > 2000) {
+            lastPrint = millis();
+            printCurrentScan();
+        }
+    }
+
+    BLE.poll();
+}

--- a/lib/ble/examples/BleRssiMapper/BleRssiMapper.ino
+++ b/lib/ble/examples/BleRssiMapper/BleRssiMapper.ino
@@ -30,11 +30,12 @@ static const int MAX_POINTS = 50;  // max measurement points
 static const int MAX_ROWS = MAX_POINTS * BEACON_COUNT;
 
 // === RSSI smoothing per beacon ===
-static int rssiHistory[3][RSSI_SAMPLES] = {{0}};
-static int rssiIndex[3] = {0};
-static int rssiCount[3] = {0};
-static int currentRssi[3];
-static bool beaconSeen[3] = {false};
+// Sizing all arrays by BEACON_COUNT so the constants stay in sync.
+static int rssiHistory[BEACON_COUNT][RSSI_SAMPLES] = {{0}};
+static int rssiIndex[BEACON_COUNT] = {0};
+static int rssiCount[BEACON_COUNT] = {0};
+static int currentRssi[BEACON_COUNT] = {0};
+static bool beaconSeen[BEACON_COUNT] = {false};
 
 // === CSV storage (in RAM) ===
 struct CsvRow {
@@ -115,7 +116,12 @@ void recordPoint() {
     for (int i = 0; i < BEACON_COUNT; i++) {
         if (beaconSeen[i] && rowCount < MAX_ROWS) {
             csvData[rowCount].pointId = pointId;
-            strncpy(csvData[rowCount].beaconName, BEACON_NAMES[i], 15);
+            // strncpy() does not null-terminate when src is longer than n —
+            // force the terminator explicitly so the struct stays safe even
+            // if BEACON_NAMES is later changed to longer strings.
+            strncpy(csvData[rowCount].beaconName, BEACON_NAMES[i],
+                    sizeof(csvData[rowCount].beaconName) - 1);
+            csvData[rowCount].beaconName[sizeof(csvData[rowCount].beaconName) - 1] = '\0';
             csvData[rowCount].rssi = currentRssi[i];
             rowCount++;
 
@@ -183,10 +189,12 @@ void loop() {
         }
     }
 
-    // Update RSSI from scan results
+    // Update RSSI from scan results — drain the whole queue, not just one
+    // packet per loop tick, otherwise some beacons go unseen during the
+    // 2 s gap between status prints.
     if (recording) {
-        BLEDevice device = BLE.available();
-        if (device) {
+        BLEDevice device;
+        while ((device = BLE.available())) {
             int idx = beaconIndex(device.localName());
             if (idx >= 0) {
                 smoothRssi(idx, device.rssi());


### PR DESCRIPTION
## Summary
Add a BLE RSSI room mapper example using STM32duinoBLE. Closes #97

## Changes
- Added `lib/ble/examples/BleRssiMapper/BleRssiMapper.ino`
- Scans up to `BEACON_COUNT` beacons simultaneously (Beacon_M1, Beacon_M2, Beacon_M3)
- Drains the full BLE packet queue on every loop tick so no advertisement is missed
- Per-beacon smoothing arrays sized by `BEACON_COUNT` (no magic literals)
- Safe CSV string copy via `strncpy(dst, src, sizeof(dst) - 1)` followed by an
  explicit null-terminator — defends the buffer against future longer beacon names
- Serial commands:
  - `r` → record current RSSI for all visible beacons as a CSV row
  - `s` → stop and print full CSV to Serial monitor
  - `h` → print help
- Moving average over 5 RSSI samples per beacon to reduce noise
- CSV stored in RAM (up to 50 points × `BEACON_COUNT` beacons) and printed on stop

## Notes
The D-PAD input and the DAPLink flash backend are not yet ported to Arduino,
so the Serial monitor is used as the user interface and CSV sink. Once those
drivers land, this example can be extended to record points via a button and
dump the CSV to flash.

## Checklist
- [x] `make lint` passes (clang-format)
- [x] `make build` passes (PlatformIO)
- [x] `make test-native` passes
- [x] `make test-hardware` passes on a connected STeaMi
- [x] README updated (if adding/changing public API)
- [x] Examples added (`lib/ble/examples/BleRssiMapper/BleRssiMapper.ino`)
- [x] Commit messages follow conventional commits format
