### PR TITLE
tooling: Homogenise make target naming and add list-tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,8 @@ Two shapes are in use, and they reflect the underlying directory structure:
 * **Hierarchical targets** use `verb/<path>` whenever the action drills into one specific item:
   * `flash-<driver>/<example>` — flash one example (e.g. `flash-hts221/dew_point`).
   * `capture-<driver>/<example>` — same, but route serial through `scripts/capture-serial.py` instead of opening miniterm.
-  * `test-native/<driver>` / `test-hardware/<driver>` / `test-integration/<driver>` — run one suite from a single tier.
-  * `test/<driver>` — composite: chains every tier that exists for that driver.
+  * `test-native/<suite>` / `test-hardware/<suite>` / `test-integration/<suite>` — run one test suite from a single tier. The suite is the directory name under `tests/<tier>/test_*` and isn't always a driver — `wire` and `led` cover mocks and board features rather than lib drivers.
+  * `test/<suite>` — composite: chains every tier that exists for that suite.
 
 The `/` separator (rather than another `-`) avoids visual ambiguity: drivers can themselves contain hyphens (`wsen-pads`, `wsen-hids`), and `flash-wsen-pads-altitude` would force the reader to guess where the boundary is. `flash-wsen-pads/altitude` is unambiguous and gives zsh's tab-completion a natural drill-down (`make flash-wsen-pads/<TAB>` lists only that driver's examples).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,12 +37,32 @@ header check on every staged `.h`/`.cpp`/`.ino` before each commit. Run
 `make setup` on a fresh clone so you don't get surprised by CI enforcing
 things your local commit let through.
 
+### Make target naming convention
+
+Two shapes are in use, and they reflect the underlying directory structure:
+
+* **Flat targets** (`build`, `lint`, `test-native`, `test-hardware`, `test-integration`, `setup`, …) are top-level actions that operate on the whole tree. The verb may be compound (`test-native`), but there's no sub-path.
+* **Hierarchical targets** use `verb/<path>` whenever the action drills into one specific item:
+  * `flash-<driver>/<example>` — flash one example (e.g. `flash-hts221/dew_point`).
+  * `capture-<driver>/<example>` — same, but route serial through `scripts/capture-serial.py` instead of opening miniterm.
+  * `test-native/<driver>` / `test-hardware/<driver>` / `test-integration/<driver>` — run one suite from a single tier.
+  * `test/<driver>` — composite: chains every tier that exists for that driver.
+
+The `/` separator (rather than another `-`) avoids visual ambiguity: drivers can themselves contain hyphens (`wsen-pads`, `wsen-hids`), and `flash-wsen-pads-altitude` would force the reader to guess where the boundary is. `flash-wsen-pads/altitude` is unambiguous and gives zsh's tab-completion a natural drill-down (`make flash-wsen-pads/<TAB>` lists only that driver's examples).
+
+To discover the targets:
+
+```bash
+make list-examples         # all flash-* and capture-* targets
+make list-tests            # all test-*/* and composite test/* targets
+```
+
+`list-examples` honors an optional `DRIVER=<name>` filter.
+
 ### Shell completion for `make` (zsh)
 
