### PR TITLE
feat(wsen-pads): Implement Arduino driver. 

### DIFF
--- a/lib/wsen-pads/README.md
+++ b/lib/wsen-pads/README.md
@@ -1,5 +1,130 @@
-# wsen-pads
+# WSEN-PADS
 
-Arduino driver for the wsen-pads component of the STeaMi board.
+Arduino/C++ driver for the Würth Elektronik WSEN-PADS barometric pressure
+and temperature sensor on the STeaMi board.
 
-> **Status**: not yet implemented
+## Hardware
+
+* I2C sensor, default 7-bit address `0x5D` (SAO pin tied high). The alternate
+  `0x5C` address is exposed as `WSEN_PADS_I2C_ADDR_SAO_LOW`.
+* No factory calibration block — conversions use the fixed sensitivity
+  constants from the datasheet (1 LSB = 1/4096 hPa for pressure, 0.01 °C for
+  temperature).
+
+## Quick start
+
+On the STeaMi board, the WSEN-PADS is routed to the **internal** I2C bus
+(pins `I2C_INT_SDA` / `I2C_INT_SCL` from the variant, not the default global
+`Wire`). Spin up a dedicated `TwoWire` and hand it to the driver:
+
+```cpp
+#include <Wire.h>
+#include <WSEN_PADS.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+WSEN_PADS sensor(internalI2C);
+
+void setup() {
+    Serial.begin(115200);
+    internalI2C.begin();
+
+    if (!sensor.begin()) {
+        Serial.println("WSEN-PADS not detected");
+        while (true) delay(1000);
+    }
+
+    sensor.setContinuous(ODR_1_HZ);
+}
+
+void loop() {
+    auto r = sensor.read();
+    Serial.print(r.pressure);
+    Serial.print(" hPa / ");
+    Serial.print(r.temperature);
+    Serial.println(" C");
+    delay(1000);
+}
+```
+
+## API
+
+All methods follow the library conventions: `camelCase`, units in method
+names only when ambiguous, no `read` / `get` prefix, `read()` for the
+combined struct reading.
+
+### Lifecycle
+
+| Method | Description |
+|--------|-------------|
+| `WSEN_PADS(TwoWire& wire = Wire, uint8_t address = WSEN_PADS_I2C_DEFAULT_ADDR)` | Construct. Defaults to the global `Wire` and address `0x5D`. |
+| `bool begin()` | Wait for boot, probe `DEVICE_ID`, apply default config (BDU + auto-increment, ODR=power-down). Returns `false` if the sensor is not detected. |
+| `uint8_t deviceId()` | Reads `DEVICE_ID` (always `0xB3`). |
+| `void softReset()` / `void reboot()` | Software reset or memory reboot via `CTRL2.SWRESET` / `CTRL2.BOOT`. Both re-apply the default config afterwards. |
+| `void powerOn()` / `void powerOff()` | Start or stop continuous measurement. `powerOn()` enters continuous mode at `ODR_1_HZ` — use `setContinuous(...)` for any other rate. |
+
+### Reading
+
+If the part is in power-down when a read is requested, the driver auto-
+triggers a one-shot, polls `dataReady()` with a timeout, and returns the
+result. The caller doesn't have to manage modes manually. On timeout the
+read returns `NaN` so silent stale readings can't propagate; callers can
+check with `isnan()`.
+
+| Method | Description |
+|--------|-------------|
+| `float pressureHpa()` | Pressure in hPa. |
+| `float temperature()` | Temperature in °C, with two-point calibration and additive offset applied. |
+| `ReadResult read()` | Both channels — `{pressure, temperature}`. |
+| `bool dataReady()` | Both `P_DA` and `T_DA` set in `STATUS`. |
+| `bool pressureReady()` / `bool temperatureReady()` | Per-channel readiness. |
+
+### Modes
+
+| Method | Description |
+|--------|-------------|
+| `void setContinuous(uint8_t odr)` | Continuous mode. Pass one of the `ODR_*` constants (1 / 10 / 25 / 50 / 75 / 100 / 200 Hz). |
+| `void triggerOneShot()` | Non-blocking: power-down + arm `CTRL2.ONE_SHOT`. Pair with `dataReady()` polling, or just call `readOneShot()`. |
+| `ReadResult readOneShot()` | Trigger + wait for `dataReady` + read + return. Returns `{NaN, NaN}` on timeout. |
+
+### Calibration
+
+`setTemperatureOffset()` and `calibrateTemperature()` are independent — the
+offset stacks on top of the two-point user slope/intercept, so calling one
+does not reset the other.
+
+| Method | Description |
+|--------|-------------|
+| `void setTemperatureOffset(float offset)` | Additive °C offset on the final temperature reading. |
+| `void calibrateTemperature(float refLow, float measLow, float refHigh, float measHigh)` | Two-point user calibration. Sets the slope/intercept used after the factory conversion. A degenerate two-point input (`measLow == measHigh`) leaves the calibration at identity. |
+
+### Driver-specific tuning
+
+| Method | Description |
+|--------|-------------|
+| `void enableLowPass(bool strong = false)` | Enable the LPF2 pressure filter. `strong = true` selects ODR/20 bandwidth, otherwise ODR/9. |
+| `void disableLowPass()` | Disable the LPF2 pressure filter. |
+| `void enableLowNoise()` / `void disableLowNoise()` | Toggle `CTRL2.LOW_NOISE_EN`. Per the datasheet, must only be modified while in power-down (call `powerOff()` first if continuous mode is running). Not allowed at 100 Hz / 200 Hz. |
+
+## Register constants
+
+`WSEN_PADS_const.h` exports register addresses (`REG_*`), bit masks
+(`CTRL1_*`, `CTRL2_*`, `STATUS_*`, `INT_SOURCE_*`), ODR values (`ODR_*`),
+and conversion constants (`PRESSURE_HPA_PER_DIGIT`,
+`TEMPERATURE_C_PER_DIGIT`, etc.) so applications can poke the part
+directly if they need something outside the driver's API surface.
+
+## Testing
+
+Host-side unit tests under
+[`tests/native/test_wsen_pads/`](../../tests/native/test_wsen_pads/) exercise
+the driver against the `TwoWire` mock and the shared
+[`driver_checks.h`](../../tests/shared/driver_checks.h) helpers. Run them
+without hardware with:
+
+```bash
+make test-native-wsen_pads
+```
+
+## License
+
+GPL-3.0-or-later — see [LICENSE](../../LICENSE).

