### PR TITLE
docs: Document zsh completion for dynamic make targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,14 +50,23 @@ zstyle ':completion:*:*:make:*:targets' call-command true
 zstyle ':completion:*:*:make:*' tag-order 'targets'
 ```
 
-The first line tells zsh to invoke `make -nsp` to get the resolved
-target database (instead of parsing the Makefile textually, which misses
-generated targets). The second line filters out variables and files from
-the completion output so `make <TAB>` only shows actual targets.
+The first line tells zsh to invoke `make` in dry-run / print-database
+mode to query the resolved target list (instead of parsing the Makefile
+textually, which misses generated targets). The second line filters out
+variables and files from the completion output so `make <TAB>` only
+shows actual targets.
 
 `exec zsh` to reload, then `make flash-<TAB>` will list every example
 across every driver, and `make test-<TAB>` every test target across the
 three tiers.
+
+A side effect of `call-command true`: every `make <TAB>` runs `make`
+under the hood, which evaluates the Makefile — including any
+`$(shell ...)` calls made at parse time. In this repo those are cheap
+(`find` over `lib/` and `tests/`), but it means the zstyle should be
+applied **per project** rather than globally if you also work on
+untrusted repos. Scope it with a directory-specific `zstyle`, or set it
+inside a per-project `.zshrc.local` sourced by your dotfiles.
 
 If you don't want to touch your zshrc, `make list` and `make list-examples`
 print the same information on stdout.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,31 @@ header check on every staged `.h`/`.cpp`/`.ino` before each commit. Run
 `make setup` on a fresh clone so you don't get surprised by CI enforcing
 things your local commit let through.
 
+### Shell completion for `make` (zsh)
+
+Many of the most useful targets are generated dynamically via
+`foreach + eval` — `flash-<driver>/<example>`, `capture-<driver>/<example>`,
+`test-native-<driver>`, `test-hardware-<driver>`, `test-integration-<driver>`,
+`test-<driver>`. zsh's stock `_make` completion can resolve these for you,
+but the relevant `zstyle` is off by default. Add to your `~/.zshrc`:
+
+```zsh
+zstyle ':completion:*:*:make:*:targets' call-command true
+zstyle ':completion:*:*:make:*' tag-order 'targets'
+```
+
+The first line tells zsh to invoke `make -nsp` to get the resolved
+target database (instead of parsing the Makefile textually, which misses
+generated targets). The second line filters out variables and files from
+the completion output so `make <TAB>` only shows actual targets.
+
+`exec zsh` to reload, then `make flash-<TAB>` will list every example
+across every driver, and `make test-<TAB>` every test target across the
+three tiers.
+
+If you don't want to touch your zshrc, `make list` and `make list-examples`
+print the same information on stdout.
+
 ## Driver structure
 
 Each driver lives in its own directory under `lib/`:


### PR DESCRIPTION
## Summary

Add a *Shell completion for `make` (zsh)* subsection to `CONTRIBUTING.md` covering the two `zstyle` lines that make zsh's stock `_make` complete the targets we generate via `foreach + eval`:

- `flash-<driver>/<example>`
- `capture-<driver>/<example>`
- `test-native-<driver>`, `test-hardware-<driver>`, `test-integration-<driver>`
- composite `test-<driver>`

Without these zstyles, `make <TAB>` parses the Makefile textually and shows variables (`PIO`, `EXAMPLE_KEYS`, ...) and files in the cwd alongside the static targets, while the dynamic ones get truncated to literal stubs (`flash-`, `capture-`, etc.). With them, completion is clean and resolves every generated target.

## Changes

* `CONTRIBUTING.md` gets a new `### Shell completion for `make` (zsh)` subsection inside *Getting started*, with the two-line zstyle snippet, a one-paragraph explanation of what each line does, and a `make list` / `make list-examples` fallback for contributors who don't want to edit their zshrc.

## Test plan

- [x] Read the section, copy the two zstyle lines into `~/.zshrc`, `exec zsh`.
- [x] `make flash-<TAB>` → expect every `flash-<driver>/<example>` listed, no files, no variables.
- [x] `make test-<TAB>` → expect the composite + per-tier targets across all drivers with tests.