### PR TITLE
test(hts221): Introduce integration hardware validation tier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,22 @@ test-integration-$(1): .venv/bin/pio
 endef
 $(foreach k,$(INTEGRATION_TEST_KEYS),$(eval $(call INTEGRATION_TEST_RULE,$(k))))
 
+# Composite per-driver targets — `make test-<driver>` runs whichever
+# tiers exist for that driver (native, hardware-unit, integration). A
+# driver with only native coverage gets a shortcut to test-native-<name>;
+# a driver with all three tiers chains them in dependency order. The
+# board-detection guard on the hardware/integration recipes still
+# applies, so a host-only run skips the on-board tiers cleanly.
+ALL_TEST_KEYS := $(sort $(NATIVE_TEST_KEYS) $(HARDWARE_TEST_KEYS) $(INTEGRATION_TEST_KEYS))
+define COMPOSITE_TEST_RULE
+.PHONY: test-$(1)
+test-$(1): \
+  $(if $(filter $(1),$(NATIVE_TEST_KEYS)),test-native-$(1)) \
+  $(if $(filter $(1),$(HARDWARE_TEST_KEYS)),test-hardware-$(1)) \
+  $(if $(filter $(1),$(INTEGRATION_TEST_KEYS)),test-integration-$(1))
+endef
+$(foreach k,$(ALL_TEST_KEYS),$(eval $(call COMPOSITE_TEST_RULE,$(k))))
+
 # --- CI ---
 
 .PHONY: ci

--- a/Makefile
+++ b/Makefile
@@ -177,12 +177,12 @@ $(foreach k,$(NATIVE_TEST_KEYS),$(eval $(call NATIVE_TEST_RULE,$(k))))
 HARDWARE_TEST_KEYS := $(patsubst tests/hardware/test_%,%,$(wildcard tests/hardware/test_*))
 
 .PHONY: test-hardware
-test-hardware: .venv/bin/pio ## Run all on-board hardware tests (skipped if no STeaMi attached)
+test-hardware: .venv/bin/pio ## Run all on-board hardware-unit tests (skipped if no STeaMi attached)
 	@if ! $(PIO) device list | grep -qiE 'steami|cmsis-dap'; then
 		echo "STeaMi not detected — skipping hardware tests."
 		exit 0
 	fi
-	$(PIO) test -e steami
+	$(PIO) test -e steami --filter hardware/test_*
 
 # Per-suite hardware test targets — `make test-hardware-<name>` runs
 # only that suite. Same shape as test-native-<name>, with the added
@@ -199,6 +199,31 @@ test-hardware-$(1): .venv/bin/pio
 	$$(PIO) test -e steami --filter hardware/test_$(1)
 endef
 $(foreach k,$(HARDWARE_TEST_KEYS),$(eval $(call HARDWARE_TEST_RULE,$(k))))
+
+INTEGRATION_TEST_KEYS := $(patsubst tests/integration/test_%,%,$(wildcard tests/integration/test_*))
+
+.PHONY: test-integration
+test-integration: .venv/bin/pio ## Run all on-board integration tests (skipped if no STeaMi attached)
+	@if ! $(PIO) device list | grep -qiE 'steami|cmsis-dap'; then
+		echo "STeaMi not detected — skipping integration tests."
+		exit 0
+	fi
+	$(PIO) test -e steami --filter integration/test_*
+
+# Per-suite integration test targets — same shape as test-hardware-<name>.
+# Integration suites validate runtime behaviour over time (acquisition
+# cadence, repeated-sample plausibility, no frozen output) on real
+# silicon, so the same board-detection guard applies.
+define INTEGRATION_TEST_RULE
+.PHONY: test-integration-$(1)
+test-integration-$(1): .venv/bin/pio
+	@if ! $$(PIO) device list | grep -qiE 'steami|cmsis-dap'; then
+		echo "STeaMi not detected — skipping integration tests."
+		exit 0
+	fi
+	$$(PIO) test -e steami --filter integration/test_$(1)
+endef
+$(foreach k,$(INTEGRATION_TEST_KEYS),$(eval $(call INTEGRATION_TEST_RULE,$(k))))
 
 # --- CI ---
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,7 +8,9 @@ board = steami
 framework = arduino
 monitor_speed = 115200
 test_framework = unity