--- a/lib/wsen-pads/src/WSEN_PADS.cpp
+++ b/lib/wsen-pads/src/WSEN_PADS.cpp
@@ -1,0 +1,338 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include "WSEN_PADS.h"
+
+#include <math.h>
+#include <stdint.h>
+
+WSEN_PADS::WSEN_PADS(TwoWire& wire, uint8_t address)
+    : _wire(&wire),
+      _address(address),
+      _tempUserSlope(1.0f),
+      _tempUserOffset(0.0f),
+      _tempOffset(0.0f) {}
+
+// ---------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------
+
+bool WSEN_PADS::begin() {
+    delay(BOOT_DELAY_MS);
+    if (!isPresent()) {
+        return false;
+    }
+    if (!waitBoot()) {
+        return false;
+    }
+    if (deviceId() != WSEN_PADS_DEVICE_ID) {
+        return false;
+    }
+    configureDefault();
+    return true;
+}
+
+uint8_t WSEN_PADS::deviceId() {
+    return readReg(REG_DEVICE_ID);
+}
+
+void WSEN_PADS::softReset() {
+    updateReg(REG_CTRL_2, CTRL2_SWRESET, CTRL2_SWRESET);
+    delay(1);
+    configureDefault();
+}
+
+void WSEN_PADS::reboot() {
+    updateReg(REG_CTRL_2, CTRL2_BOOT, CTRL2_BOOT);
+    waitBoot();
+    configureDefault();
+}
+
+void WSEN_PADS::powerOff() {
+    // ODR = 000 puts the part in power-down. ONE_SHOT is only effective
+    // from this state.
+    updateReg(REG_CTRL_1, CTRL1_ODR_MASK, ODR_POWER_DOWN << CTRL1_ODR_SHIFT);
+}
+
+void WSEN_PADS::powerOn() {
+    setContinuous(ODR_1_HZ);
+}
+
+// ---------------------------------------------------------------------
+// Reading
+// ---------------------------------------------------------------------
+
+float WSEN_PADS::pressureHpa() {
+    int32_t raw = pressureRaw();
+    if (raw == INT32_MIN) {
+        return NAN;
+    }
+    return raw * PRESSURE_HPA_PER_DIGIT;
+}
+
+float WSEN_PADS::temperature() {
+    int32_t raw = temperatureRaw();
+    if (raw == INT32_MIN) {
+        return NAN;
+    }
+    float factory = raw * TEMPERATURE_C_PER_DIGIT;
+    return _tempUserSlope * factory + _tempUserOffset + _tempOffset;
+}
+
+WSEN_PADS::ReadResult WSEN_PADS::read() {
+    if (!isPoweredOn()) {
+        triggerOneShot();
+        if (!waitForDataReady()) {
+            return {NAN, NAN};
+        }
+    }
+    return readSensorData();
+}
+
+// ---------------------------------------------------------------------
+// Status
+// ---------------------------------------------------------------------
+
+bool WSEN_PADS::dataReady() {
+    uint8_t s = status();
+    return (s & (STATUS_P_DA | STATUS_T_DA)) == (STATUS_P_DA | STATUS_T_DA);
+}
+
+bool WSEN_PADS::pressureReady() {
+    return (status() & STATUS_P_DA) != 0;
+}
+
+bool WSEN_PADS::temperatureReady() {
+    return (status() & STATUS_T_DA) != 0;
+}
+
+// ---------------------------------------------------------------------
+// Modes
+// ---------------------------------------------------------------------
+
+void WSEN_PADS::setContinuous(uint8_t odr) {
+    // Build CTRL_1 with the requested ODR plus BDU. LPF and low-noise
+    // bits live elsewhere (CTRL_2 / CTRL_1.LPFP) and aren't touched here
+    // — callers layer them on with enableLowPass / enableLowNoise.
+    uint8_t ctrl1 = CTRL1_BDU | ((odr << CTRL1_ODR_SHIFT) & CTRL1_ODR_MASK);
+    writeReg(REG_CTRL_1, ctrl1);
+}
+
+void WSEN_PADS::triggerOneShot() {
+    // The ONE_SHOT bit only matters when ODR = 000, so put the part in
+    // power-down first. Non-blocking: callers that need to wait for the
+    // result poll dataReady() (or use readOneShot()).
+    powerOff();
+    updateReg(REG_CTRL_2, CTRL2_ONE_SHOT, CTRL2_ONE_SHOT);
+}
+
+WSEN_PADS::ReadResult WSEN_PADS::readOneShot() {
+    triggerOneShot();
+    if (!waitForDataReady()) {
+        return {NAN, NAN};
+    }
+    return readSensorData();
+}
+
+// ---------------------------------------------------------------------
+// Calibration
+// ---------------------------------------------------------------------
+
+void WSEN_PADS::setTemperatureOffset(float offset) {
+    _tempOffset = offset;
+}
+
+void WSEN_PADS::calibrateTemperature(float refLow, float measLow, float refHigh, float measHigh) {
+    float span = measHigh - measLow;
+    if (span == 0.0f) {
+        // Identity — caller asked for a degenerate two-point calibration.
+        _tempUserSlope = 1.0f;
+        _tempUserOffset = 0.0f;
+        return;
+    }
+    _tempUserSlope = (refHigh - refLow) / span;
+    _tempUserOffset = refLow - _tempUserSlope * measLow;
+}
+
+// ---------------------------------------------------------------------
+// Driver-specific tuning
+// ---------------------------------------------------------------------
+
+void WSEN_PADS::enableLowPass(bool strong) {
+    uint8_t current = readReg(REG_CTRL_1);
+    current |= CTRL1_EN_LPFP;
+    if (strong) {
+        current |= CTRL1_LPFP_CFG;
+    } else {
+        current &= ~CTRL1_LPFP_CFG;
+    }
+    writeReg(REG_CTRL_1, current);
+}
+
+void WSEN_PADS::disableLowPass() {
+    uint8_t current = readReg(REG_CTRL_1);
+    current &= ~(CTRL1_EN_LPFP | CTRL1_LPFP_CFG);
+    writeReg(REG_CTRL_1, current);
+}
+
+void WSEN_PADS::enableLowNoise() {
+    // Datasheet: LOW_NOISE_EN must only be modified while in power-down.
+    // Caller is expected to be in power-down (e.g. right after begin())
+    // or to call powerOff() first.
+    updateReg(REG_CTRL_2, CTRL2_LOW_NOISE_EN, CTRL2_LOW_NOISE_EN);
+}
+
+void WSEN_PADS::disableLowNoise() {
+    updateReg(REG_CTRL_2, CTRL2_LOW_NOISE_EN, 0);
+}
+
+// ---------------------------------------------------------------------
+// I2C helpers
+// ---------------------------------------------------------------------
+
+bool WSEN_PADS::isPresent() {
+    _wire->beginTransmission(_address);
+    return _wire->endTransmission() == 0;
+}
+
+uint8_t WSEN_PADS::readReg(uint8_t reg) {
+    _wire->beginTransmission(_address);
+    _wire->write(reg);
+    _wire->endTransmission(false);
+    _wire->requestFrom(_address, static_cast<uint8_t>(1));
+    if (_wire->available()) {
+        return static_cast<uint8_t>(_wire->read());
+    }
+    return 0;
+}
+
+void WSEN_PADS::readBlock(uint8_t reg, uint8_t* buf, size_t len) {
+    for (size_t i = 0; i < len; ++i) {
+        buf[i] = 0;
+    }
+    _wire->beginTransmission(_address);
+    _wire->write(reg);
+    _wire->endTransmission(false);
+    _wire->requestFrom(_address, static_cast<uint8_t>(len));
+    for (size_t i = 0; i < len && _wire->available(); ++i) {
+        buf[i] = static_cast<uint8_t>(_wire->read());
+    }
+}
+
+void WSEN_PADS::writeReg(uint8_t reg, uint8_t value) {
+    _wire->beginTransmission(_address);
+    _wire->write(reg);
+    _wire->write(value);
+    _wire->endTransmission();
+}
+
+void WSEN_PADS::updateReg(uint8_t reg, uint8_t mask, uint8_t value) {
+    uint8_t current = readReg(reg);
+    current = (current & ~mask) | (value & mask);
+    writeReg(reg, current);
+}
+
+// ---------------------------------------------------------------------
+// Boot helpers
+// ---------------------------------------------------------------------
+
+bool WSEN_PADS::waitBoot(uint32_t timeoutMs) {
+    uint32_t start = millis();
+    while (readReg(REG_INT_SOURCE) & INT_SOURCE_BOOT_ON) {
+        if ((millis() - start) > timeoutMs) {
+            return false;
+        }
+        delay(1);
+    }
+    return true;
+}
+
+void WSEN_PADS::configureDefault() {
+    // Auto-increment for multi-byte reads, low-noise off, BDU enabled,
+    // ODR = power-down. LPF is left untouched.
+    updateReg(REG_CTRL_2, CTRL2_IF_ADD_INC | CTRL2_LOW_NOISE_EN, CTRL2_IF_ADD_INC);
+    writeReg(REG_CTRL_1, CTRL1_BDU);
+}
+
+// ---------------------------------------------------------------------
+// Data path
+// ---------------------------------------------------------------------
+
+bool WSEN_PADS::isPoweredOn() {
+    return (readReg(REG_CTRL_1) & CTRL1_ODR_MASK) != 0;
+}
+
+bool WSEN_PADS::waitForDataReady(uint32_t timeoutMs) {
+    uint32_t start = millis();
+    while ((millis() - start) < timeoutMs) {
+        if (dataReady()) {
+            return true;
+        }
+        delay(1);
+    }
+    return false;
+}
+
+uint8_t WSEN_PADS::status() {
+    return readReg(REG_STATUS);
+}
+
+int32_t WSEN_PADS::pressureRaw() {
+    if (!isPoweredOn()) {
+        triggerOneShot();
+        if (!waitForDataReady()) {
+            return INT32_MIN;
+        }
+    }
+    uint8_t data[3];
+    readBlock(REG_DATA_P_XL, data, 3);
+    uint32_t raw = (static_cast<uint32_t>(data[2]) << 16) | (static_cast<uint32_t>(data[1]) << 8) |
+                   static_cast<uint32_t>(data[0]);
+    return toSigned24(raw);
+}
+
+int32_t WSEN_PADS::temperatureRaw() {
+    if (!isPoweredOn()) {
+        triggerOneShot();
+        if (!waitForDataReady()) {
+            return INT32_MIN;
+        }
+    }
+    uint8_t data[2];
+    readBlock(REG_DATA_T_L, data, 2);
+    uint16_t raw = static_cast<uint16_t>((data[1] << 8) | data[0]);
+    return toSigned16(raw);
+}
+
+WSEN_PADS::ReadResult WSEN_PADS::readSensorData() {
+    uint8_t pData[3];
+    readBlock(REG_DATA_P_XL, pData, 3);
+    uint32_t pBits = (static_cast<uint32_t>(pData[2]) << 16) |
+                     (static_cast<uint32_t>(pData[1]) << 8) | static_cast<uint32_t>(pData[0]);
+    int32_t pRaw = toSigned24(pBits);
+
+    uint8_t tData[2];
+    readBlock(REG_DATA_T_L, tData, 2);
+    uint16_t tBits = static_cast<uint16_t>((tData[1] << 8) | tData[0]);
+    int32_t tRaw = toSigned16(tBits);
+
+    float tFactory = tRaw * TEMPERATURE_C_PER_DIGIT;
+    float tC = _tempUserSlope * tFactory + _tempUserOffset + _tempOffset;
+    return {pRaw * PRESSURE_HPA_PER_DIGIT, tC};
+}
+
+// ---------------------------------------------------------------------
+// Conversion utilities
+// ---------------------------------------------------------------------
+
+int32_t WSEN_PADS::toSigned24(uint32_t value) {
+    if (value & 0x800000u) {
+        return static_cast<int32_t>(value) - 0x1000000;
+    }
+    return static_cast<int32_t>(value);
+}
+
+int32_t WSEN_PADS::toSigned16(uint16_t value) {
+    if (value & 0x8000u) {
+        return static_cast<int32_t>(value) - 0x10000;
+    }
+    return static_cast<int32_t>(value);
+}

