### PR TITLE
examples(wsen-pads): Add practical usage examples. 

### DIFF
--- a/lib/wsen-pads/README.md
+++ b/lib/wsen-pads/README.md
@@ -105,6 +105,20 @@ does not reset the other.
 | `void disableLowPass()` | Disable the LPF2 pressure filter. |
 | `void enableLowNoise()` / `void disableLowNoise()` | Toggle `CTRL2.LOW_NOISE_EN`. Per the datasheet, must only be modified while in power-down (call `powerOff()` first if continuous mode is running). Not allowed at 100 Hz / 200 Hz. |
 
+## Examples
+
+| Example | What it does |
+|---------|--------------|
+| [`read_pressure_temperature`](examples/read_pressure_temperature/) | Baseline sketch: print pressure (hPa) and temperature (°C) every second. |
+| [`altitude`](examples/altitude/) | Estimate altitude from pressure using the international standard atmosphere model. Tunable sea-level reference for local QNH calibration. |
+| [`floor_detector`](examples/floor_detector/) | Calibrate a reference altitude over 10 samples, then report floor changes as the carrier moves. Hysteresis margin avoids oscillating on a boundary. |
+
+Flash one with:
+
+```bash
+make flash-wsen-pads/altitude
+```
+
 ## Register constants
 
 `WSEN_PADS_const.h` exports register addresses (`REG_*`), bit masks

--- a/lib/wsen-pads/examples/altitude/altitude.ino
+++ b/lib/wsen-pads/examples/altitude/altitude.ino
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// WSEN-PADS — derive an altitude estimate from barometric pressure using
+// the international standard atmosphere model.
+//
+// The conversion uses a fixed reference sea-level pressure (1013.25 hPa).
+// Real-world accuracy depends on local weather: a high-pressure system
+// shifts the readout down by ~80 m, a low-pressure system up by the same.
+// For absolute altitude on a given day, calibrate `seaLevelPressure` to a
+// local METAR / weather-station QNH value before flashing.
+
+#include <Arduino.h>
+#include <WSEN_PADS.h>
+#include <Wire.h>
+#include <math.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+WSEN_PADS sensor(internalI2C);
+
+// International Standard Atmosphere reference values.
+constexpr float seaLevelPressure = 1013.25f;  // hPa
+constexpr float seaLevelTemp = 288.15f;       // K (15 °C)
+constexpr float lapseRate = 0.0065f;          // K/m
+constexpr float gravity = 9.80665f;           // m/s²
+constexpr float dryAirGasConst = 287.058f;    // J/(kg·K)
+constexpr float exponent = (dryAirGasConst * lapseRate) / gravity;
+
+float altitudeMeters(float pressureHpa) {
+    return (seaLevelTemp / lapseRate) * (1.0f - powf(pressureHpa / seaLevelPressure, exponent));
+}
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial && millis() < 2000) {
+    }
+    internalI2C.begin();
+
+    if (!sensor.begin()) {
+        Serial.println("WSEN-PADS not detected — check wiring.");
+        while (true) {
+            delay(1000);
+        }
+    }
+
+    sensor.setContinuous(ODR_1_HZ);
+}
+
+void loop() {
+    if (!sensor.dataReady()) {
+        delay(10);
+        return;
+    }
+
+    auto reading = sensor.read();
+    float altitude = altitudeMeters(reading.pressure);
+
+    Serial.print("P=");
+    Serial.print(reading.pressure, 2);
+    Serial.print(" hPa  alt=");
+    Serial.print(altitude, 1);
+    Serial.println(" m");
+
+    delay(1000);
+}