-test_filter = hardware/test_*
+test_filter =
+  hardware/test_*
+  integration/test_*
 build_flags =
   -I tests/shared
 

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -2,210 +2,243 @@
 
 ## Overview
 
-This repository uses PlatformIO's unit testing framework to validate Arduino drivers for the STeaMi board.
-
-Two complementary testing approaches are used:
-
-* **Hardware tests (`tests/hardware/`)**
-  Run directly on a connected STeaMi board.
+This repository uses PlatformIO's Unity testing framework to validate Arduino
+drivers for the STeaMi board through three complementary test tiers:
 
 * **Native tests (`tests/native/`)**
-  Run on the host machine (desktop) using mocks to simulate hardware behavior.
+  Run on the host machine using mocks. Fast, deterministic desktop tests for
+  driver logic.
 
-This mixed strategy allows both real hardware validation and fast, reproducible tests without requiring a board.
+* **Hardware unit tests (`tests/hardware/`)**
+  Run directly on a connected STeaMi board to validate atomic driver contracts
+  on real silicon.
+
+* **Integration tests (`tests/integration/`)**
+  Run on a connected STeaMi board over longer acquisition scenarios to validate
+  runtime behaviour over time.
+
+This layered strategy provides:
+
+* fast logic validation without hardware,
+* direct on-board contract validation,
+* end-to-end behavioural confidence under realistic usage.
 
 ---
 
 ## Test Structure
 
-```
+```text
 tests/
-├── hardware/
-│   └── test_<name>/
-│       └── test_main.cpp
 ├── native/
-│   └── test_<name>/
+│   └── test_<driver>/
 │       └── test_main.cpp
+├── hardware/
+│   └── test_<driver>/
+│       └── test_main.cpp
+├── integration/
+│   └── test_<driver>/
+│       └── test_main.cpp
+├── shared/
+│   └── driver_checks.h
 └── TESTING.md
 ```
 
-* Each test suite must be inside a folder named `test_<name>`
-* Each suite contains a `test_main.cpp`
-* Tests use the Unity framework
+Rules:
+
+* Each suite lives inside a folder named `test_<driver>`.
+* Each suite contains a `test_main.cpp`.
+* All tests use the Unity framework.
+* Native, hardware, and integration suites for the same driver should reuse the
+  same driver name.
 
 ---
 
 ## Running Tests
 
-### Hardware tests (on STeaMi board)
+The Makefile generates one phony target per suite under each tier (via
+`foreach + eval`, same shape as `flash-<driver>/<example>`). Tab-completion on
+zsh/bash works for `make test-<tier>-<TAB>` and adding a new suite directory
+picks up automatically — no Makefile edits.
 
-```bash
-pio test -e steami
-```
-
-Requirements:
-
-* STeaMi board connected via USB
-* Correct upload port configured if needed
-
----
-
-### Native tests (desktop)
-
-```bash
-pio test -e native
-```
-
-* No hardware required
-* Faster execution
-* Uses mocked Arduino APIs
-
----
-
-### Run a specific test suite
-
-```bash
-pio test -e steami --filter hardware/test_led
-pio test -e native --filter native/test_led
-```
-
----
-
-### Using Makefile
-
-The `make` wrappers route through the venv `pio` installed by `make setup`,
-and one phony target is generated per suite under `tests/native/test_*` and
-`tests/hardware/test_*` (via `foreach + eval`, same shape as
-`flash-<driver>/<example>`):
+### Native tests (desktop, mock-based)
 
 ```bash
 make test-native              # all native suites
 make test-native-hts221       # one suite — auto-discovered from tests/native/test_hts221/
 make test-native-led
 make test-native-wire
