### PR TITLE
feat(wsen-hids): Add examples.

### DIFF
--- a/lib/wsen-hids/README.md
+++ b/lib/wsen-hids/README.md
@@ -56,7 +56,10 @@ See [examples/BasicRead/](examples/BasicRead/) for the full sketch.
 
 | Example                            | What it does                                                  |
 | ---------------------------------- | ------------------------------------------------------------- |
-| [`BasicRead`](examples/BasicRead/) | Baseline sketch: print temperature and humidity every second. |
+| `BasicReader` | Baseline sketch: print temperature and humidity every second. |
+| `HumidityAlert/HumidityAlert.ino` | Trigger buzzer when humidity exceeds a threshold (mold prevention) |
+| `DewPointMonitor/DewPointMonitor.ino` | Calculate and display dew point, warn when condensation risk is high |
+| `ComfortZone/ComfortZone.ino` | Classify environment as comfortable/dry/humid using temperature-humidity chart |
 
 ### Building an example
 

--- a/lib/wsen-hids/README.md
+++ b/lib/wsen-hids/README.md
@@ -51,9 +51,12 @@ See [examples/BasicReader/](examples/BasicReader/) for the full sketch.
 
 ## Examples
 
-| Example                                | What it does                                                  |
-| -------------------------------------- | ------------------------------------------------------------- |
-| [`BasicReader`](examples/BasicReader/) | Baseline sketch: print temperature and humidity every second. |
+| Example                                        | What it does                                                                                |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| [`BasicReader`](examples/BasicReader/)         | Baseline sketch: print temperature and humidity every second.                               |
+| [`HumidityAlert`](examples/HumidityAlert/)     | Sound the on-board buzzer when humidity climbs past a mold-risk threshold.                  |
+| [`DewPointMonitor`](examples/DewPointMonitor/) | Compute the dew point from T and RH, warn when condensation risk is high (T − Td < 2 °C).   |
+| [`ComfortZone`](examples/ComfortZone/)         | Classify the room as comfortable / too dry / too humid / too cold / too hot.                |
 
 ### Building an example
 

--- a/lib/wsen-hids/examples/ComfortZone/ComfortZone.ino
+++ b/lib/wsen-hids/examples/ComfortZone/ComfortZone.ino
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <Wire.h>
+#include <WsenHids.h>
+#include <WsenHids_const.h>
+
+TwoWire internalWire(I2C_INT_SDA, I2C_INT_SCL);
+WsenHids hids(internalWire, WsenHids::DEFAULT_ADDRESS);
+
+const char* classifyComfort(float temperature, float humidity) {
+    if (temperature < 18.0F) {
+        return "Too cold";
+    }
+
+    if (temperature > 26.0F) {
+        return "Too hot";
+    }
+
+    if (humidity < 30.0F) {
+        return "Too dry";
+    }
+
+    if (humidity > 65.0F) {
+        return "Too humid";
+    }
+
+    return "Comfortable";
+}
+
+void setup() {
+    Serial.begin(115200);
+    internalWire.begin();
+
+    if (!hids.begin()) {
+        Serial.println("WSEN-HIDS not detected");
+        while (true) {
+            delay(1000);
+        }
+    }
+
+    hids.setContinuous(WsenHidsConst::ODR_1HZ);
+    Serial.println("Comfort zone monitor started");
+}
+
+void loop() {
+    if (hids.dataReady()) {
+        float temperature = hids.temperature();
+        float humidity = hids.humidity();
+
+        Serial.print("Temperature: ");
+        Serial.print(temperature);
+        Serial.print(" C | Humidity: ");
+        Serial.print(humidity);
+        Serial.print(" % -> ");
+        Serial.println(classifyComfort(temperature, humidity));
+    }
+
+    delay(500);
+}