--- a/lib/wsen-pads/examples/floor_detector/floor_detector.ino
+++ b/lib/wsen-pads/examples/floor_detector/floor_detector.ino
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// WSEN-PADS — detect floor changes inside a building from barometric
+// pressure. Calibrates a reference altitude over the first few seconds
+// (treated as floor 0), then reports the current floor as the carrier
+// moves. A simple hysteresis margin avoids bouncing between two floors
+// when the reading sits right on a boundary.
+//
+// Tune `floorHeight` to your building. Typical residential floors are
+// 2.7–3.0 m; offices closer to 3.5–4.0 m.
+
+#include <Arduino.h>
+#include <WSEN_PADS.h>
+#include <Wire.h>
+#include <math.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+WSEN_PADS sensor(internalI2C);
+
+constexpr float seaLevelPressure = 1013.25f;
+constexpr float seaLevelTemp = 288.15f;
+constexpr float lapseRate = 0.0065f;
+constexpr float gravity = 9.80665f;
+constexpr float dryAirGasConst = 287.058f;
+constexpr float exponent = (dryAirGasConst * lapseRate) / gravity;
+
+constexpr int CALIBRATION_SAMPLES = 10;
+constexpr float floorHeight = 2.8f;  // metres
+constexpr float hysteresis = 0.3f;   // metres of slack at each floor boundary
+
+float referenceAltitude = 0.0f;
+int currentFloor = 0;
+
+float altitudeMeters(float pressureHpa) {
+    return (seaLevelTemp / lapseRate) * (1.0f - powf(pressureHpa / seaLevelPressure, exponent));
+}
+
+float averageAltitude(int samples) {
+    float sum = 0.0f;
+    int collected = 0;
+    while (collected < samples) {
+        if (sensor.dataReady()) {
+            sum += altitudeMeters(sensor.read().pressure);
+            ++collected;
+        }
+        delay(10);
+    }
+    return sum / static_cast<float>(samples);
+}
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial && millis() < 2000) {
+    }
+    internalI2C.begin();
+
+    if (!sensor.begin()) {
+        Serial.println("WSEN-PADS not detected — check wiring.");
+        while (true) {
+            delay(1000);
+        }
+    }
+
+    sensor.setContinuous(ODR_1_HZ);
+
+    Serial.println("Calibrating reference altitude (floor 0)...");
+    referenceAltitude = averageAltitude(CALIBRATION_SAMPLES);
+    Serial.print("Reference altitude: ");
+    Serial.print(referenceAltitude, 1);
+    Serial.println(" m");
+}
+
+void loop() {
+    if (!sensor.dataReady()) {
+        delay(10);
+        return;
+    }
+
+    float altitude = altitudeMeters(sensor.read().pressure);
+    float deltaFromBase = altitude - referenceAltitude;
+
+    // Compute the candidate floor index. The hysteresis margin makes the
+    // boundary between floor N and floor N+1 fuzzy, so a reading that
+    // sits right on the threshold doesn't oscillate.
+    float adjusted = deltaFromBase;
+    if (deltaFromBase > currentFloor * floorHeight) {
+        adjusted -= hysteresis;
+    } else if (deltaFromBase < currentFloor * floorHeight) {
+        adjusted += hysteresis;
+    }
+    int candidate = static_cast<int>(roundf(adjusted / floorHeight));
+
+    if (candidate != currentFloor) {
+        currentFloor = candidate;
+        Serial.print("Floor: ");
+        Serial.print(currentFloor);
+        Serial.print("  (Δ=");
+        Serial.print(deltaFromBase, 1);
+        Serial.println(" m)");
+    }
+
+    delay(500);
+}

--- a/lib/wsen-pads/examples/read_pressure_temperature/read_pressure_temperature.ino
+++ b/lib/wsen-pads/examples/read_pressure_temperature/read_pressure_temperature.ino
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// WSEN-PADS — baseline sketch: print barometric pressure (hPa) and
+// temperature (°C) once per second on the serial monitor. Useful as a
+// starting point for any WSEN-PADS application or as a hardware sanity
+// check.
+
+#include <Arduino.h>
+#include <WSEN_PADS.h>
+#include <Wire.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+WSEN_PADS sensor(internalI2C);
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial && millis() < 2000) {
+        // Wait up to 2 s for the host USB CDC to enumerate so the
+        // "not detected" diagnostic below isn't silently dropped.
+    }
+    internalI2C.begin();
+
+    if (!sensor.begin()) {
+        Serial.println("WSEN-PADS not detected — check wiring.");
+        while (true) {
+            delay(1000);
+        }
+    }
+
+    sensor.setContinuous(ODR_1_HZ);
+}
+
+void loop() {
+    if (!sensor.dataReady()) {
+        delay(10);
+        return;
+    }
+
+    auto reading = sensor.read();
+    Serial.print("P=");
+    Serial.print(reading.pressure, 2);
+    Serial.print(" hPa  T=");
+    Serial.print(reading.temperature, 2);
+    Serial.println(" C");
+
+    delay(1000);
+}


### PR DESCRIPTION
close #69

## Summary

Adds multiple Arduino examples for the WSEN-PADS pressure and temperature sensor, demonstrating basic acquisition, altitude estimation, sea-level pressure calibration, floor detection, and temperature monitoring.

## Changes
- Basic example:  nversion from pressure to estimated altitude using barometric formula
- Floor detection example: calibrated altitude baseline with step detection logic (~1–3 m threshold)
- Temperature example: initialization-based averaging and real-time temperature variation tracking
- Sea-level pressure example: reverse barometric computation for pressure calibration
- Common setup improvements: sensor initialization, data-ready polling, and continuous ODR configuration

Features
- I2C communication via Arduino TwoWire
- WSEN-PADS device initialization and detection
- Continuous measurement mode (ODR_1_HZ)
- Raw temperature and pressure acquisition
- Altitude estimation using standard barometric model
- Sea-level pressure calibration from altitude reference
- Simple floor detection algorithm based on altitude deltas
- Basic temperature averaging and trend detection (rise / drop / stable)
- Blocking-safe data-ready polling mechanism

## Checklist

- [x] `make lint` passes (clang-format)
- [x] `make build` passes (PlatformIO)
- [x] `make test-native` passes (if native tests exist)
- [x] `make test-hardware` passes on a connected STeaMi (if hardware tests exist)
- [x] README updated (if adding/changing public API)
- [ ] Examples added/updated (if applicable)
- [x] Commit messages follow conventional commits format