-Many of the most useful targets are generated dynamically via
-`foreach + eval` — `flash-<driver>/<example>`, `capture-<driver>/<example>`,
-`test-native-<driver>`, `test-hardware-<driver>`, `test-integration-<driver>`,
-`test-<driver>`. zsh's stock `_make` completion can resolve these for you,
+The hierarchical and per-suite targets above are generated dynamically via
+`foreach + eval`. zsh's stock `_make` completion can resolve them for you,
 but the relevant `zstyle` is off by default. Add to your `~/.zshrc`:
 
 ```zsh
@@ -68,8 +88,8 @@ applied **per project** rather than globally if you also work on
 untrusted repos. Scope it with a directory-specific `zstyle`, or set it
 inside a per-project `.zshrc.local` sourced by your dotfiles.
 
-If you don't want to touch your zshrc, `make list` and `make list-examples`
-print the same information on stdout.
+If you don't want to touch your zshrc, `make list-examples` and
+`make list-tests` print the same information on stdout.
 
 ## Driver structure
 

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ upload: .venv/bin/pio ## Upload to board
 EXAMPLE_KEYS := $(shell find $(EXAMPLES_ROOT) -mindepth 3 -maxdepth 3 -type d -path '$(EXAMPLES_ROOT)/*/examples/*' 2>/dev/null | sed 's|$(EXAMPLES_ROOT)/\([^/]*\)/examples/\([^/]*\)|\1/\2|' | LC_ALL=C sort)
 
 .PHONY: list-examples
-list-examples: ## List ready-to-run flash- targets, optionally filtered with DRIVER=<driver>
+list-examples: ## List ready-to-run flash-/capture- targets, optionally filtered with DRIVER=<driver>
 	@if [ -n "$(DRIVER)" ]; then \
 		matches="$$(printf '%s\n' $(EXAMPLE_KEYS) | grep -E '^$(DRIVER)/' || true)"; \
 		if [ -z "$$matches" ]; then \
@@ -119,8 +119,10 @@ list-examples: ## List ready-to-run flash- targets, optionally filtered with DRI
 			exit 1; \
 		fi; \
 		printf '%s\n' "$$matches" | sed 's|^|flash-|'; \
+		printf '%s\n' "$$matches" | sed 's|^|capture-|'; \
 	else \
 		printf '%s\n' $(EXAMPLE_KEYS) | sed 's|^|flash-|'; \
+		printf '%s\n' $(EXAMPLE_KEYS) | sed 's|^|capture-|'; \
 	fi
 
 # Per-example flash targets. Pattern rules with `%` don't span `/` in
@@ -153,23 +155,25 @@ endef
 $(foreach k,$(EXAMPLE_KEYS),$(eval $(call CAPTURE_RULE,$(k))))
 
 # --- Testing ---
+#
+# Naming convention: hierarchical actions use `verb/path` so the verb
+# stays readable when sub-paths are involved. Same shape as the flash-
+# and capture- families on the examples side. Drivers contain hyphens
+# (`wsen-pads`, `wsen-hids`) so a flat `verb-driver-suite` form would be
+# visually ambiguous; `/` is the unambiguous separator.
 
-# Discovered once at parse time. Each entry is the suite name (without
-# the test_ prefix) and becomes a `test-native-<name>` phony target via
-# the foreach+eval block below — same shape as the flash- and capture-
-# families. Adding a new tests/native/test_<name>/ directory picks up
-# automatically.
 NATIVE_TEST_KEYS := $(patsubst tests/native/test_%,%,$(wildcard tests/native/test_*))
 
 .PHONY: test-native
 test-native: .venv/bin/pio ## Run all host-side native tests (no board required)
 	$(PIO) test -e native
 
-# Per-suite native test targets — `make test-native-<name>` runs only
-# that suite via PlatformIO's --filter flag.
+# Per-suite native test targets — `make test-native/<name>` runs only
+# that suite via PlatformIO's --filter flag. Adding a new
+# tests/native/test_<name>/ directory picks up automatically.
 define NATIVE_TEST_RULE
-.PHONY: test-native-$(1)
-test-native-$(1): .venv/bin/pio
+.PHONY: test-native/$(1)
+test-native/$(1): .venv/bin/pio
 	$$(PIO) test -e native --filter native/test_$(1)
 endef
 $(foreach k,$(NATIVE_TEST_KEYS),$(eval $(call NATIVE_TEST_RULE,$(k))))
@@ -184,14 +188,14 @@ test-hardware: .venv/bin/pio ## Run all on-board hardware-unit tests (skipped if
 	fi
 	$(PIO) test -e steami --filter hardware/test_*
 
-# Per-suite hardware test targets — `make test-hardware-<name>` runs
-# only that suite. Same shape as test-native-<name>, with the added
+# Per-suite hardware test targets — `make test-hardware/<name>` runs
+# only that suite. Same shape as test-native/<name>, with the added
 # board-detection guard: if no STeaMi is attached, the recipe prints a
 # message and exits 0 so a CI script that pessimistically calls these
 # without a board doesn't fail.
 define HARDWARE_TEST_RULE
-.PHONY: test-hardware-$(1)
-test-hardware-$(1): .venv/bin/pio
+.PHONY: test-hardware/$(1)
+test-hardware/$(1): .venv/bin/pio
 	@if ! $$(PIO) device list | grep -qiE 'steami|cmsis-dap'; then
 		echo "STeaMi not detected — skipping hardware tests."
 		exit 0
@@ -210,13 +214,13 @@ test-integration: .venv/bin/pio ## Run all on-board integration tests (skipped i
 	fi
 	$(PIO) test -e steami --filter integration/test_*
 
-# Per-suite integration test targets — same shape as test-hardware-<name>.
+# Per-suite integration test targets — same shape as test-hardware/<name>.
 # Integration suites validate runtime behaviour over time (acquisition
 # cadence, repeated-sample plausibility, no frozen output) on real
 # silicon, so the same board-detection guard applies.
 define INTEGRATION_TEST_RULE
-.PHONY: test-integration-$(1)
-test-integration-$(1): .venv/bin/pio
+.PHONY: test-integration/$(1)
+test-integration/$(1): .venv/bin/pio
 	@if ! $$(PIO) device list | grep -qiE 'steami|cmsis-dap'; then
 		echo "STeaMi not detected — skipping integration tests."
 		exit 0
@@ -225,21 +229,28 @@ test-integration-$(1): .venv/bin/pio
 endef
 $(foreach k,$(INTEGRATION_TEST_KEYS),$(eval $(call INTEGRATION_TEST_RULE,$(k))))
 
-# Composite per-driver targets — `make test-<driver>` runs whichever
+# Composite per-driver targets — `make test/<driver>` runs whichever
 # tiers exist for that driver (native, hardware-unit, integration). A
-# driver with only native coverage gets a shortcut to test-native-<name>;
+# driver with only native coverage gets a shortcut to test-native/<name>;
 # a driver with all three tiers chains them in dependency order. The
 # board-detection guard on the hardware/integration recipes still
 # applies, so a host-only run skips the on-board tiers cleanly.
 ALL_TEST_KEYS := $(sort $(NATIVE_TEST_KEYS) $(HARDWARE_TEST_KEYS) $(INTEGRATION_TEST_KEYS))
 define COMPOSITE_TEST_RULE
-.PHONY: test-$(1)
-test-$(1): \
-  $(if $(filter $(1),$(NATIVE_TEST_KEYS)),test-native-$(1)) \
-  $(if $(filter $(1),$(HARDWARE_TEST_KEYS)),test-hardware-$(1)) \
-  $(if $(filter $(1),$(INTEGRATION_TEST_KEYS)),test-integration-$(1))
+.PHONY: test/$(1)
+test/$(1): \
+  $(if $(filter $(1),$(NATIVE_TEST_KEYS)),test-native/$(1)) \
+  $(if $(filter $(1),$(HARDWARE_TEST_KEYS)),test-hardware/$(1)) \
+  $(if $(filter $(1),$(INTEGRATION_TEST_KEYS)),test-integration/$(1))
 endef
 $(foreach k,$(ALL_TEST_KEYS),$(eval $(call COMPOSITE_TEST_RULE,$(k))))
+
+.PHONY: list-tests
+list-tests: ## List ready-to-run test- targets across all tiers
+	@printf 'test-native/%s\n' $(NATIVE_TEST_KEYS)
+	@printf 'test-hardware/%s\n' $(HARDWARE_TEST_KEYS)
+	@printf 'test-integration/%s\n' $(INTEGRATION_TEST_KEYS)
+	@printf 'test/%s\n' $(ALL_TEST_KEYS)
 
 # --- CI ---
 

--- a/Makefile
+++ b/Makefile
@@ -229,12 +229,14 @@ test-integration/$(1): .venv/bin/pio
 endef
 $(foreach k,$(INTEGRATION_TEST_KEYS),$(eval $(call INTEGRATION_TEST_RULE,$(k))))
 
-# Composite per-driver targets — `make test/<driver>` runs whichever
-# tiers exist for that driver (native, hardware-unit, integration). A
-# driver with only native coverage gets a shortcut to test-native/<name>;
-# a driver with all three tiers chains them in dependency order. The
+# Composite per-suite targets — `make test/<suite>` runs whichever
+# tiers exist for that suite (native, hardware-unit, integration).
+# A suite with only native coverage gets a shortcut to test-native/<suite>;
+# one with all three tiers chains them in dependency order. The
 # board-detection guard on the hardware/integration recipes still
 # applies, so a host-only run skips the on-board tiers cleanly.
+# "Suite" rather than "driver": some suites (e.g. wire, led) cover
+# board features or test infrastructure that don't sit under lib/.
 ALL_TEST_KEYS := $(sort $(NATIVE_TEST_KEYS) $(HARDWARE_TEST_KEYS) $(INTEGRATION_TEST_KEYS))
 define COMPOSITE_TEST_RULE
 .PHONY: test/$(1)
@@ -247,10 +249,10 @@ $(foreach k,$(ALL_TEST_KEYS),$(eval $(call COMPOSITE_TEST_RULE,$(k))))
 
 .PHONY: list-tests
 list-tests: ## List ready-to-run test- targets across all tiers
-	@printf 'test-native/%s\n' $(NATIVE_TEST_KEYS)
-	@printf 'test-hardware/%s\n' $(HARDWARE_TEST_KEYS)
-	@printf 'test-integration/%s\n' $(INTEGRATION_TEST_KEYS)
-	@printf 'test/%s\n' $(ALL_TEST_KEYS)
+	@for k in $(NATIVE_TEST_KEYS); do printf 'test-native/%s\n' "$$k"; done
+	@for k in $(HARDWARE_TEST_KEYS); do printf 'test-hardware/%s\n' "$$k"; done
+	@for k in $(INTEGRATION_TEST_KEYS); do printf 'test-integration/%s\n' "$$k"; done
+	@for k in $(ALL_TEST_KEYS); do printf 'test/%s\n' "$$k"; done
 
 # --- CI ---
 

--- a/lib/wsen-pads/README.md
+++ b/lib/wsen-pads/README.md
@@ -136,7 +136,7 @@ the driver against the `TwoWire` mock and the shared
 without hardware with:
 
 ```bash
