### PR TITLE
feat: Add ble scope to commit convention.

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -28,6 +28,7 @@ module.exports = {
         'vl53l1x',
         'wsen-hids',
         'wsen-pads',
+        'ble',
         'ci',
         'docs',
         'style',


### PR DESCRIPTION
##Summary

Closes #145

Add ble as an allowed commit scope in commitlint so BLE-related changes can use a dedicated conventional commit scope.

##Changes
* Add ble to the allowed scope-enum list in commitlint.config.js
* Update CONTRIBUTING.md to document ble as a supported scope for commit messages