--- a/lib/wsen-hids/examples/ComfortZone/ComfortZone.ino
+++ b/lib/wsen-hids/examples/ComfortZone/ComfortZone.ino
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// ComfortZone — classify the room as comfortable / too dry / too humid /
+// too cold / too hot based on the temperature-humidity chart taught in
+// most building-physics courses.
+//
+// Thresholds picked for indoor comfort in temperate climates:
+//   T  in [18 °C, 26 °C]
+//   RH in [30 %, 65 %]
+// Anything outside these bounds is flagged with a textual label.
+//
+// The WSEN-HIDS sits on the STeaMi internal I2C bus. Flash and open the
+// serial monitor at 115200 baud.
+
+#include <Arduino.h>
+#include <Wire.h>
+#include <WsenHids.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+WsenHids sensor(internalI2C);
+
+const char* classifyComfort(float temperature, float humidity) {
+    if (temperature < 18.0f) {
+        return "Too cold";
+    }
+    if (temperature > 26.0f) {
+        return "Too hot";
+    }
+    if (humidity < 30.0f) {
+        return "Too dry";
+    }
+    if (humidity > 65.0f) {
+        return "Too humid";
+    }
+    return "Comfortable";
+}
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial && millis() < 2000) {
+        // Wait up to 2 s for a connected monitor.
+    }
+
+    internalI2C.begin();
+
+    if (!sensor.begin()) {
+        Serial.println("WSEN-HIDS not detected — check wiring and I2C address.");
+        while (true) {
+            delay(1000);
+        }
+    }
+
+    sensor.setContinuous(WSEN_HIDS_ODR_1_HZ);
+    Serial.println("Comfort zone monitor started.");
+}
+
+void loop() {
+    if (!sensor.dataReady()) {
+        delay(10);
+        return;
+    }
+
+    auto reading = sensor.read();
+
+    Serial.print("T = ");
+    Serial.print(reading.temperature, 2);
+    Serial.print(" C  |  H = ");
+    Serial.print(reading.humidity, 1);
+    Serial.print(" %  ->  ");
+    Serial.println(classifyComfort(reading.temperature, reading.humidity));
+}

--- a/lib/wsen-hids/examples/ComfortZone/ComfortZone.ino
+++ b/lib/wsen-hids/examples/ComfortZone/ComfortZone.ino
@@ -68,4 +68,8 @@ void loop() {
     Serial.print(reading.humidity, 1);
     Serial.print(" %  ->  ");
     Serial.println(classifyComfort(reading.temperature, reading.humidity));
+
+    // Wait for the next 1 Hz sample. The 10 ms poll above only kicks in
+    // for the last fraction of a second before the next dataReady flag.
+    delay(1000);
 }

--- a/lib/wsen-hids/examples/DewPointMonitor/DewPointMonitor.ino
+++ b/lib/wsen-hids/examples/DewPointMonitor/DewPointMonitor.ino
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <Wire.h>
+#include <WsenHids.h>
+#include <WsenHids_const.h>
+#include <math.h>
+
+TwoWire internalWire(I2C_INT_SDA, I2C_INT_SCL);
+WsenHids hids(internalWire, WsenHids::DEFAULT_ADDRESS);
+
+float computeDewPoint(float temperature, float humidity) {
+    constexpr float A = 17.27F;
+    constexpr float B = 237.7F;
+
+    float gamma = ((A * temperature) / (B + temperature)) + log(humidity / 100.0F);
+    return (B * gamma) / (A - gamma);
+}
+
+void setup() {
+    Serial.begin(115200);
+    internalWire.begin();
+
+    if (!hids.begin()) {
+        Serial.println("WSEN-HIDS not detected");
+        while (true) {
+            delay(1000);
+        }
+    }
+
+    hids.setContinuous(WsenHidsConst::ODR_1HZ);
+    Serial.println("Dew point monitor started");
+}
+
+void loop() {
+    if (hids.dataReady()) {
+        float temperature = hids.temperature();
+        float humidity = hids.humidity();
+        float dewPoint = computeDewPoint(temperature, humidity);
+
+        Serial.print("Temperature: ");
+        Serial.print(temperature);
+        Serial.print(" C | Humidity: ");
+        Serial.print(humidity);
+        Serial.print(" % | Dew point: ");
+        Serial.print(dewPoint);
+        Serial.println(" C");
+
+        if ((temperature - dewPoint) < 2.0F) {
+            Serial.println("Condensation risk is high");
+            tone(SPEAKER, 2000, 150);
+        }
+    }
+
+    delay(500);
+}

