### PR TITLE
test(tests): Add shared driver checks for native and hardware parity.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,6 +9,8 @@ framework = arduino
 monitor_speed = 115200
 test_framework = unity
 test_filter = hardware/test_*
+build_flags =
+  -I tests/shared
 
 [env:native]
 platform = native
@@ -19,3 +21,4 @@ build_flags =
   -std=c++17
   -D UNIT_TEST
   -I tests/native/helpers
+  -I tests/shared

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -137,6 +137,27 @@ Example:
 
 ---
 
+## Shared checks
+
+Common driver assertions that should hold in both native and hardware tests
+are defined in `tests/shared/driver_checks.h`.
+
+These helpers provide a small, shared contract for drivers:
+
+* `check_begin()` — verifies that the device initializes correctly
+* `check_who_am_i()` — verifies device identity via the WHO_AM_I register
+* `check_read_plausible()` — verifies that sensor readings fall within a valid range
+
+Usage pattern:
+
+* **Native tests** use these checks with exact, mock-controlled values
+* **Hardware tests** use the same checks with realistic plausibility ranges
+
+This ensures both test suites exercise the same core driver behavior, while
+keeping native tests precise and hardware tests robust to real-world variation.
+
+See `tests/native/test_hts221/` for a reference implementation.
+
 ## Mocking Approach
 
 Native tests use lightweight mocks to simulate Arduino behavior. Mocks live

--- a/tests/native/test_hts221/test_main.cpp
+++ b/tests/native/test_hts221/test_main.cpp
@@ -5,6 +5,7 @@
 
 #include "HTS221.h"
 #include "Wire.h"
+#include "driver_checks.h"
 
 // The driver uses bit 7 of the sub-address as the ST auto-increment flag for
 // multi-byte reads (see HTS221_AUTO_INCREMENT). The Wire mock is a straight
