### PR TITLE
Feat/daplink bridge driver

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -16,6 +16,7 @@ module.exports = {
         'apds9960',
         'bme280',
         'bq27441',
+        'daplink_bridge',
         'daplink_flash',
         'gc9a01',
         'hts221',

--- a/lib/daplink_bridge/README.md
+++ b/lib/daplink_bridge/README.md
@@ -1,0 +1,96 @@
+# DAPLink Bridge
+
+Arduino/C++ driver for the STM32F103 DAPLink I2C bridge on the STeaMi
+board.
+
+## Hardware
+
+* I2C device, default 7-bit address `0x3B` (the same chip is referred to
+  as `0x76` in 8-bit format in the CODAL convention).
+* Provides access to a 1 KB persistent config zone backed by the F103
+  internal flash. The bridge protocol uses small frames (`CMD | offset |
+  length | payload`) so any single transfer fits in the default Arduino
+  Wire receive buffer.
+* Exposed only on the STeaMi **internal** I2C bus, not the default
+  global `Wire`.
+
+## Quick start
+
+```cpp
+#include <Wire.h>
+#include <DaplinkBridge.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+DaplinkBridge bridge(internalI2C);
+
+void setup() {
+    Serial.begin(115200);
+    internalI2C.begin();
+
+    if (!bridge.begin()) {
+        Serial.println("DAPLink bridge not detected");
+        while (true) delay(1000);
+    }
+
+    bridge.clearConfig();
+    bridge.writeConfig("hello");
+
+    uint8_t buf[64];
+    size_t len = bridge.readConfig(buf, sizeof(buf));
+    Serial.write(buf, len);
+    Serial.println();
+}
+```
+
+## API
+
+### Lifecycle
+
+| Method | Description |
+|--------|-------------|
+| `DaplinkBridge(TwoWire& wire = Wire, uint8_t address = DAPLINK_BRIDGE_DEFAULT_ADDR)` | Construct. Defaults to the global `Wire` and address `0x3B`. |
+| `bool begin()` | Probe the bridge by checking WHO_AM_I. Returns `false` if the device is not present or the identity register doesn't match. |
+| `uint8_t deviceId()` | Read the WHO_AM_I register (always `0x4C`). |
+
+### Status
+
+| Method | Description |
+|--------|-------------|
+| `bool busy()` | Read `STATUS.BUSY`. The bridge is busy while erasing or writing flash. |
+
+### Config zone
+
+A 1 KB block (`DAPLINK_BRIDGE_CONFIG_SIZE`) of persistent storage in
+the F103 internal flash. Sentinel value for unused bytes is `0xFF`,
+matching the erased-flash state.
+
+| Method | Description |
+|--------|-------------|
+| `bool clearConfig()` | Erase the entire 1 KB config zone. Waits for the busy bit to clear and returns `false` if the device reports an error. |
+| `bool writeConfig(const uint8_t* data, size_t length, uint16_t offset = 0)` | Write raw bytes to the zone starting at `offset`. The driver chunks the payload into frames of at most `DAPLINK_BRIDGE_MAX_WRITE_CHUNK` bytes and waits for the busy bit between chunks. Returns `false` if the range overflows the zone or the device reports an error. |
+| `bool writeConfig(const char* str, uint16_t offset = 0)` | Convenience overload for null-terminated strings. |
+| `size_t readConfig(uint8_t* result, size_t maxLen)` | Read up to `maxLen` bytes, stopping at the first `0xFF` (end-of-data sentinel) or when the buffer is full. Returns the number of bytes copied. |
+
+## Register constants
+
+`daplink_bridge_const.h` exports command codes (`DAPLINK_BRIDGE_CMD_*`),
+register addresses (`DAPLINK_BRIDGE_REG_*`), status / error bits, the
+`DAPLINK_BRIDGE_CONFIG_SIZE` constant, and the protocol's chunk-size and
+timeout limits. Applications can reach for them if they need something
+outside the driver's API surface.
+
+## Testing
+
+Host-side unit tests under
+[`tests/native/test_daplink_bridge/`](../../tests/native/test_daplink_bridge/)
+exercise the driver against the `TwoWire` mock and the shared
+[`driver_checks.h`](../../tests/shared/driver_checks.h) helpers. Run them
+without hardware with:
+
+```bash
+make test-native/daplink_bridge
+```
+
+## License
+
+GPL-3.0-or-later — see [LICENSE](../../LICENSE).

--- a/lib/daplink_bridge/library.properties
+++ b/lib/daplink_bridge/library.properties
@@ -1,0 +1,10 @@
+name=STeaMi DAPLink Bridge
+version=1.0.0
+author=STeaMi contributors
+maintainer=STeaMi contributors
+sentence=DAPLink I2C bridge driver for the STeaMi board.
+paragraph=Arduino-compatible low-level driver for the STM32F103 DAPLink chip's I2C bridge. Exposes WHO_AM_I detection, busy/error polling, and read/write/clear access to the 1 KB persistent config zone in the F103 internal flash. Used as a base by daplink_flash and daplink_config (and any future driver that needs to talk to the DAPLink chip).
+category=Communication
+url=https://github.com/steamicc/arduino-steami-lib
+architectures=*
+includes=DaplinkBridge.h

--- a/lib/daplink_bridge/src/DaplinkBridge.cpp
+++ b/lib/daplink_bridge/src/DaplinkBridge.cpp
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include "DaplinkBridge.h"
+
+#include <string.h>
+
+#include <algorithm>
+
+DaplinkBridge::DaplinkBridge(TwoWire& wire, uint8_t address) : _wire(&wire), _address(address) {}
+
+// ---------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------
+
+bool DaplinkBridge::begin() {
+    if (!isPresent()) {
+        return false;
+    }
+    return deviceId() == DAPLINK_BRIDGE_WHO_AM_I;
+}
+
+uint8_t DaplinkBridge::deviceId() {
+    return readReg(DAPLINK_BRIDGE_CMD_WHO_AM_I);
+}
+
+// ---------------------------------------------------------------------
+// Status
+// ---------------------------------------------------------------------
+
+bool DaplinkBridge::busy() {
+    return (status() & DAPLINK_BRIDGE_STATUS_BUSY) != 0;
+}
+
+// ---------------------------------------------------------------------
+// Config zone
+// ---------------------------------------------------------------------
+
+bool DaplinkBridge::clearConfig() {
+    if (!waitNotBusy(DAPLINK_BRIDGE_WRITE_TIMEOUT_MS)) {
+        return false;
+    }
+    uint8_t cmd = DAPLINK_BRIDGE_CMD_CLEAR_CONFIG;
+    writeFrame(&cmd, 1);
+    if (!waitNotBusy(DAPLINK_BRIDGE_CLEAR_TIMEOUT_MS)) {
+        return false;
+    }
+    return error() == 0;
+}
+
+bool DaplinkBridge::writeConfig(const uint8_t* data, size_t length, uint16_t offset) {
+    if (length == 0) {
+        return true;
+    }
+    if (offset >= DAPLINK_BRIDGE_CONFIG_SIZE || length > DAPLINK_BRIDGE_CONFIG_SIZE - offset) {
+        return false;
+    }
+
+    // Frame layout: [CMD | offsetHi | offsetLo | chunkLen | payload...]
+    constexpr size_t kHeaderLen = 4;
+    uint8_t buf[kHeaderLen + DAPLINK_BRIDGE_MAX_WRITE_CHUNK];
+
+    size_t pos = 0;
+    while (pos < length) {
+        if (!waitNotBusy(DAPLINK_BRIDGE_WRITE_TIMEOUT_MS)) {
+            return false;
+        }
+        const size_t remaining = length - pos;
+        const uint8_t chunkLen =
+            static_cast<uint8_t>(std::min<size_t>(DAPLINK_BRIDGE_MAX_WRITE_CHUNK, remaining));
+        const uint16_t curOffset = static_cast<uint16_t>(offset + pos);
+
+        buf[0] = DAPLINK_BRIDGE_CMD_WRITE_CONFIG;
+        buf[1] = static_cast<uint8_t>((curOffset >> 8) & 0xFF);
+        buf[2] = static_cast<uint8_t>(curOffset & 0xFF);
+        buf[3] = chunkLen;
+        memcpy(&buf[kHeaderLen], &data[pos], chunkLen);
+
+        writeFrame(buf, kHeaderLen + chunkLen);
+        pos += chunkLen;
+    }
+
+    if (!waitNotBusy(DAPLINK_BRIDGE_WRITE_TIMEOUT_MS)) {
+        return false;
+    }
+    return error() == 0;
+}
+
+bool DaplinkBridge::writeConfig(const char* str, uint16_t offset) {
+    if (str == nullptr) {
+        return false;
+    }
+    return writeConfig(reinterpret_cast<const uint8_t*>(str), strlen(str), offset);
+}
+
+size_t DaplinkBridge::readConfig(uint8_t* result, size_t maxLen) {
+    if (result == nullptr || maxLen == 0) {
+        return 0;
+    }
+
+    size_t produced = 0;
+    while (produced < maxLen) {
+        if (!waitNotBusy(DAPLINK_BRIDGE_READ_TIMEOUT_MS)) {
+            return produced;
+        }
+
+        uint8_t chunk[DAPLINK_BRIDGE_MAX_READ_CHUNK];
+        const uint8_t want = static_cast<uint8_t>(
+            std::min<size_t>(DAPLINK_BRIDGE_MAX_READ_CHUNK, maxLen - produced));
+        readBlock(DAPLINK_BRIDGE_CMD_READ_CONFIG, chunk, want);
+
+        for (uint8_t i = 0; i < want; ++i) {
+            // 0xFF marks the first unused byte in the config zone — treat
+            // it as end-of-string and stop returning data to the caller.
+            if (chunk[i] == 0xFF) {
+                return produced;
+            }
+            result[produced++] = chunk[i];
+            if (produced == maxLen) {
+                return produced;
+            }
+        }
+    }
+    return produced;
+}
+
+// ---------------------------------------------------------------------
+// I2C helpers
+// ---------------------------------------------------------------------
+
+bool DaplinkBridge::isPresent() {
+    _wire->beginTransmission(_address);
+    return _wire->endTransmission() == 0;
+}
+
+uint8_t DaplinkBridge::readReg(uint8_t reg) {
+    _wire->beginTransmission(_address);
+    _wire->write(reg);
+    _wire->endTransmission(false);
+    _wire->requestFrom(_address, static_cast<uint8_t>(1));
+    if (_wire->available()) {
+        return static_cast<uint8_t>(_wire->read());
+    }
+    return 0;
+}
+
+void DaplinkBridge::readBlock(uint8_t reg, uint8_t* buf, uint8_t len) {
+    for (uint8_t i = 0; i < len; ++i) {
+        buf[i] = 0;
+    }
+    _wire->beginTransmission(_address);
+    _wire->write(reg);
+    _wire->endTransmission(false);
+    _wire->requestFrom(_address, len);
+    for (uint8_t i = 0; i < len && _wire->available(); ++i) {
+        buf[i] = static_cast<uint8_t>(_wire->read());
+    }
+}
+
+void DaplinkBridge::writeFrame(const uint8_t* data, size_t len) {
+    _wire->beginTransmission(_address);
+    for (size_t i = 0; i < len; ++i) {
+        _wire->write(data[i]);
+    }
+    _wire->endTransmission();
+}
+
+// ---------------------------------------------------------------------
+// Status / error
+// ---------------------------------------------------------------------
+
+uint8_t DaplinkBridge::status() {
+    return readReg(DAPLINK_BRIDGE_REG_STATUS);
+}
+
+uint8_t DaplinkBridge::error() {
+    return readReg(DAPLINK_BRIDGE_REG_ERROR);
+}
+
+bool DaplinkBridge::waitNotBusy(uint32_t timeoutMs) {
+    const uint32_t start = millis();
+    while (busy()) {
+        if ((millis() - start) > timeoutMs) {
+            return false;
+        }
+        delay(2);
+    }
+    return true;
+}

--- a/lib/daplink_bridge/src/DaplinkBridge.h
+++ b/lib/daplink_bridge/src/DaplinkBridge.h
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include <Arduino.h>
+#include <Wire.h>
+
+#include "daplink_bridge_const.h"
+
+class DaplinkBridge {
+   public:
+    DaplinkBridge(TwoWire& wire = Wire, uint8_t address = DAPLINK_BRIDGE_DEFAULT_ADDR);
+
+    // --- Lifecycle ---
+    bool begin();
+    uint8_t deviceId();
+
+    // --- Status ---
+    bool busy();
+
+    // --- Config zone (1 KB persistent storage in F103 internal flash) ---
+    bool clearConfig();
+    bool writeConfig(const uint8_t* data, size_t length, uint16_t offset = 0);
+    bool writeConfig(const char* str, uint16_t offset = 0);
+    size_t readConfig(uint8_t* result, size_t maxLen);
+
+   private:
+    TwoWire* _wire;
+    uint8_t _address;
+
+    // I2C helpers
+    bool isPresent();
+    uint8_t readReg(uint8_t reg);
+    void readBlock(uint8_t reg, uint8_t* buf, uint8_t len);
+    void writeFrame(const uint8_t* data, size_t len);
+
+    // Status / error
+    uint8_t status();
+    uint8_t error();
+    bool waitNotBusy(uint32_t timeoutMs);
+};

--- a/lib/daplink_bridge/src/daplink_bridge_const.h
+++ b/lib/daplink_bridge/src/daplink_bridge_const.h
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+#include <stdint.h>
+
+// ============================================================================
+// I2C addressing
+// ============================================================================
+
+// 7-bit I2C address. The DAPLink chip uses 0x76 in 8-bit format (CODAL
+// convention), which is 0x3B in 7-bit.
+constexpr uint8_t DAPLINK_BRIDGE_DEFAULT_ADDR = 0x3B;
+
+// Expected WHO_AM_I value.
+constexpr uint8_t DAPLINK_BRIDGE_WHO_AM_I = 0x4C;
+
+// ============================================================================
+// Command codes
+// ============================================================================
+
+constexpr uint8_t DAPLINK_BRIDGE_CMD_WHO_AM_I = 0x01;
+constexpr uint8_t DAPLINK_BRIDGE_CMD_WRITE_CONFIG = 0x30;
+constexpr uint8_t DAPLINK_BRIDGE_CMD_READ_CONFIG = 0x31;
+constexpr uint8_t DAPLINK_BRIDGE_CMD_CLEAR_CONFIG = 0x32;
+
+// ============================================================================
+// Status / error register addresses
+// ============================================================================
+
+constexpr uint8_t DAPLINK_BRIDGE_REG_STATUS = 0x80;
+constexpr uint8_t DAPLINK_BRIDGE_REG_ERROR = 0x81;
+
+// ============================================================================
+// Status register bits
+// ============================================================================
+
+constexpr uint8_t DAPLINK_BRIDGE_STATUS_BUSY = 0x80;
+
+// ============================================================================
+// Error register bits
+// ============================================================================
+
+constexpr uint8_t DAPLINK_BRIDGE_ERROR_BAD_PARAM = 0x01;
+constexpr uint8_t DAPLINK_BRIDGE_ERROR_CMD_FAILED = 0x80;
+
+// ============================================================================
+// Protocol limits
+// ============================================================================
+
+// Maximum payload bytes per WRITE_CONFIG frame. The bridge accepts
+// `CMD + 2-byte offset + 1-byte length + payload` and the F103 buffers
+// it up to ~32 bytes; 30 leaves headroom for the 4-byte header.
+constexpr uint8_t DAPLINK_BRIDGE_MAX_WRITE_CHUNK = 30;
+
+// Maximum payload bytes per READ_CONFIG frame. Arduino Wire's default
+// receive buffer is 32 bytes, so we cap reads at 16 to leave room for
+// future protocol extensions and to keep latency predictable.
+constexpr uint8_t DAPLINK_BRIDGE_MAX_READ_CHUNK = 16;
+
+// 1 KB persistent config zone (in F103 internal flash).
+constexpr uint16_t DAPLINK_BRIDGE_CONFIG_SIZE = 1024;
+
+// ============================================================================
+// Timing helpers
+// ============================================================================
+
+// Worst-case erase of the 1 KB config zone in the F103 flash.
+constexpr uint32_t DAPLINK_BRIDGE_CLEAR_TIMEOUT_MS = 1000;
+
+// Worst-case write of one chunk into flash.
+constexpr uint32_t DAPLINK_BRIDGE_WRITE_TIMEOUT_MS = 100;
+
+// Worst-case read latency.
+constexpr uint32_t DAPLINK_BRIDGE_READ_TIMEOUT_MS = 50;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 // lib/<component>/examples/ for driver usage.
 
 #include <Arduino.h>
+#include <DaplinkBridge.h>
 #include <HTS221.h>
 #include <WSEN_PADS.h>
 #include <Wire.h>
@@ -24,6 +25,7 @@ TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
 
 HTS221 hts221(internalI2C);
 WSEN_PADS wsen_pads(internalI2C);
+DaplinkBridge daplink_bridge(internalI2C);
 
 void setup() {
     Serial.begin(115200);
@@ -65,6 +67,14 @@ void setup() {
         Serial.println(" C");
     } else {
         Serial.println("WSEN-PADS not detected");
+    }
+
+    // --- DAPLink bridge (I2C-to-flash protocol on the on-board F103) ---
+    if (daplink_bridge.begin()) {
+        Serial.print("DAPLink bridge detected, WHO_AM_I = 0x");
+        Serial.println(daplink_bridge.deviceId(), HEX);
+    } else {
+        Serial.println("DAPLink bridge not detected");
     }
 }
 

--- a/tests/native/test_daplink_bridge/test_main.cpp
+++ b/tests/native/test_daplink_bridge/test_main.cpp
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <unity.h>
+
+#include <cstring>
+
+#include "DaplinkBridge.h"
+#include "Wire.h"
+#include "driver_checks.h"
+
+constexpr uint8_t ADDR = DAPLINK_BRIDGE_DEFAULT_ADDR;
+
+static void preloadDeviceId(bool valid = true) {
+    Wire.setRegister(ADDR, DAPLINK_BRIDGE_CMD_WHO_AM_I, valid ? DAPLINK_BRIDGE_WHO_AM_I : 0x42);
+}
+
+static void preloadStatus(bool busy) {
+    Wire.setRegister(ADDR, DAPLINK_BRIDGE_REG_STATUS, busy ? DAPLINK_BRIDGE_STATUS_BUSY : 0x00);
+}
+
+static void preloadError(uint8_t value) {
+    Wire.setRegister(ADDR, DAPLINK_BRIDGE_REG_ERROR, value);
+}
+
+DaplinkBridge bridge;
+
+void setUp(void) {
+    Wire = TwoWire();
+    preloadDeviceId();
+    preloadStatus(false);
+    preloadError(0);
+    bridge = DaplinkBridge();
+}
+
+void tearDown(void) {}
+
+void test_begin_detects_device(void) {
+    check_begin(bridge);
+}
+
+void test_begin_rejects_wrong_who_am_i(void) {
+    preloadDeviceId(false);
+    TEST_ASSERT_FALSE(bridge.begin());
+}
+
+void test_device_id_returns_who_am_i(void) {
+    check_who_am_i(bridge, DAPLINK_BRIDGE_WHO_AM_I);
+}
+
+void test_busy_reflects_status_register(void) {
+    preloadStatus(true);
+    TEST_ASSERT_TRUE(bridge.busy());
+
+    preloadStatus(false);
+    TEST_ASSERT_FALSE(bridge.busy());
+}
+
+void test_clear_config_returns_true_on_no_error(void) {
+    // The Wire mock only records writes whose transmission carries a
+    // payload byte (reg + value). A single-byte command write (just
+    // `[CMD_CLEAR_CONFIG]`) leaves no entry in getWrites(), so we
+    // exercise the negative path (test below) to prove the driver
+    // really sends the command and reads back the error register.
+    bridge.begin();
+    TEST_ASSERT_TRUE(bridge.clearConfig());
+}
+
+void test_clear_config_returns_false_on_device_error(void) {
+    bridge.begin();
+    preloadError(DAPLINK_BRIDGE_ERROR_CMD_FAILED);
+    TEST_ASSERT_FALSE(bridge.clearConfig());
+}
+
+void test_write_config_rejects_offset_at_or_past_end(void) {
+    bridge.begin();
+    const uint8_t payload[1] = {0x42};
+    TEST_ASSERT_FALSE(bridge.writeConfig(payload, 1, DAPLINK_BRIDGE_CONFIG_SIZE));
+}
+
+void test_write_config_rejects_payload_overflowing_zone(void) {
+    bridge.begin();
+    const uint8_t payload[2] = {0x01, 0x02};
+    // Last valid offset is CONFIG_SIZE - 1; writing 2 bytes there overflows.
+    TEST_ASSERT_FALSE(
+        bridge.writeConfig(payload, 2, static_cast<uint16_t>(DAPLINK_BRIDGE_CONFIG_SIZE - 1)));
+}
+
+void test_write_config_writes_framed_payload(void) {
+    bridge.begin();
+    Wire.clearWrites();
+
+    const char* payload = "hello";
+    TEST_ASSERT_TRUE(bridge.writeConfig(payload, 0));
+
+    // The frame is `[CMD_WRITE_CONFIG, off_hi, off_lo, len, h, e, l, l, o]`.
+    // The Wire mock treats the first byte as the register address and
+    // records one WriteOp per subsequent byte (so 8 entries for a 9-byte
+    // frame).
+    const auto& writes = Wire.getWrites();
+    TEST_ASSERT_EQUAL_INT(8, writes.size());
+    TEST_ASSERT_EQUAL_HEX8(0x00, writes[0].value);  // offset hi
+    TEST_ASSERT_EQUAL_HEX8(0x00, writes[1].value);  // offset lo
+    TEST_ASSERT_EQUAL_HEX8(0x05, writes[2].value);  // chunk length
+    TEST_ASSERT_EQUAL_HEX8('h', writes[3].value);
+    TEST_ASSERT_EQUAL_HEX8('e', writes[4].value);
+    TEST_ASSERT_EQUAL_HEX8('l', writes[5].value);
+    TEST_ASSERT_EQUAL_HEX8('l', writes[6].value);
+    TEST_ASSERT_EQUAL_HEX8('o', writes[7].value);
+}
+
+void test_write_config_chunked_when_payload_exceeds_max_chunk(void) {
+    bridge.begin();
+    Wire.clearWrites();
+
+    constexpr size_t kPayloadLen = DAPLINK_BRIDGE_MAX_WRITE_CHUNK + 5;
+    uint8_t payload[kPayloadLen];
+    for (size_t i = 0; i < kPayloadLen; ++i) {
+        payload[i] = static_cast<uint8_t>(i & 0xFF);
+    }
+    TEST_ASSERT_TRUE(bridge.writeConfig(payload, kPayloadLen, 0));
+
+    // Two frames: one MAX_WRITE_CHUNK long, one 5 bytes long.
+    int chunkLengthsSeen = 0;
+    for (const auto& w : Wire.getWrites()) {
+        // The third byte of each frame (offset 0, 1, 2, 3, ...) at register
+        // CMD_WRITE_CONFIG + 3 carries the chunk length. Two frames means
+        // the mock writes that "register" twice across the whole call.
+        if (w.reg == DAPLINK_BRIDGE_CMD_WRITE_CONFIG + 3) {
+            ++chunkLengthsSeen;
+        }
+    }
+    TEST_ASSERT_EQUAL_INT(2, chunkLengthsSeen);
+}
+
+void test_write_config_returns_false_on_device_error(void) {
+    bridge.begin();
+    preloadError(DAPLINK_BRIDGE_ERROR_CMD_FAILED);
+    TEST_ASSERT_FALSE(bridge.writeConfig("x", 0));
+}
+
+void test_read_config_returns_data_until_first_0xff(void) {
+    bridge.begin();
+
+    // The Wire mock auto-increments the register pointer on requestFrom,
+    // so loading consecutive registers under CMD_READ_CONFIG mimics a
+    // bridge that streams 5 payload bytes then 0xFF as end-of-data.
+    const char* expected = "hello";
+    for (size_t i = 0; i < 5; ++i) {
+        Wire.setRegister(ADDR, DAPLINK_BRIDGE_CMD_READ_CONFIG + i,
+                         static_cast<uint8_t>(expected[i]));
+    }
+    Wire.setRegister(ADDR, DAPLINK_BRIDGE_CMD_READ_CONFIG + 5, 0xFF);
+
+    uint8_t buf[32] = {0};
+    size_t len = bridge.readConfig(buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_INT(5, len);
+    TEST_ASSERT_EQUAL_STRING_LEN(expected, reinterpret_cast<char*>(buf), 5);
+}
+
+void test_read_config_returns_zero_on_immediate_0xff(void) {
+    bridge.begin();
+    Wire.setRegister(ADDR, DAPLINK_BRIDGE_CMD_READ_CONFIG, 0xFF);
+
+    uint8_t buf[32] = {0};
+    TEST_ASSERT_EQUAL_INT(0, bridge.readConfig(buf, sizeof(buf)));
+}
+
+void test_read_config_truncates_to_max_len(void) {
+    bridge.begin();
+    // Fill enough registers that readConfig would otherwise keep reading.
+    for (size_t i = 0; i < 10; ++i) {
+        Wire.setRegister(ADDR, DAPLINK_BRIDGE_CMD_READ_CONFIG + i, 'a');
+    }
+    // No 0xFF sentinel: readConfig must stop at maxLen.
+    uint8_t buf[3] = {0};
+    TEST_ASSERT_EQUAL_INT(3, bridge.readConfig(buf, sizeof(buf)));
+    TEST_ASSERT_EQUAL_HEX8('a', buf[0]);
+    TEST_ASSERT_EQUAL_HEX8('a', buf[1]);
+    TEST_ASSERT_EQUAL_HEX8('a', buf[2]);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_begin_detects_device);
+    RUN_TEST(test_begin_rejects_wrong_who_am_i);
+    RUN_TEST(test_device_id_returns_who_am_i);
+    RUN_TEST(test_busy_reflects_status_register);
+    RUN_TEST(test_clear_config_returns_true_on_no_error);
+    RUN_TEST(test_clear_config_returns_false_on_device_error);
+    RUN_TEST(test_write_config_rejects_offset_at_or_past_end);
+    RUN_TEST(test_write_config_rejects_payload_overflowing_zone);
+    RUN_TEST(test_write_config_writes_framed_payload);
+    RUN_TEST(test_write_config_chunked_when_payload_exceeds_max_chunk);
+    RUN_TEST(test_write_config_returns_false_on_device_error);
+    RUN_TEST(test_read_config_returns_data_until_first_0xff);
+    RUN_TEST(test_read_config_returns_zero_on_immediate_0xff);
+    RUN_TEST(test_read_config_truncates_to_max_len);
+    return UNITY_END();
+}


### PR DESCRIPTION
close #156 

## Summary

Adds the Arduino/C++ driver for the STM32F103 DAPLink I2C bridge, including
the driver implementation, constants, and native unit tests.

## Changes

* `daplink_bridge_const.h` — command codes, register addresses, status bits,
  and protocol limits
* `daplink_bridge.h` — class declaration with all public and private members
* `daplink_bridge.cpp` — full driver implementation
* `tests/native/test_daplink_bridge/` — native unit tests against the
  `TwoWire` mock
* `README.md` — driver documentation

## Features

* I2C communication via Arduino `TwoWire`
* Device identification via `WHO_AM_I` register
* Busy polling with configurable timeout
* 1 KB persistent config zone stored in STM32F103 internal flash
* Config zone erase (`clearConfig`)
* Chunked config write with offset support (`writeConfig`) — accepts both
  raw bytes and null-terminated strings
* Config read up to first `0xFF` sentinel (`readConfig`)
* Error register checking after write and clear operations

## Checklist

- [x] `make lint` passes (clang-format)
- [ ] `make build` passes (PlatformIO)
- [x] `make test-native` passes (if native tests exist)
- [ ] `make test-hardware` passes on a connected STeaMi (if hardware tests exist)
- [x] README updated (if adding/changing public API)
- [ ] Examples added/updated (if applicable)
- [x] Commit messages follow conventional commits format