--- a/lib/wsen-hids/examples/DewPointMonitor/DewPointMonitor.ino
+++ b/lib/wsen-hids/examples/DewPointMonitor/DewPointMonitor.ino
@@ -70,4 +70,8 @@ void loop() {
         Serial.println("Condensation risk is high.");
         tone(SPEAKER, 2000, 150);
     }
+
+    // Wait for the next 1 Hz sample. The 10 ms poll above only kicks in
+    // for the last fraction of a second before the next dataReady flag.
+    delay(1000);
 }

--- a/lib/wsen-hids/examples/DewPointMonitor/DewPointMonitor.ino
+++ b/lib/wsen-hids/examples/DewPointMonitor/DewPointMonitor.ino
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// DewPointMonitor — compute the dew point from temperature and humidity,
+// and warn when condensation risk becomes high (T − Td < 2 °C).
+//
+// Uses the Magnus-Tetens approximation:
+//   γ(T, RH) = (a·T) / (b + T) + ln(RH / 100)
+//   Td      = (b·γ) / (a − γ)        with a = 17.27, b = 237.7 (°C)
+//
+// The WSEN-HIDS sits on the STeaMi internal I2C bus. Flash and open the
+// serial monitor at 115200 baud.
+
+#include <Arduino.h>
+#include <Wire.h>
+#include <WsenHids.h>
+#include <math.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+WsenHids sensor(internalI2C);
+
+float computeDewPoint(float temperature, float humidity) {
+    constexpr float A = 17.27f;
+    constexpr float B = 237.7f;
+    constexpr float MIN_HUMIDITY = 0.001f;
+
+    // logf() argument must be strictly positive — clamp dry-sensor readings.
+    float safeHumidity = fmaxf(humidity, MIN_HUMIDITY);
+
+    float gamma = ((A * temperature) / (B + temperature)) + logf(safeHumidity / 100.0f);
+    return (B * gamma) / (A - gamma);
+}
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial && millis() < 2000) {
+        // Wait up to 2 s for a connected monitor.
+    }
+
+    internalI2C.begin();
+
+    if (!sensor.begin()) {
+        Serial.println("WSEN-HIDS not detected — check wiring and I2C address.");
+        while (true) {
+            delay(1000);
+        }
+    }
+
+    sensor.setContinuous(WSEN_HIDS_ODR_1_HZ);
+    Serial.println("Dew point monitor started.");
+}
+
+void loop() {
+    if (!sensor.dataReady()) {
+        delay(10);
+        return;
+    }
+
+    auto reading = sensor.read();
+    float dewPoint = computeDewPoint(reading.temperature, reading.humidity);
+
+    Serial.print("T = ");
+    Serial.print(reading.temperature, 2);
+    Serial.print(" C  |  H = ");
+    Serial.print(reading.humidity, 1);
+    Serial.print(" %  |  Td = ");
+    Serial.print(dewPoint, 2);
+    Serial.println(" C");
+
+    if ((reading.temperature - dewPoint) < 2.0f) {
+        Serial.println("Condensation risk is high.");
+        tone(SPEAKER, 2000, 150);
+    }
+}

--- a/lib/wsen-hids/examples/HumidityAlert/HumidityAlert.ino
+++ b/lib/wsen-hids/examples/HumidityAlert/HumidityAlert.ino
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <Wire.h>
+#include <WsenHids.h>
+#include <WsenHids_const.h>
+
+TwoWire internalWire(I2C_INT_SDA, I2C_INT_SCL);
+WsenHids hids(internalWire, WsenHids::DEFAULT_ADDRESS);
+
+constexpr float HUMIDITY_THRESHOLD = 70.0F;
+
+void buzzAlert() {
+    tone(SPEAKER, 1500, 200);
+    delay(300);
+    tone(SPEAKER, 1500, 200);
+}
+
+void setup() {
+    Serial.begin(115200);
+    internalWire.begin();
+
+    if (!hids.begin()) {
+        Serial.println("WSEN-HIDS not detected");
+        while (true) {
+            delay(1000);
+        }
+    }
+
+    hids.setContinuous(WsenHidsConst::ODR_1HZ);
+    Serial.println("Humidity alert started");
+}
+
+void loop() {
+    if (hids.dataReady()) {
+        float temperature = hids.temperature();
+        float humidity = hids.humidity();
+
+        Serial.print("Temperature: ");
+        Serial.print(temperature);
+        Serial.print(" C | Humidity: ");
+        Serial.print(humidity);
+        Serial.println(" %");
+
+        if (humidity > HUMIDITY_THRESHOLD) {
+            Serial.println("Warning: humidity too high (mold risk)");
+            buzzAlert();
+        }
+    }
+
+    delay(250);
+}