-make test-native-wsen_pads
+make test-native/wsen_pads
 ```
 
 ## License

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -96,15 +96,19 @@ Requires a board (same skip behaviour as hardware unit tests). Integration
 suites are intentionally slower than hardware unit tests because they observe
 repeated measurements over time — typically tens of seconds per suite.
 
-### Composite per-driver target
+### Composite per-suite target
 
-`make test/<driver>` chains whichever tiers exist for that driver:
+`make test/<suite>` chains whichever tiers exist for that suite:
 
 ```bash
 make test/hts221              # native + hardware-unit + integration
 make test/led                 # native + hardware-unit
 make test/wire                # native only
 ```
+
+The placeholder is `<suite>` rather than `<driver>` because some suites
+cover board features or test infrastructure (e.g. `wire`, `led`) that
+don't have a corresponding driver under `lib/`.
 
 ### Direct PlatformIO invocations
 

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -56,17 +56,19 @@ Rules:
 ## Running Tests
 
 The Makefile generates one phony target per suite under each tier (via
-`foreach + eval`, same shape as `flash-<driver>/<example>`). Tab-completion on
-zsh/bash works for `make test-<tier>-<TAB>` and adding a new suite directory
-picks up automatically — no Makefile edits.
+`foreach + eval`, same shape as `flash-<driver>/<example>`). The convention
+is `verb/<target>` whenever there's a sub-path: tab-completion on zsh/bash
+works for `make test-<tier>/<TAB>` and adding a new suite directory picks
+up automatically — no Makefile edits. `make list-tests` prints every
+discoverable test target across the three tiers plus the composite.
 
 ### Native tests (desktop, mock-based)
 
 ```bash
 make test-native              # all native suites