--- a/lib/wsen-pads/src/WSEN_PADS.h
+++ b/lib/wsen-pads/src/WSEN_PADS.h
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include <Arduino.h>
+#include <Wire.h>
+
+#include "WSEN_PADS_const.h"
+
+class WSEN_PADS {
+   public:
+    WSEN_PADS(TwoWire& wire = Wire, uint8_t address = WSEN_PADS_I2C_DEFAULT_ADDR);
+
+    // --- Lifecycle ---
+    bool begin();
+    uint8_t deviceId();
+    void softReset();
+    void reboot();
+    void powerOn();
+    void powerOff();
+
+    // --- Reading ---
+    struct ReadResult {
+        float pressure;     // hPa
+        float temperature;  // °C, factory + user calibration applied
+    };
+    float pressureHpa();
+    float temperature();
+    ReadResult read();
+
+    // --- Status ---
+    bool dataReady();
+    bool pressureReady();
+    bool temperatureReady();
+
+    // --- Modes ---
+    void setContinuous(uint8_t odr);
+    void triggerOneShot();
+    ReadResult readOneShot();
+
+    // --- Calibration ---
+    // setTemperatureOffset() and calibrateTemperature() are independent:
+    // the offset stacks on top of the two-point user slope/intercept.
+    void setTemperatureOffset(float offset);
+    void calibrateTemperature(float refLow, float measLow, float refHigh, float measHigh);
+
+    // --- Driver-specific tuning ---
+    // Both LOW_NOISE_EN and the LPF bits are layered on the running CTRL
+    // registers, so callers can flip them without losing the current ODR.
+    // LOW_NOISE_EN is only valid when ODR is 1, 10, 25, 50 or 75 Hz —
+    // see the WSEN-PADS datasheet (rev. 1.5) §6.1.
+    void enableLowPass(bool strong = false);
+    void disableLowPass();
+    void enableLowNoise();
+    void disableLowNoise();
+
+   private:
+    TwoWire* _wire;
+    uint8_t _address;
+    float _tempUserSlope;   // two-point user calibration slope
+    float _tempUserOffset;  // two-point user calibration intercept
+    float _tempOffset;      // additive offset on top of user calibration
+
+    // I2C helpers
+    bool isPresent();
+    uint8_t readReg(uint8_t reg);
+    void readBlock(uint8_t reg, uint8_t* buf, size_t len);
+    void writeReg(uint8_t reg, uint8_t value);
+    void updateReg(uint8_t reg, uint8_t mask, uint8_t value);
+
+    // Boot helpers
+    bool waitBoot(uint32_t timeoutMs = 20);
+    void configureDefault();
+
+    // Data path
+    bool isPoweredOn();
+    bool waitForDataReady(uint32_t timeoutMs = 100);
+    int32_t pressureRaw();     // returns INT32_MIN on failure
+    int32_t temperatureRaw();  // returns INT32_MIN on failure
+    ReadResult readSensorData();
+
+    uint8_t status();
+
+    static int32_t toSigned24(uint32_t value);
+    static int32_t toSigned16(uint16_t value);
+};