-
-make test-hardware            # all hardware suites
-make test-hardware-led        # one suite — auto-discovered from tests/hardware/test_led/
 ```
 
-Tab-completion on zsh/bash works for `make test-native-<TAB>` and
-`make test-hardware-<TAB>`. Adding a new suite directory picks up
-automatically on the next `make` invocation — no Makefile edits.
+No hardware required. CI-friendly.
 
-The hardware targets check for an attached STeaMi via `pio device list`
-before they run; if no board is detected they print
-`STeaMi not detected — skipping hardware tests.` and exit 0, so a CI script
-that calls them without a board attached doesn't fail.
+### Hardware unit tests (real board)
 
----
+```bash
+make test-hardware            # all hardware suites
+make test-hardware-hts221     # one suite — auto-discovered from tests/hardware/test_hts221/
+make test-hardware-led
+```
 
-## Testing Strategy
+Requires a connected STeaMi over CMSIS-DAP. If no board is detected the recipe
+prints `STeaMi not detected — skipping hardware tests.` and exits 0, so a CI
+script that calls these without a board attached doesn't fail.
 
-### Hardware tests
+### Integration tests (real board, longer scenarios)
 
-Used to validate:
+```bash
+make test-integration         # all integration suites
+make test-integration-hts221  # one suite — auto-discovered from tests/integration/test_hts221/
+```
 
-* Real hardware behavior
-* GPIO, I2C, SPI communication
-* Integration with the STeaMi board
+Requires a board (same skip behaviour as hardware unit tests). Integration
+suites are intentionally slower than hardware unit tests because they observe
+repeated measurements over time — typically tens of seconds per suite.
 
-Example:
+### Direct PlatformIO invocations
 
-* LED blinking
-* Sensor register read
+For ad-hoc runs outside the Makefile:
 
----
-
-### Native tests (mock-based)
-
-Used to validate:
-
-* Driver logic
-* Register handling
-* Data processing
-
-Mocks replace Arduino functions such as:
-
-* `pinMode`
-* `digitalWrite`
-* `Wire`
-
-Example:
-
-* Simulated LED state tracking
-* Fake I2C register reads
+```bash
+pio test -e native
+pio test -e steami                                    # hardware + integration
+pio test -e steami --filter hardware/test_<driver>
+pio test -e steami --filter integration/test_<driver>
+```
 
 ---
 
-## Shared checks
+## Test Tier Responsibilities
 
-Common driver assertions that should hold in both native and hardware tests
-are defined in `tests/shared/driver_checks.h`.
+### 1. Native tests (`tests/native/`)
 
-These helpers provide a small, shared contract for drivers:
+Validate pure driver logic in a deterministic host environment.
 
-* `check_begin()` — verifies that the device initializes correctly
-* `check_who_am_i()` — verifies device identity via the WHO_AM_I register
-* `check_read_plausible()` — verifies that sensor readings fall within a valid range
+Typical responsibilities:
+
+* register decoding,
+* configuration writes,
+* conversion formulas,
+* API behaviour with exact mock-controlled values.
+
+These tests should be fast, deterministic, CI-friendly, and independent from
+physical hardware.
+
+### 2. Hardware unit tests (`tests/hardware/`)
+
+Validate atomic contracts on a real STeaMi board.
+
+Typical responsibilities:
+
+* `begin()` succeeds on real silicon,
+* `deviceId()` matches,
+* one measurement returns a plausible value,
+* low-level bus communication works.
+
+These tests answer:
+
+> "Does this individual driver call work correctly on the board?"
+
+They are intentionally short and fail fast.
+
+### 3. Integration tests (`tests/integration/`)
+
+Validate runtime behaviour across a longer scenario.
+
+Typical responsibilities:
+
+* repeated acquisitions over time,
+* expected output data rate,
+* sensor values remain plausible across multiple samples,
+* outputs are not frozen or stale.
+
+These tests answer:
+
+> "Does this driver still behave correctly when used continuously as intended?"
+
+Integration tests complement hardware unit tests rather than replace them.
+
+---
+
+## Shared Driver Checks
+
+Common atomic assertions used by both native and hardware unit tests are
+defined in:
+
+```text
+tests/shared/driver_checks.h
+```
+
+Current shared helpers:
+
+* `check_begin()` — device initializes correctly.
+* `check_who_am_i()` — identity register matches expected value.
+* `check_read_plausible()` — reading falls within an expected range.
 
 Usage pattern:
 
-* **Native tests** use these checks with exact, mock-controlled values
-* **Hardware tests** use the same checks with realistic plausibility ranges
+* **Native suites** use exact, mock-controlled values.
+* **Hardware unit suites** use broad plausibility windows on real hardware.
 
-This ensures both test suites exercise the same core driver behavior, while
-keeping native tests precise and hardware tests robust to real-world variation.
+This keeps the same basic driver contract validated in both environments while
+allowing each tier to use assertion ranges appropriate to its execution model.
 
-See `tests/native/test_hts221/` for a reference implementation.
+Integration tests intentionally do **not** use these helpers, because they
+validate multi-step runtime behaviour rather than single-call contracts. See
+`tests/integration/test_hts221/` for the reference shape.
 
-## Mocking Approach
+---
 
-Native tests use lightweight mocks to simulate Arduino behavior. Mocks live
-in `tests/native/helpers/` and are automatically available to every native
-test via the `[env:native]` build flag `-I tests/native/helpers`.
+## Mocking Approach (Native Only)
+
+Native tests use lightweight Arduino-compatible mocks stored in
+`tests/native/helpers/`. They are automatically included by the `[env:native]`
+PlatformIO environment.
 
 ### GPIO mock
 
-`tests/native/helpers/Arduino.h` provides:
+`Arduino.h` provides:
 
-* `pinMode(pin, mode)` records the mode into `gpioPinMode()`
-* `digitalWrite(pin, value)` records the state into `gpioPinState()`
-* `digitalRead(pin)` returns the last recorded state
-* `delay(ms)` is a no-op
+* `pinMode(pin, mode)` records the mode into `gpioPinMode()`,
+* `digitalWrite(pin, value)` records the state into `gpioPinState()`,
+* `digitalRead(pin)` returns the last recorded state,
+* `delay(ms)` is a no-op.
 
 Tests assert expected pin state by querying the two maps directly.
 
 ### I2C mock (`TwoWire`)
 
-`tests/native/helpers/Wire.h` provides a minimal host-side implementation
-of the Arduino `TwoWire` class, plus a single `inline TwoWire Wire;` global
-so drivers typed as `TwoWire&` can be passed either `Wire` or a locally
-constructed instance.
+`Wire.h` provides a minimal host-side `TwoWire` implementation, plus a single
+`inline TwoWire Wire;` global so drivers typed as `TwoWire&` can be passed
+either `Wire` or a locally constructed instance.
 
 Features:
 
-* Preload a register value on a specific address:
+* preload a register value on a specific address:
 
   ```cpp
   wire.setRegister(address, reg, value);
   ```
 
-* Simulate a register read (`beginTransmission` / `write` / `endTransmission(false)` / `requestFrom` / `read`) — backed by the preloaded values.
-* Capture every `endTransmission` that carries a register write:
+* simulate a register read (`beginTransmission` / `write` /
+  `endTransmission(false)` / `requestFrom` / `read`) backed by the preloaded
+  values.
+* capture every `endTransmission` that carries a register write:
 
   ```cpp
   const auto& writes = wire.getWrites();  // vector<WriteOp{address, reg, value}>
   wire.clearWrites();
   ```
 
-* Multi-byte reads via `requestFrom(address, quantity)` then repeated `read()`.
-* Registers are keyed by `(address, reg)`, so a single `TwoWire` instance can simulate several I2C peripherals on the same bus.
+* multi-byte reads via `requestFrom(address, quantity)` then repeated `read()`.
+* registers are keyed by `(address, reg)`, so a single `TwoWire` instance can
+  simulate several I2C peripherals on the same bus.
 
-The contract is pinned by the `tests/native/test_wire/` suite; see it for the expected invocation sequence.
+The contract is pinned by the `tests/native/test_wire/` suite; see it for the
+expected invocation sequence.
 
 ---
 
-## Example: driver test using the Wire mock
+## Example: native test using the Wire mock
 
 ```cpp
 #include <unity.h>
