### PR TITLE
test(tooling): Generate one test-hardware- target per suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,9 +174,31 @@ test-native-$(1): .venv/bin/pio
 endef
 $(foreach k,$(NATIVE_TEST_KEYS),$(eval $(call NATIVE_TEST_RULE,$(k))))
 
+HARDWARE_TEST_KEYS := $(patsubst tests/hardware/test_%,%,$(wildcard tests/hardware/test_*))
+
 .PHONY: test-hardware
-test-hardware: .venv/bin/pio ## Run on-board hardware tests (STeaMi required)
+test-hardware: .venv/bin/pio ## Run all on-board hardware tests (skipped if no STeaMi attached)
+	@if ! $(PIO) device list | grep -qiE 'steami|cmsis-dap'; then
+		echo "STeaMi not detected — skipping hardware tests."
+		exit 0
+	fi
 	$(PIO) test -e steami
+
+# Per-suite hardware test targets — `make test-hardware-<name>` runs
+# only that suite. Same shape as test-native-<name>, with the added
+# board-detection guard: if no STeaMi is attached, the recipe prints a
+# message and exits 0 so a CI script that pessimistically calls these
+# without a board doesn't fail.
+define HARDWARE_TEST_RULE
+.PHONY: test-hardware-$(1)
+test-hardware-$(1): .venv/bin/pio
+	@if ! $$(PIO) device list | grep -qiE 'steami|cmsis-dap'; then
+		echo "STeaMi not detected — skipping hardware tests."
+		exit 0
+	fi
+	$$(PIO) test -e steami --filter hardware/test_$(1)
+endef
+$(foreach k,$(HARDWARE_TEST_KEYS),$(eval $(call HARDWARE_TEST_RULE,$(k))))
 
 # --- CI ---
 

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -74,20 +74,28 @@ pio test -e native --filter native/test_led
 ### Using Makefile
 
 The `make` wrappers route through the venv `pio` installed by `make setup`,
-and one phony target is generated per suite under `tests/native/test_*`
-(via `foreach + eval`, same shape as `flash-<driver>/<example>`):
+and one phony target is generated per suite under `tests/native/test_*` and
+`tests/hardware/test_*` (via `foreach + eval`, same shape as
+`flash-<driver>/<example>`):
 
 ```bash
 make test-native              # all native suites
 make test-native-hts221       # one suite — auto-discovered from tests/native/test_hts221/
 make test-native-led
 make test-native-wire
-make test-hardware            # all hardware suites (board required)
+
+make test-hardware            # all hardware suites
+make test-hardware-led        # one suite — auto-discovered from tests/hardware/test_led/
 ```
 
-Tab-completion on zsh/bash works for `make test-native-<TAB>`. Adding a new
-suite directory under `tests/native/test_<name>/` picks up automatically on
-the next `make` invocation — no Makefile edits.
+Tab-completion on zsh/bash works for `make test-native-<TAB>` and
+`make test-hardware-<TAB>`. Adding a new suite directory picks up
+automatically on the next `make` invocation — no Makefile edits.
+
+The hardware targets check for an attached STeaMi via `pio device list`
+before they run; if no board is detected they print
+`STeaMi not detected — skipping hardware tests.` and exit 0, so a CI script
+that calls them without a board attached doesn't fail.
 
 ---
 


### PR DESCRIPTION
## Summary

Mirror the per-suite test target pattern from #137 for the on-board side: each directory under `tests/hardware/test_*/` becomes a `make test-hardware-<name>` phony target via `foreach + eval`. New suite = new directory, nothing else to wire up.

Closes #120

```bash
make test-hardware              # all hardware suites
make test-hardware-led          # one suite — auto-discovered from tests/hardware/test_led/
```

Tab-completion on zsh/bash works for `make test-hardware-<TAB>`.

## Hardware-specific addition: board detection

Per the acceptance criteria of #120, each `test-hardware*` recipe checks for an attached STeaMi before running:

```sh
pio device list | grep -iE 'steami|cmsis-dap'
```

If no board is detected, the recipe prints `STeaMi not detected — skipping hardware tests.` and exits 0. The exit-0 (rather than exit-1) is intentional: a CI script that pessimistically calls these without a board attached should not fail. The same guard applies to `make test-hardware` (run-all) and to every generated `test-hardware-<name>`.

## Why per-target instead of `driver=<name>`?

This branch originally proposed `make test-hardware driver=<name>` plus a `test-hardware-list` helper, mirroring the original shape of #137. After #137 landed in its rewritten form (per-target generation, no argument), keeping `driver=<name>` here would break the symmetry between the two halves. Per-target generation:

* keeps the Makefile mechanically uniform with `flash-<driver>/<example>` (#133), `capture-<driver>/<example>` (#138), and `test-native-<name>` (#137);
* enables tab-completion natively;
* lets users discover suites the same way they already do for examples and native tests;
* makes the foreach+eval block trivially copy-paste-able for the next test family someone wants to add.

The earlier `test-hardware-list` helper drops out: tab-completion + `make help` are sufficient. An invalid name (`make test-hardware-bogus`) falls through to Make's standard "no rule" error.

## Changes

* `Makefile` — `HARDWARE_TEST_KEYS` discovered via `$(wildcard tests/hardware/test_*)` + `$(patsubst …)`, then a `define / foreach / eval` block emits one `test-hardware-<name>` per suite. The board-detection guard is embedded into both the run-all target and the generated per-suite recipes.
* `tests/TESTING.md` — *Using Makefile* section extended to cover the hardware variant alongside the native one, with a note about the board-detection skip behaviour.

The earlier "Install PlatformIO" CI workflow change from this branch is dropped — `make test-hardware` already installs `pio` into the venv via the `.venv/bin/pio` prerequisite, and the workflow runs the make target directly.

## Validated on real hardware

```
$ ls /dev/ttyACM*
/dev/ttyACM0
$ make test-hardware-led
...
[stm32wbx.cpu] halted due to debug-request, current mode: Thread
** Programming Started **
** Verified OK **
** Resetting Target **
tests/hardware/test_led/test_main.cpp:45: test_led_pins_output_mode      [PASSED]
tests/hardware/test_led/test_main.cpp:46: test_led_blink_sequence        [PASSED]
2 test cases: 2 succeeded in 00:00:18.306
```

The skip path was sanity-checked separately by running the same `pio device list | grep` against a non-matching pattern — exits non-zero as expected, so the `if !` branch fires and the skip message would appear when no board is attached.