--- a/lib/wsen-pads/src/WSEN_PADS_const.h
+++ b/lib/wsen-pads/src/WSEN_PADS_const.h
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+#include <stdint.h>
+
+// ============================================================================
+// I2C addressing
+// ============================================================================
+
+// 7-bit I2C address when SAO pin is tied low
+constexpr uint8_t WSEN_PADS_I2C_ADDR_SAO_LOW = 0x5C;
+
+// 7-bit I2C address when SAO pin is tied high
+constexpr uint8_t WSEN_PADS_I2C_ADDR_SAO_HIGH = 0x5D;
+
+// Default address recommended for a single device on the bus
+constexpr uint8_t WSEN_PADS_I2C_DEFAULT_ADDR = WSEN_PADS_I2C_ADDR_SAO_HIGH;
+
+// Expected device ID value
+constexpr uint8_t WSEN_PADS_DEVICE_ID = 0xB3;
+
+// ============================================================================
+// Register map
+// ============================================================================
+
+constexpr uint8_t REG_INT_CFG = 0x0B;
+constexpr uint8_t REG_THR_P_L = 0x0C;
+constexpr uint8_t REG_THR_P_H = 0x0D;
+constexpr uint8_t REG_INTERFACE_CTRL = 0x0E;
+constexpr uint8_t REG_DEVICE_ID = 0x0F;
+constexpr uint8_t REG_CTRL_1 = 0x10;
+constexpr uint8_t REG_CTRL_2 = 0x11;
+constexpr uint8_t REG_CTRL_3 = 0x12;
+constexpr uint8_t REG_FIFO_CTRL = 0x13;
+constexpr uint8_t REG_FIFO_WTM = 0x14;
+constexpr uint8_t REG_REF_P_L = 0x15;
+constexpr uint8_t REG_REF_P_H = 0x16;
+constexpr uint8_t REG_OPC_P_L = 0x18;
+constexpr uint8_t REG_OPC_P_H = 0x19;
+constexpr uint8_t REG_INT_SOURCE = 0x24;
+constexpr uint8_t REG_FIFO_STATUS_1 = 0x25;
+constexpr uint8_t REG_FIFO_STATUS_2 = 0x26;
+constexpr uint8_t REG_STATUS = 0x27;
+constexpr uint8_t REG_DATA_P_XL = 0x28;
+constexpr uint8_t REG_DATA_P_L = 0x29;
+constexpr uint8_t REG_DATA_P_H = 0x2A;
+constexpr uint8_t REG_DATA_T_L = 0x2B;
+constexpr uint8_t REG_DATA_T_H = 0x2C;
+
+// FIFO output registers (not used yet in the V1 driver)
+constexpr uint8_t REG_FIFO_DATA_P_XL = 0x78;
+constexpr uint8_t REG_FIFO_DATA_P_L = 0x79;
+constexpr uint8_t REG_FIFO_DATA_P_H = 0x7A;
+constexpr uint8_t REG_FIFO_DATA_T_L = 0x7B;
+constexpr uint8_t REG_FIFO_DATA_T_H = 0x7C;
+
+// ============================================================================
+// CTRL_1 register bits
+// ============================================================================
+
+// ODR[2:0] field occupies bits 6:4
+constexpr uint8_t CTRL1_ODR_SHIFT = 4;
+constexpr uint8_t CTRL1_ODR_MASK = 0x70;
+
+// Enable second low-pass filter for pressure
+constexpr uint8_t CTRL1_EN_LPFP = 1 << 3;
+
+// Low-pass filter bandwidth configuration
+constexpr uint8_t CTRL1_LPFP_CFG = 1 << 2;
+
+// Block data update
+constexpr uint8_t CTRL1_BDU = 1 << 1;
+
+// SPI mode selection (not used in I2C mode)
+constexpr uint8_t CTRL1_SIM = 1 << 0;
+
+// ============================================================================
+// CTRL_2 register bits
+// ============================================================================
+
+constexpr uint8_t CTRL2_BOOT = 1 << 7;
+constexpr uint8_t CTRL2_INT_H_L = 1 << 6;
+constexpr uint8_t CTRL2_PP_OD = 1 << 5;
+constexpr uint8_t CTRL2_IF_ADD_INC = 1 << 4;
+constexpr uint8_t CTRL2_SWRESET = 1 << 2;
+constexpr uint8_t CTRL2_LOW_NOISE_EN = 1 << 1;
+constexpr uint8_t CTRL2_ONE_SHOT = 1 << 0;
+
+// ============================================================================
+// INT_SOURCE register bits
+// ============================================================================
+
+constexpr uint8_t INT_SOURCE_BOOT_ON = 1 << 7;
+constexpr uint8_t INT_SOURCE_IA = 1 << 2;
+constexpr uint8_t INT_SOURCE_PL = 1 << 1;
+constexpr uint8_t INT_SOURCE_PH = 1 << 0;
+
+// ============================================================================
+// STATUS register bits
+// ============================================================================
+
+constexpr uint8_t STATUS_T_OR = 1 << 5;
+constexpr uint8_t STATUS_P_OR = 1 << 4;
+constexpr uint8_t STATUS_T_DA = 1 << 1;
+constexpr uint8_t STATUS_P_DA = 1 << 0;
+
+// ============================================================================
+// Output data rate (ODR) values for CTRL_1[6:4]
+// ============================================================================
+
+constexpr uint8_t ODR_POWER_DOWN = 0x00;
+constexpr uint8_t ODR_1_HZ = 0x01;
+constexpr uint8_t ODR_10_HZ = 0x02;
+constexpr uint8_t ODR_25_HZ = 0x03;
+constexpr uint8_t ODR_50_HZ = 0x04;
+constexpr uint8_t ODR_75_HZ = 0x05;
+constexpr uint8_t ODR_100_HZ = 0x06;
+constexpr uint8_t ODR_200_HZ = 0x07;
+
+// ============================================================================
+// Conversion constants
+// ============================================================================
+
+// Pressure sensitivity:
+// 1 digit = 1 / 40960 kPa = 1 / 4096 hPa = 1 / 40.96 Pa
+constexpr float PRESSURE_HPA_PER_DIGIT = 1.0 / 4096.0;
+constexpr float PRESSURE_KPA_PER_DIGIT = 1.0 / 40960.0;
+constexpr float PRESSURE_PA_PER_DIGIT = 1.0 / 40.96;
+
+// Temperature sensitivity:
+// 1 digit = 0.01 °C
+constexpr float TEMPERATURE_C_PER_DIGIT = 0.01;
+
+// ============================================================================
+// Timing helpers
+// ============================================================================
+
+// Typical boot time after power-up is up to 4.5 ms, so 5 ms is a safe minimum.
+constexpr uint8_t BOOT_DELAY_MS = 5;
+
+// Typical conversion time in one-shot mode
+constexpr uint8_t ONE_SHOT_LOW_POWER_DELAY_MS = 5;
+constexpr uint8_t ONE_SHOT_LOW_NOISE_DELAY_MS = 15;