--- a/lib/wsen-hids/examples/HumidityAlert/HumidityAlert.ino
+++ b/lib/wsen-hids/examples/HumidityAlert/HumidityAlert.ino
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// HumidityAlert — sound the on-board buzzer when ambient humidity climbs
+// past a mold-risk threshold.
+//
+// The WSEN-HIDS sits on the STeaMi internal I2C bus, so spin up a
+// dedicated TwoWire pointed at the variant pin macros and hand it to the
+// driver. Open the serial monitor at 115200 baud to see the live readings.
+
+#include <Arduino.h>
+#include <Wire.h>
+#include <WsenHids.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+WsenHids sensor(internalI2C);
+
+constexpr float HUMIDITY_THRESHOLD = 70.0f;  // %RH — mold risk above this
+
+void buzzAlert() {
+    tone(SPEAKER, 1500, 200);
+    delay(300);
+    tone(SPEAKER, 1500, 200);
+}
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial && millis() < 2000) {
+        // Wait up to 2 s for a connected monitor — on the STeaMi USB CDC
+        // !Serial stays true until the host enumerates.
+    }
+
+    internalI2C.begin();
+
+    if (!sensor.begin()) {
+        Serial.println("WSEN-HIDS not detected — check wiring and I2C address.");
+        while (true) {
+            delay(1000);
+        }
+    }
+
+    sensor.setContinuous(WSEN_HIDS_ODR_1_HZ);
+    Serial.println("Humidity alert started.");
+}
+
+void loop() {
+    if (!sensor.dataReady()) {
+        delay(10);
+        return;
+    }
+
+    auto reading = sensor.read();
+
+    Serial.print("T = ");
+    Serial.print(reading.temperature, 2);
+    Serial.print(" C  |  H = ");
+    Serial.print(reading.humidity, 1);
+    Serial.println(" %");
+
+    if (reading.humidity > HUMIDITY_THRESHOLD) {
+        Serial.println("Warning: humidity too high (mold risk).");
+        buzzAlert();
+    }
+}

--- a/lib/wsen-hids/examples/HumidityAlert/HumidityAlert.ino
+++ b/lib/wsen-hids/examples/HumidityAlert/HumidityAlert.ino
@@ -60,4 +60,8 @@ void loop() {
         Serial.println("Warning: humidity too high (mold risk).");
         buzzAlert();
     }
+
+    // Wait for the next 1 Hz sample. The 10 ms poll above only kicks in
+    // for the last fraction of a second before the next dataReady flag.
+    delay(1000);
 }


### PR DESCRIPTION
## Summary

Adds multiple standalone real-world Arduino example sketches for the WSEN-HIDS humidity and temperature sensor driver, covering environmental alerting, condensation monitoring, and comfort classification scenarios. Closes #158.

The DAPLink-backed persistent logging example has been split into a dedicated follow-up issue: relates to #159.

Depens on #131 

## Changes

* Added `HumidityAlert` example:

  * continuously monitors ambient humidity
  * triggers the onboard buzzer when humidity exceeds a mold-risk threshold
* Added `DewPointMonitor` example:

  * computes dew point from temperature and relative humidity
  * warns when condensation risk becomes high
* Added `ComfortZone` example:

  * classifies the room as comfortable / too dry / too humid / too cold / too hot
* Kept `BasicReader` as the baseline serial environmental readout example
* Updated `README.md` example table and usage documentation to reference the new sketches
* Deferred `HumidityLogger` persistent flash logging example to follow-up DAPLink integration issue #159

## Checklist

* [x] `make lint` passes (clang-format)
* [x] `make build` passes (PlatformIO)
* [ ] `make test-native` passes (if native tests exist)
* [ ] `make test-hardware` passes on a connected STeaMi (if hardware tests exist)
* [x] README updated (if adding/changing public API)
* [x] Examples added/updated (if applicable)
* [x] Commit messages follow conventional commits format