@@ -81,7 +82,7 @@ void setUp(void) {
 void tearDown(void) {}
 
 void test_begin_detects_device(void) {
-    TEST_ASSERT_TRUE(sensor.begin());
+    check_begin(sensor);
 }
 
 void test_begin_rejects_wrong_who_am_i(void) {
@@ -90,7 +91,7 @@ void test_begin_rejects_wrong_who_am_i(void) {
 }
 
 void test_device_id_returns_who_am_i(void) {
-    TEST_ASSERT_EQUAL_HEX8(HTS221_WHO_AM_I_VALUE, sensor.deviceId());
+    check_who_am_i(sensor, HTS221_WHO_AM_I_VALUE);
 }
 
 void test_power_on_sets_ctrl1_pd(void) {
@@ -137,6 +138,22 @@ void test_data_ready_reflects_status_register(void) {
     TEST_ASSERT_TRUE(sensor.humidityReady());
 }
 
+void test_temperature_is_plausible(void) {
+    sensor.begin();
+    sensor.setContinuous(HTS221_ODR_1_HZ);
+    preloadMeasurement(21.5f, 42.0f);
+
+    check_read_plausible(sensor, &HTS221::temperature, -40.0f, 120.0f);
+}
+
+void test_humidity_is_plausible(void) {
+    sensor.begin();
+    sensor.setContinuous(HTS221_ODR_1_HZ);
+    preloadMeasurement(21.5f, 42.0f);
+
+    check_read_plausible(sensor, &HTS221::humidity, 0.0f, 100.0f);
+}
+
 void test_read_returns_calibrated_values(void) {
     sensor.begin();
     sensor.setContinuous(HTS221_ODR_1_HZ);
@@ -174,6 +191,8 @@ void test_read_auto_triggers_when_powered_down(void) {
     auto r = sensor.read();
 
     TEST_ASSERT_FLOAT_WITHIN(0.01f, 10.0f, r.temperature);
+    TEST_ASSERT_FLOAT_WITHIN(0.1f, 30.0f, r.humidity);
+
     // The read() flow should have emitted a CTRL1 power-up and a CTRL2
     // ONE_SHOT write before reading the OUT registers.
     bool sawCtrl1PowerUp = false;
@@ -254,6 +273,8 @@ int main(void) {
     RUN_TEST(test_set_continuous_writes_expected_ctrl1);
     RUN_TEST(test_trigger_one_shot_sets_ctrl2_one_shot);
     RUN_TEST(test_data_ready_reflects_status_register);
+    RUN_TEST(test_temperature_is_plausible);
+    RUN_TEST(test_humidity_is_plausible);
     RUN_TEST(test_read_returns_calibrated_values);
     RUN_TEST(test_humidity_is_clamped_to_0_100);
     RUN_TEST(test_read_auto_triggers_when_powered_down);

--- a/tests/shared/driver_checks.h
+++ b/tests/shared/driver_checks.h
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+/*
+ * Shared driver checks for dual-use test suites.
+ *
+ * Call these helpers from native tests with exact mock-loaded values, and from
+ * hardware tests with plausibility ranges. The goal is to keep native and
+ * hardware-unit suites aligned around the same public driver contract.
+ */
+
+#include <unity.h>
+
+template <class D>
+inline void check_begin(D& drv) {
+    TEST_ASSERT_TRUE(drv.begin());
+}
+
+template <class D>
+inline void check_who_am_i(D& drv, uint8_t expected) {
+    TEST_ASSERT_EQUAL_UINT8(expected, drv.deviceId());
+}
+
+template <class D, class Reading>
+inline void check_read_plausible(D& drv, Reading minValue, Reading maxValue) {
+    const Reading value = drv.read();
+    TEST_ASSERT_GREATER_OR_EQUAL(minValue, value);
+    TEST_ASSERT_LESS_OR_EQUAL(maxValue, value);
+}
+
+template <class D, class Reading>
+inline void check_read_plausible(D& drv, Reading (D::*reader)(), Reading minValue,
+                                 Reading maxValue) {
+    const Reading value = (drv.*reader)();
+    TEST_ASSERT_GREATER_OR_EQUAL(minValue, value);
+    TEST_ASSERT_LESS_OR_EQUAL(maxValue, value);
+}
+
+template <class D, class Result, class Value>
+inline void check_read_plausible(D& drv, Result (D::*reader)(), Value Result::* field,
+                                 Value minValue, Value maxValue) {
+    const Result value = (drv.*reader)();
+    TEST_ASSERT_GREATER_OR_EQUAL(minValue, value.*field);
+    TEST_ASSERT_LESS_OR_EQUAL(maxValue, value.*field);
+}


### PR DESCRIPTION
## Summary

Introduce shared driver checks for native/mock and hardware-unit parity.

Closes #121

## Context

The HTS221 native suite and the hardware test suite currently evolve independently.
That makes parity between mock-based and on-board validation a convention rather
than a property of the test code.

This PR adds a small shared assertion layer so both environments can call the
same core driver checks:
- initialization succeeds
- device identity matches expectation
- readings are plausible for the target environment

## Changes

- add `tests/shared/driver_checks.h` as a header-only shared test helper
- provide templated inline helpers:
  - `check_begin()`
  - `check_who_am_i()`
  - `check_read_plausible()`
- make the header intent explicit for dual use:
  - native tests pass exact mock-controlled values
  - hardware tests pass plausibility ranges
- add `-I tests/shared` to both `[env:native]` and `[env:steami]` in `platformio.ini`
- refactor `tests/native/test_hts221/test_main.cpp` to use the shared helpers where they map cleanly to the existing assertions
- keep HTS221-specific assertions in place for register behavior, calibration, timeout, and reboot flows
- document the pattern in `tests/TESTING.md` with a short `Shared checks` section pointing to HTS221 as the reference example

## Notes

- The shared header is intentionally small and focused on the common public driver contract.
- The HTS221 suite still preserves its more detailed driver-specific unit coverage.
- The original HTS221 suite did not just stay green: it now also includes added plausibility coverage, so the suite count increases from 15 to 17 tests.

## Checklist

- [x] `make lint` passes (clang-format)
- [x] `make build` passes (PlatformIO)
- [x] `make test` passes
- [ ] Tested on hardware (if applicable)
- [ ] README updated (if adding/changing public API)
- [ ] Examples added/updated (if applicable)
- [x] Commit messages follow conventional commits format