-make test-native-hts221       # one suite — auto-discovered from tests/native/test_hts221/
-make test-native-led
-make test-native-wire
+make test-native/hts221       # one suite — auto-discovered from tests/native/test_hts221/
+make test-native/led
+make test-native/wire
 ```
 
 No hardware required. CI-friendly.
@@ -75,8 +77,8 @@ No hardware required. CI-friendly.
 
 ```bash
 make test-hardware            # all hardware suites
-make test-hardware-hts221     # one suite — auto-discovered from tests/hardware/test_hts221/
-make test-hardware-led
+make test-hardware/hts221     # one suite — auto-discovered from tests/hardware/test_hts221/
+make test-hardware/led
 ```
 
 Requires a connected STeaMi over CMSIS-DAP. If no board is detected the recipe
@@ -87,12 +89,22 @@ script that calls these without a board attached doesn't fail.
 
 ```bash
 make test-integration         # all integration suites
-make test-integration-hts221  # one suite — auto-discovered from tests/integration/test_hts221/
+make test-integration/hts221  # one suite — auto-discovered from tests/integration/test_hts221/
 ```
 
 Requires a board (same skip behaviour as hardware unit tests). Integration
 suites are intentionally slower than hardware unit tests because they observe
 repeated measurements over time — typically tens of seconds per suite.
+
+### Composite per-driver target
+
+`make test/<driver>` chains whichever tiers exist for that driver:
+
+```bash
+make test/hts221              # native + hardware-unit + integration
+make test/led                 # native + hardware-unit
+make test/wire                # native only
+```
 
 ### Direct PlatformIO invocations
 


### PR DESCRIPTION
## Summary

Two rough edges came out of using the Makefile across drivers — `list-*` was incomplete, and the `test-` family used a different separator than `flash-`/`capture-`. Aligning both behind a single rule and documenting it.

## Naming convention

| Shape | When | Examples |
|---|---|---|
| `verb` (flat) | top-level actions, no sub-path | `build`, `lint`, `test-native`, `test-hardware` (run-all), `setup`, … |
| `verb/<path>` (hierarchical) | drill into one item | `flash-hts221/dew_point`, `capture-wsen-pads/altitude`, `test-native/hts221`, `test/hts221` |

The `/` separator (rather than another `-`) matters because driver names already contain hyphens (`wsen-pads`, `wsen-hids`). `flash-wsen-pads-altitude` forces the reader to guess the boundary; `flash-wsen-pads/altitude` is unambiguous and gives zsh tab-completion a natural drill-down (`make flash-wsen-pads/<TAB>` → only that driver's examples).

## Renames

| Before | After |
|---|---|
| `make test-native-hts221` | `make test-native/hts221` |
| `make test-hardware-hts221` | `make test-hardware/hts221` |
| `make test-integration-hts221` | `make test-integration/hts221` |
| `make test-hts221` (composite) | `make test/hts221` |

`flash-<driver>/<example>` and `capture-<driver>/<example>` already followed the rule and stay unchanged.

## Discovery

* New **`make list-tests`** prints every `test-*/*` target plus the composite `test/*` entries:

  ```
  test-native/hts221
  test-native/led
  test-native/wire
  test-native/wsen_pads
  test-hardware/hts221
  test-hardware/led
  test-integration/hts221
  test/hts221
  test/led
  test/wire
  test/wsen_pads
  ```

* **`make list-examples`** now prints both `flash-*` and `capture-*` lines (it was flash-only). The `DRIVER=<name>` filter still applies.

## Docs

* `CONTRIBUTING.md` — new *Make target naming convention* subsection right after the targets table in *Getting started*.
* `tests/TESTING.md` — examples migrated to the new shape, plus a small *Composite per-driver target* subsection.
* `lib/wsen-pads/README.md` — `make test-native-wsen_pads` → `make test-native/wsen_pads`.

## Validated end-to-end on hardware

```
$ make test/hts221
... native: 17/17 PASSED (0.9 s)
... hardware: 4/4 PASSED (11.9 s)
... integration: 1/1 PASSED (17.9 s)
```

The composite chains the three tiers in dependency order, the board-detection guard still skips the on-board tiers cleanly when no STeaMi is attached.

## Note on stack ordering

[#162](https://github.com/steamicc/arduino-steami-lib/pull/162) (zsh completion docs) is still open and references the old test target names (`test-native-<driver>`, etc.) in its *Shell completion* subsection. Whichever lands second will need a one-line follow-up to update those references — happy to do it as part of merging.