--- a/tests/native/test_wsen_pads/test_main.cpp
+++ b/tests/native/test_wsen_pads/test_main.cpp
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <unity.h>
+
+#include "WSEN_PADS.h"
+#include "WSEN_PADS_const.h"
+#include "Wire.h"
+#include "driver_checks.h"
+
+constexpr uint8_t ADDR = WSEN_PADS_I2C_DEFAULT_ADDR;
+
+static void preloadDeviceId(bool valid = true) {
+    Wire.setRegister(ADDR, REG_DEVICE_ID, valid ? WSEN_PADS_DEVICE_ID : 0x42);
+}
+
+// Force the device to look "powered on" so reads don't auto-trigger a
+// one-shot. Tests that exercise the auto-trigger path explicitly clear
+// CTRL_1 first.
+static void preloadPoweredOn() {
+    Wire.setRegister(ADDR, REG_CTRL_1, CTRL1_BDU | (ODR_1_HZ << CTRL1_ODR_SHIFT));
+}
+
+static void preloadMeasurement(float tempC, float pressureHpa) {
+    auto rawFromTemp = [](float t) -> int16_t { return static_cast<int16_t>(t / 0.01f); };
+    auto rawPressure = [](float p) -> int32_t { return static_cast<int32_t>(p * 4096); };
+
+    int16_t tempRaw = rawFromTemp(tempC);
+    int32_t pressureRaw = rawPressure(pressureHpa);
+
+    Wire.setRegister(ADDR, REG_DATA_P_XL, pressureRaw & 0xFF);
+    Wire.setRegister(ADDR, REG_DATA_P_L, (pressureRaw >> 8) & 0xFF);
+    Wire.setRegister(ADDR, REG_DATA_P_H, (pressureRaw >> 16) & 0xFF);
+
+    Wire.setRegister(ADDR, REG_DATA_T_L, tempRaw & 0xFF);
+    Wire.setRegister(ADDR, REG_DATA_T_H, (tempRaw >> 8) & 0xFF);
+
+    Wire.setRegister(ADDR, REG_STATUS, STATUS_P_DA | STATUS_T_DA);
+}
+
+WSEN_PADS sensor;
+
+void setUp() {
+    Wire = TwoWire();
+    preloadDeviceId();
+    sensor = WSEN_PADS();
+}
+
+void tearDown(void) {}
+
+void test_begin_detects_device(void) {
+    check_begin(sensor);
+}
+
+void test_begin_rejects_wrong_device_id(void) {
+    preloadDeviceId(false);
+    TEST_ASSERT_FALSE(sensor.begin());
+}
+
+void test_device_id_returns_correct_value(void) {
+    check_who_am_i(sensor, WSEN_PADS_DEVICE_ID);
+}
+
+void test_power_on_sets_ctrl1(void) {
+    sensor.begin();
+    sensor.powerOn();
+    uint8_t ctrl1 = Wire.getRegister(ADDR, REG_CTRL_1);
+    TEST_ASSERT_BITS_HIGH(CTRL1_BDU, ctrl1);
+    TEST_ASSERT_NOT_EQUAL(0, ctrl1 & CTRL1_ODR_MASK);
+}
+
+void test_power_off_clears_ctrl1_odr(void) {
+    sensor.begin();
+    sensor.powerOn();
+    sensor.powerOff();
+    uint8_t ctrl1 = Wire.getRegister(ADDR, REG_CTRL_1);
+    TEST_ASSERT_EQUAL(0, ctrl1 & CTRL1_ODR_MASK);
+}
+
+void test_set_continuous_writes_expected_ctrl1(void) {
+    sensor.begin();
+    sensor.setContinuous(ODR_1_HZ);
+    uint8_t ctrl1 = Wire.getRegister(ADDR, REG_CTRL_1);
+    uint8_t expected = CTRL1_BDU | (ODR_1_HZ << CTRL1_ODR_SHIFT);
+    TEST_ASSERT_EQUAL_HEX8(expected, ctrl1);
+}
+
+void test_trigger_one_shot_sets_ctrl2_one_shot(void) {
+    sensor.begin();
+    sensor.triggerOneShot();
+    uint8_t ctrl2 = Wire.getRegister(ADDR, REG_CTRL_2);
+    TEST_ASSERT_BITS_HIGH(CTRL2_ONE_SHOT, ctrl2);
+}
+
+void test_trigger_one_shot_powers_down_first(void) {
+    // ONE_SHOT only fires from ODR=000. Verify the trigger forces the
+    // power-down before flipping the bit.
+    sensor.begin();
+    sensor.setContinuous(ODR_25_HZ);
+    sensor.triggerOneShot();
+    uint8_t ctrl1 = Wire.getRegister(ADDR, REG_CTRL_1);
+    TEST_ASSERT_EQUAL(0, ctrl1 & CTRL1_ODR_MASK);
+}
+
+void test_data_ready_reflects_status_register(void) {
+    sensor.begin();
+    Wire.setRegister(ADDR, REG_STATUS, 0);
+    TEST_ASSERT_FALSE(sensor.dataReady());
+    TEST_ASSERT_FALSE(sensor.pressureReady());
+    TEST_ASSERT_FALSE(sensor.temperatureReady());
+
+    Wire.setRegister(ADDR, REG_STATUS, STATUS_P_DA);
+    TEST_ASSERT_FALSE(sensor.dataReady());
+    TEST_ASSERT_TRUE(sensor.pressureReady());
+    TEST_ASSERT_FALSE(sensor.temperatureReady());
+
+    Wire.setRegister(ADDR, REG_STATUS, STATUS_P_DA | STATUS_T_DA);
+    TEST_ASSERT_TRUE(sensor.dataReady());
+    TEST_ASSERT_TRUE(sensor.pressureReady());
+    TEST_ASSERT_TRUE(sensor.temperatureReady());
+}
+
+void test_read_returns_converted_values(void) {
+    sensor.begin();
+    sensor.setContinuous(ODR_1_HZ);
+    preloadMeasurement(23.0f, 1013.0f);
+
+    auto r = sensor.read();
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 23.0f, r.temperature);
+    TEST_ASSERT_FLOAT_WITHIN(0.1f, 1013.0f, r.pressure);
+}
+
+void test_pressure_hpa_returns_nan_on_powered_down_timeout(void) {
+    // begin() leaves the part in power-down. With STATUS reporting no
+    // data ready, the auto-trigger path times out and pressureHpa()
+    // must surface NaN — not silently return 0 hPa.
+    sensor.begin();
+    Wire.setRegister(ADDR, REG_STATUS, 0);
+    TEST_ASSERT_TRUE(isnan(sensor.pressureHpa()));
+}
+
+void test_temperature_returns_nan_on_powered_down_timeout(void) {
+    sensor.begin();
+    Wire.setRegister(ADDR, REG_STATUS, 0);
+    TEST_ASSERT_TRUE(isnan(sensor.temperature()));
+}
+
+void test_set_temperature_offset_shifts_reading(void) {
+    sensor.begin();
+    sensor.setContinuous(ODR_1_HZ);
+    preloadMeasurement(23.0f, 1013.0f);
+    sensor.setTemperatureOffset(1.5f);
+
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 24.5f, sensor.temperature());
+}
+
+void test_calibrate_temperature_applies_correction(void) {
+    sensor.begin();
+    sensor.setContinuous(ODR_1_HZ);
+    sensor.calibrateTemperature(1.0f, 0.0f, 22.0f, 20.0f);
+    preloadMeasurement(20.0f, 1013.0f);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 22.0f, sensor.temperature());
+}
+
+void test_offset_stacks_on_top_of_calibration(void) {
+    // Two-point calibration and the additive offset are independent —
+    // setTemperatureOffset doesn't reset slope/intercept set by
+    // calibrateTemperature, and vice versa. Same contract as HTS221.
+    sensor.begin();
+    sensor.setContinuous(ODR_1_HZ);
+    sensor.calibrateTemperature(1.0f, 0.0f, 22.0f, 20.0f);  // slope = 1.05, offset = 1.0
+    sensor.setTemperatureOffset(0.5f);
+    preloadMeasurement(20.0f, 1013.0f);
+
+    // 1.05 * 20 + 1.0 + 0.5 = 22.5
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 22.5f, sensor.temperature());
+}
+
+void test_reboot_writes_ctrl2_boot(void) {
+    sensor.begin();
+    Wire.clearWrites();
+    Wire.setRegister(ADDR, REG_CTRL_2, 0);
+    sensor.reboot();
+    bool sawBootSet = false;
+    for (const auto& w : Wire.getWrites()) {
+        if (w.reg == REG_CTRL_2 && (w.value & CTRL2_BOOT)) {
+            sawBootSet = true;
+            break;
+        }
+    }
+    TEST_ASSERT_TRUE(sawBootSet);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_begin_detects_device);
+    RUN_TEST(test_begin_rejects_wrong_device_id);
+    RUN_TEST(test_device_id_returns_correct_value);
+    RUN_TEST(test_power_on_sets_ctrl1);
+    RUN_TEST(test_power_off_clears_ctrl1_odr);
+    RUN_TEST(test_set_continuous_writes_expected_ctrl1);
+    RUN_TEST(test_trigger_one_shot_sets_ctrl2_one_shot);
+    RUN_TEST(test_trigger_one_shot_powers_down_first);
+    RUN_TEST(test_data_ready_reflects_status_register);
+    RUN_TEST(test_read_returns_converted_values);
+    RUN_TEST(test_pressure_hpa_returns_nan_on_powered_down_timeout);
+    RUN_TEST(test_temperature_returns_nan_on_powered_down_timeout);
+    RUN_TEST(test_set_temperature_offset_shifts_reading);
+    RUN_TEST(test_calibrate_temperature_applies_correction);
+    RUN_TEST(test_offset_stacks_on_top_of_calibration);
+    RUN_TEST(test_reboot_writes_ctrl2_boot);
+    return UNITY_END();
+}


### PR DESCRIPTION
close #5 
close #25
## Summary

Adds a C++ Arduino driver for the WSEN-PADS barometric pressure and temperature sensor, translated and adapted from the existing MicroPython driver.

## Changes

WSEN_PADS_const.h — register map, bit definitions, ODR values, and conversion constants
WSEN_PADS.h — class declaration with all public and private members
WSEN_PADS.cpp — full driver implementation

##Features

I- 2C communication via Arduino TwoWire
- Device detection and ID verification on startup
- Boot sequence handling with timeout
- Power-down / continuous mode control
- One-shot acquisition mode (low-power and low-noise)
- Raw and converted pressure readings (hPa, Pa, kPa)
- Raw and converted temperature readings (°C)
- Low-pass filter configuration
- Soft reset and reboot
- Two-point temperature calibration

## Checklist

- [x] `make lint` passes (clang-format)
- [x] `make build` passes (PlatformIO)
- [x] `make test-native` passes (if native tests exist)
- [x] `make test-hardware` passes on a connected STeaMi (if hardware tests exist)
- [x] README updated (if adding/changing public API)
- [ ] Examples added/updated (if applicable)
- [x] Commit messages follow conventional commits format