@@ -229,32 +262,48 @@ void test_begin_checks_who_am_i(void) {
 
 ---
 
-## Current Status
+## Writing tests for a new driver
 
-* Basic hardware test infrastructure is working
-* Native test environment with mocks is functional
-* LED mock test covers GPIO recording
-* Wire mock test pins the I2C mock contract (register preload, write capture, multi-byte reads, per-address isolation)
+When adding a new driver, the expected progression is:
 
-Future work:
+### Native tier
 
-* Add driver-specific tests (e.g. HTS221, WSEN-HIDS)
-* Extend mocks as new peripheral types need host-side coverage (SPI, PDM, etc.)
-* Increase coverage of driver APIs
+Validate configuration logic, register reads/writes, conversion helpers. Use
+`driver_checks.h` for the common contract checks where they apply.
+
+### Hardware unit tier
+
+Validate board connectivity, identity register, one plausible measurement. Use
+the same `driver_checks.h` helpers with broad plausibility windows.
+
+### Integration tier
+
+Validate continuous runtime behaviour, acquisition cadence, repeated-sample
+plausibility. Don't use `driver_checks.h` — assert time-based properties
+directly.
+
+Not every driver needs an integration suite immediately, but sensor drivers
+with continuous acquisition modes should strongly prefer one.
 
 ---
 
 ## Guidelines
 
-* Prefer testing public driver APIs (`begin()`, `deviceId()`, etc.)
-* Keep tests simple and deterministic
-* Avoid hardware dependencies in native tests
-* Use hardware tests for integration validation
+* Prefer testing public driver APIs (`begin()`, `deviceId()`, `temperature()`,
+  etc.).
+* Keep native tests deterministic.
+* Keep hardware unit tests short and fail-fast.
+* Use integration tests for time-based behavioural assertions.
+* Avoid duplicate assertions across tiers unless they validate different
+  contexts.
+* Add new mocks only when a driver cannot be meaningfully tested without them.
 
 ---
 
 ## Notes
 
-* Hardware tests require a connected STeaMi board
-* Native tests are suitable for CI environments
-* Both approaches are complementary and should be used together
+* Native tests are CI-friendly and hardware-free.
+* Hardware unit tests require a connected STeaMi board.
+* Integration tests are slower by design.
+* All three tiers are complementary and together provide the repository's
+  driver confidence model.

--- a/tests/integration/test_hts221/test_main.cpp
+++ b/tests/integration/test_hts221/test_main.cpp
@@ -53,8 +53,12 @@ void test_hts221_continuous_runtime_behavior() {
         wait_for_data_ready();
 
         timestamps[i] = millis();
-        temperatures[i] = sensor.temperature();
-        humidities[i] = sensor.humidity();
+        // Single read() call: cheaper (one I2C transaction instead of two)
+        // and guarantees both channels come from the same conversion under
+        // BDU.
+        auto reading = sensor.read();
+        temperatures[i] = reading.temperature;
+        humidities[i] = reading.humidity;
 
         TEST_ASSERT_GREATER_OR_EQUAL_FLOAT(MIN_TEMP, temperatures[i]);
         TEST_ASSERT_LESS_OR_EQUAL_FLOAT(MAX_TEMP, temperatures[i]);
@@ -78,8 +82,8 @@ void test_hts221_continuous_runtime_behavior() {
     bool all_frozen = true;
 
     for (int i = 1; i < SAMPLE_COUNT; i++) {
-        bool temp_same = fabs(temperatures[i] - temperatures[0]) < CHANGE_EPSILON;
-        bool hum_same = fabs(humidities[i] - humidities[0]) < CHANGE_EPSILON;
+        bool temp_same = fabsf(temperatures[i] - temperatures[0]) < CHANGE_EPSILON;
+        bool hum_same = fabsf(humidities[i] - humidities[0]) < CHANGE_EPSILON;
 
         if (!(temp_same && hum_same)) {
             all_frozen = false;

--- a/tests/integration/test_hts221/test_main.cpp
+++ b/tests/integration/test_hts221/test_main.cpp
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/*
+ * Integration validation for HTS221 on real STeaMi silicon.
+ *
+ * Verifies:
+ * - successful initialization,
+ * - continuous 1 Hz acquisition cadence,
+ * - plausible environmental values across time,
+ * - readings are not frozen across the full capture window.
+ */
+
+#include <Arduino.h>
+#include <HTS221.h>
+#include <Wire.h>
+#include <math.h>
+#include <unity.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+HTS221 sensor(internalI2C);
+
+static constexpr int SAMPLE_COUNT = 10;
+static constexpr float MIN_TEMP = 0.0f;
+static constexpr float MAX_TEMP = 50.0f;
+static constexpr float MIN_HUM = 10.0f;
+static constexpr float MAX_HUM = 90.0f;
+static constexpr unsigned long MIN_AVG_INTERVAL_MS = 800;
+static constexpr unsigned long MAX_AVG_INTERVAL_MS = 1300;
+static constexpr float CHANGE_EPSILON = 0.001f;
+
+float temperatures[SAMPLE_COUNT];
+float humidities[SAMPLE_COUNT];
+unsigned long timestamps[SAMPLE_COUNT];
+
+void wait_for_data_ready() {
+    unsigned long start = millis();
+
+    while (!sensor.dataReady()) {
+        if (millis() - start > 3000) {
+            TEST_FAIL_MESSAGE("Timeout waiting for HTS221 dataReady()");
+        }
+        delay(5);
+    }
+}
+
+void test_hts221_continuous_runtime_behavior() {
+    TEST_ASSERT_TRUE(sensor.begin());
+
+    sensor.setContinuous(HTS221_ODR_1_HZ);
+    delay(1200);
+
+    for (int i = 0; i < SAMPLE_COUNT; i++) {
+        wait_for_data_ready();
+
+        timestamps[i] = millis();
+        temperatures[i] = sensor.temperature();
+        humidities[i] = sensor.humidity();
+
+        TEST_ASSERT_GREATER_OR_EQUAL_FLOAT(MIN_TEMP, temperatures[i]);
+        TEST_ASSERT_LESS_OR_EQUAL_FLOAT(MAX_TEMP, temperatures[i]);
+        TEST_ASSERT_GREATER_OR_EQUAL_FLOAT(MIN_HUM, humidities[i]);
+        TEST_ASSERT_LESS_OR_EQUAL_FLOAT(MAX_HUM, humidities[i]);
+
+        delay(900);
+    }
+
+    unsigned long interval_sum = 0;
+
+    for (int i = 1; i < SAMPLE_COUNT; i++) {
+        interval_sum += timestamps[i] - timestamps[i - 1];
+    }
+
+    unsigned long average_interval = interval_sum / (SAMPLE_COUNT - 1);
+
+    TEST_ASSERT_GREATER_OR_EQUAL_UINT32(MIN_AVG_INTERVAL_MS, average_interval);
+    TEST_ASSERT_LESS_OR_EQUAL_UINT32(MAX_AVG_INTERVAL_MS, average_interval);
+
+    bool all_frozen = true;
+
+    for (int i = 1; i < SAMPLE_COUNT; i++) {
+        bool temp_same = fabs(temperatures[i] - temperatures[0]) < CHANGE_EPSILON;
+        bool hum_same = fabs(humidities[i] - humidities[0]) < CHANGE_EPSILON;
+
+        if (!(temp_same && hum_same)) {
+            all_frozen = false;
+            break;
+        }
+    }
+
+    TEST_ASSERT_FALSE_MESSAGE(all_frozen, "HTS221 readings remained frozen over all samples");
+}
+
+void setup() {
+    delay(2000);
+    internalI2C.begin();
+
+    UNITY_BEGIN();
+    RUN_TEST(test_hts221_continuous_runtime_behavior);
+    UNITY_END();
+}
+
+void loop() {}


### PR DESCRIPTION
## Summary

Introduce the level-2 / integration test tier — runtime behaviour validation on real STeaMi silicon, complementing the level-1 hardware unit tests landed in #153. Adds the Makefile scaffold, PlatformIO discovery, and HTS221 reference suite, and rewrites `tests/TESTING.md` around the now-complete three-tier model.

Closes #123

## What lands

* **`tests/integration/test_hts221/test_main.cpp`** — reference integration suite: enables continuous 1 Hz acquisition, captures 10 samples, asserts each sample is plausible, asserts the average inter-sample interval lands in `[800, 1300]` ms, and asserts not all readings are frozen (catches a stuck BDU or a never-updating register).
* **Makefile** — `test-integration-<driver>` targets generated via `foreach + eval` from `tests/integration/test_*/`, mirroring the `test-native-<name>` (#137) and `test-hardware-<name>` (#144) families. Same board-detection guard as the hardware tier (skip + exit 0 if no STeaMi attached). `make test-integration` runs them all.
* **`platformio.ini`** — extends `test_filter` for `[env:steami]` to include `integration/test_*` alongside `hardware/test_*`, so a direct `pio test -e steami` discovers both. The Makefile uses explicit `--filter` per target so `make test-hardware` and `make test-integration` stay non-overlapping.
* **`tests/TESTING.md`** — rewritten around the now-complete 3-tier model (native / hardware unit / integration), with tier responsibilities, the shared-checks pattern, and a "writing tests for a new driver" section that walks contributors through the progression.

## Why per-target instead of `driver=<name>`

The earlier shape on this branch used `make test-integration driver=<name>` plus a `test-integration-list` helper. After #137 / #144 landed in their per-target form, keeping `driver=<name>` here would re-introduce the asymmetry we explicitly factored out. Per-target generation keeps all four families uniform — `flash-<driver>/<example>` (#133), `capture-<driver>/<example>` (#138), `test-native-<name>` (#137), `test-hardware-<name>` (#144), and now `test-integration-<name>` — and gives tab-completion natively.

## Validated end-to-end on hardware

```
$ make test-integration-hts221
...
tests/integration/test_hts221/test_main.cpp:98: test_hts221_continuous_runtime_behavior  [PASSED]
1 test cases: 1 succeeded in 00:00:23.762
```

23.76 s for 10 samples at 1 Hz, with all four invariants (per-sample plausibility, average cadence, no-freeze) checked.

## Acceptance criteria (#123)

- [x] New tier directory under `tests/integration/`.
- [x] HTS221 reference suite: continuous 1 Hz, ≥10 samples, plausibility, cadence, no-freeze.
- [x] Makefile: `test-integration` (run-all) and `test-integration-<driver>` (per-suite) generated from the filesystem.
- [x] PlatformIO env discovers integration suites alongside hardware ones.
- [x] `tests/TESTING.md` documents the three-tier model and tier responsibilities.