### PR TITLE
tooling: Ship library.properties for every driver and document deps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,15 +119,30 @@ lib/<component>/
   within its own tree.
 - The class name is `PascalCase` (`HTS221`, `Mcp23009e`) and lives in
   `src/<DriverName>.h`.
-- Each driver is self-contained — no cross-driver dependencies.
+- Drivers are self-contained by default. When one driver does need to
+  call into another's public API (e.g. the DAPLink family, where
+  `daplink_flash` and `daplink_config` both speak through
+  `daplink_bridge`), declare the dependency explicitly via the
+  `depends=` field of the consumer's `library.properties`. This is
+  what PlatformIO's library finder uses to resolve `-I` paths across
+  libs and what the Arduino Library Manager surfaces to end users.
+  Avoid implicit cross-driver `#include`s without a matching
+  `depends=` — the build will work locally but break for downstream
+  consumers.
 - Every new C/C++ source (`.h`, `.cpp`, `.ino`) carries the SPDX license
   header on the very first line (see issue #104):
   ```
   // SPDX-License-Identifier: GPL-3.0-or-later
   ```
 - Include guards use `#pragma once`, not `#ifndef`/`#define` wrappers.
-- `library.properties` declares `architectures=*` so host-side tests can
-  pull the library in (the native platform has no "framework").
+- Every driver ships a `library.properties` (Arduino Library Manager
+  metadata). Required fields: `name`, `version`, `sentence`, `category`,
+  `architectures=*` (so host-side tests can pull the library in — the
+  native platform has no "framework"). Optional but recommended: a
+  longer `paragraph` and an `includes=` line listing the public
+  header. Stub drivers ship a `library.properties` with `version=0.0.0`
+  to mark them as not yet implemented; bump to `1.0.0` on first
+  release.
 
 ### Example folders
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,13 +136,16 @@ lib/<component>/
   ```
 - Include guards use `#pragma once`, not `#ifndef`/`#define` wrappers.
 - Every driver ships a `library.properties` (Arduino Library Manager
-  metadata). Required fields: `name`, `version`, `sentence`, `category`,
-  `architectures=*` (so host-side tests can pull the library in — the
-  native platform has no "framework"). Optional but recommended: a
-  longer `paragraph` and an `includes=` line listing the public
-  header. Stub drivers ship a `library.properties` with `version=0.0.0`
-  to mark them as not yet implemented; bump to `1.0.0` on first
-  release.
+  metadata). Per the Arduino library specification the required fields
+  are `name`, `version`, `author`, `maintainer`, `sentence`, `category`,
+  `url`, and `architectures` — set `architectures=*` so host-side tests
+  can pull the library in (the native platform has no "framework"). The
+  collection convention is `author=STeaMi contributors` and
+  `maintainer=STeaMi contributors`; the `url` points back to this
+  repository. Optional but recommended: a longer `paragraph` describing
+  the API, and an `includes=` line listing the public header. Stub
+  drivers ship a `library.properties` with `version=0.0.0` to mark them
+  as not yet implemented; bump to `1.0.0` on first release.
 
 ### Example folders
 

--- a/Makefile
+++ b/Makefile
@@ -69,17 +69,26 @@ format-fix: .venv/bin/clang-format ## Auto-fix formatting in place
 # lint is a meta-target — it aggregates every static check we run on the
 # source tree. Each sub-target is runnable on its own.
 
-# Driver sources analysed by clang-tidy. Listed via $(shell) so the set
-# is current each time make runs.
+# Driver sources and headers analysed by clang-tidy. Listed via
+# $(shell) so the set is current each time make runs. Headers are
+# tracked too because PlatformIO's library dependency finder follows
+# `#include` directives — a new include in a header (e.g. one driver
+# pulling in another's public API) changes the resolved include paths
+# but wouldn't otherwise trigger a compile_commands.json refresh.
 DRIVER_SOURCES := $(shell find lib -type f -path '*/src/*.cpp')
+DRIVER_HEADERS := $(shell find lib -type f -path '*/src/*.h')
+DRIVER_LIBPROPS := $(shell find lib -type f -name 'library.properties')
 
-# compile_commands.json is regenerated whenever platformio.ini, the board
-# JSON, or the driver source list changes — clang-tidy needs the exact
-# compile flags PIO used for every file it analyses. Adding a new driver
-# forces a DB refresh so tidy doesn't fall back to guessed flags.
-# Generated from the native env because host compile handles the STL /
-# headers cleanly (the ARM cross-compile toolchain trips clang-tidy up).
-compile_commands.json: .venv/bin/pio platformio.ini boards/steami.json $(DRIVER_SOURCES)
+# compile_commands.json is regenerated whenever platformio.ini, the
+# board JSON, the driver source/header set, or any library.properties
+# changes — clang-tidy needs the exact compile flags PIO used for
+# every file it analyses, including the resolved `-I` paths from LDF.
+# Adding a new driver, a new cross-driver include, or a new `depends=`
+# entry forces a DB refresh so tidy doesn't fall back to guessed flags.
+# Generated from the native env because host compile handles the STL
+# / headers cleanly (the ARM cross-compile toolchain trips clang-tidy
+# up).
+compile_commands.json: .venv/bin/pio platformio.ini boards/steami.json $(DRIVER_SOURCES) $(DRIVER_HEADERS) $(DRIVER_LIBPROPS)
 	$(PIO) run -t compiledb -e native
 
 .PHONY: tidy

--- a/Makefile
+++ b/Makefile
@@ -69,12 +69,15 @@ format-fix: .venv/bin/clang-format ## Auto-fix formatting in place
 # lint is a meta-target — it aggregates every static check we run on the
 # source tree. Each sub-target is runnable on its own.
 
-# Driver sources and headers analysed by clang-tidy. Listed via
-# $(shell) so the set is current each time make runs. Headers are
-# tracked too because PlatformIO's library dependency finder follows
-# `#include` directives — a new include in a header (e.g. one driver
-# pulling in another's public API) changes the resolved include paths
-# but wouldn't otherwise trigger a compile_commands.json refresh.
+# Driver source files analysed by clang-tidy. Listed via $(shell) so
+# the set is current each time make runs. Headers and library.properties
+# are tracked separately as Make-level dependencies of
+# compile_commands.json — clang-tidy itself only runs on the .cpp files
+# below — because PlatformIO's library dependency finder follows
+# `#include` directives and `depends=` entries. A new include in a
+# header (e.g. one driver pulling in another's public API) or a new
+# `depends=` line changes the resolved `-I` paths but wouldn't
+# otherwise trigger a compile_commands.json refresh.
 DRIVER_SOURCES := $(shell find lib -type f -path '*/src/*.cpp')
 DRIVER_HEADERS := $(shell find lib -type f -path '*/src/*.h')
 DRIVER_LIBPROPS := $(shell find lib -type f -name 'library.properties')

--- a/lib/apds9960/library.properties
+++ b/lib/apds9960/library.properties
@@ -1,0 +1,8 @@
+name=STeaMi APDS-9960
+version=0.0.0
+author=STeaMi contributors
+maintainer=STeaMi contributors
+sentence=APDS-9960 proximity, gesture, color and ambient-light sensor driver for the STeaMi board.
+category=Sensors
+url=https://github.com/steamicc/arduino-steami-lib
+architectures=*

--- a/lib/bme280/library.properties
+++ b/lib/bme280/library.properties
@@ -1,0 +1,8 @@
+name=STeaMi BME280
+version=0.0.0
+author=STeaMi contributors
+maintainer=STeaMi contributors
+sentence=Bosch BME280 pressure, humidity and temperature sensor driver for the STeaMi board.
+category=Sensors
+url=https://github.com/steamicc/arduino-steami-lib
+architectures=*

--- a/lib/bq27441/library.properties
+++ b/lib/bq27441/library.properties
@@ -1,0 +1,8 @@
+name=STeaMi BQ27441
+version=0.0.0
+author=STeaMi contributors
+maintainer=STeaMi contributors
+sentence=TI BQ27441-G1 single-cell battery fuel gauge driver for the STeaMi board.
+category=Sensors
+url=https://github.com/steamicc/arduino-steami-lib
+architectures=*

--- a/lib/daplink_flash/library.properties
+++ b/lib/daplink_flash/library.properties
@@ -1,0 +1,8 @@
+name=STeaMi DAPLink Flash
+version=0.0.0
+author=STeaMi contributors
+maintainer=STeaMi contributors
+sentence=Driver for the on-board DAPLink I2C-to-SPI flash bridge plus persistent config zone.
+category=Data Storage
+url=https://github.com/steamicc/arduino-steami-lib
+architectures=*

--- a/lib/gc9a01/library.properties
+++ b/lib/gc9a01/library.properties
@@ -1,0 +1,8 @@
+name=STeaMi GC9A01
+version=0.0.0
+author=STeaMi contributors
+maintainer=STeaMi contributors
+sentence=GC9A01 round colour LCD display driver for the STeaMi board.
+category=Display
+url=https://github.com/steamicc/arduino-steami-lib
+architectures=*

--- a/lib/im34dt05/library.properties
+++ b/lib/im34dt05/library.properties
@@ -1,0 +1,8 @@
+name=STeaMi IM34DT05
+version=0.0.0
+author=STeaMi contributors
+maintainer=STeaMi contributors
+sentence=IM34DT05 PDM digital microphone driver for the STeaMi board.
+category=Sensors
+url=https://github.com/steamicc/arduino-steami-lib
+architectures=*

--- a/lib/ism330dl/library.properties
+++ b/lib/ism330dl/library.properties
@@ -1,0 +1,8 @@
+name=STeaMi ISM330DL
+version=0.0.0
+author=STeaMi contributors
+maintainer=STeaMi contributors
+sentence=ISM330DL 6-axis IMU (accelerometer + gyroscope) driver for the STeaMi board.
+category=Sensors
+url=https://github.com/steamicc/arduino-steami-lib
+architectures=*

--- a/lib/lis2mdl/library.properties
+++ b/lib/lis2mdl/library.properties
@@ -1,0 +1,8 @@
+name=STeaMi LIS2MDL
+version=0.0.0
+author=STeaMi contributors
+maintainer=STeaMi contributors
+sentence=LIS2MDL 3-axis magnetometer driver for the STeaMi board.
+category=Sensors
+url=https://github.com/steamicc/arduino-steami-lib
+architectures=*

--- a/lib/mcp23009e/library.properties
+++ b/lib/mcp23009e/library.properties
@@ -1,0 +1,8 @@
+name=STeaMi MCP23009E
+version=0.0.0
+author=STeaMi contributors
+maintainer=STeaMi contributors
+sentence=MCP23009E 8-bit I2C I/O expander driver for the STeaMi board (D-PAD inputs).
+category=Signal Input/Output
+url=https://github.com/steamicc/arduino-steami-lib
+architectures=*

--- a/lib/ssd1327/library.properties
+++ b/lib/ssd1327/library.properties
@@ -1,0 +1,8 @@
+name=STeaMi SSD1327
+version=0.0.0
+author=STeaMi contributors
+maintainer=STeaMi contributors
+sentence=SSD1327 128x128 greyscale OLED display driver for the STeaMi board.
+category=Display
+url=https://github.com/steamicc/arduino-steami-lib
+architectures=*

--- a/lib/steami_config/library.properties
+++ b/lib/steami_config/library.properties
@@ -1,0 +1,8 @@
+name=STeaMi Config
+version=0.0.0
+author=STeaMi contributors
+maintainer=STeaMi contributors
+sentence=Persistent board configuration store driver for the STeaMi board.
+category=Data Storage
+url=https://github.com/steamicc/arduino-steami-lib
+architectures=*

--- a/lib/vl53l1x/library.properties
+++ b/lib/vl53l1x/library.properties
@@ -1,0 +1,8 @@
+name=STeaMi VL53L1X
+version=0.0.0
+author=STeaMi contributors
+maintainer=STeaMi contributors
+sentence=VL53L1X Time-of-Flight distance sensor driver for the STeaMi board.
+category=Sensors
+url=https://github.com/steamicc/arduino-steami-lib
+architectures=*

--- a/lib/wsen-hids/library.properties
+++ b/lib/wsen-hids/library.properties
@@ -1,0 +1,8 @@
+name=STeaMi WSEN-HIDS
+version=0.0.0
+author=STeaMi contributors
+maintainer=STeaMi contributors
+sentence=Würth Elektronik WSEN-HIDS humidity and temperature sensor driver for the STeaMi board.
+category=Sensors
+url=https://github.com/steamicc/arduino-steami-lib
+architectures=*

--- a/lib/wsen-pads/library.properties
+++ b/lib/wsen-pads/library.properties
@@ -1,0 +1,10 @@
+name=STeaMi WSEN-PADS
+version=1.0.0
+author=STeaMi contributors
+maintainer=STeaMi contributors
+sentence=Würth Elektronik WSEN-PADS barometric pressure and temperature sensor driver for the STeaMi board.
+paragraph=Arduino-compatible driver for the WSEN-PADS I2C pressure + temperature sensor. Exposes the STeaMi driver collection API (begin, deviceId, pressureHpa, temperature, read, setContinuous, triggerOneShot, readOneShot) plus driver-specific tuning (low-pass filter, low-noise mode) and two-point user calibration with stacking offset.
+category=Sensors
+url=https://github.com/steamicc/arduino-steami-lib
+architectures=*
+includes=WSEN_PADS.h


### PR DESCRIPTION
## Summary

Three rough edges that came to light when the DAPLink family started taking shape (`lib/daplink_bridge` being consumed by `lib/daplink_flash` and the upcoming `lib/daplink_config`):

1. **Only HTS221 had a `library.properties` on main.** Without one in the consumer, PlatformIO's Library Dependency Finder has no `depends=` to resolve cross-driver `#include`s, so a header that references another driver's public API fails clang-tidy with `file not found`.
2. **The CONTRIBUTING.md rule "drivers are self-contained, no cross-driver dependencies"** doesn't fit families like DAPLink where one bridge driver is genuinely consumed by sibling drivers.
3. **The Makefile's `compile_commands.json` rule** listed only `.cpp` files as inputs, so adding a new header (e.g. wiring a new cross-driver `#include`) didn't trigger a DB refresh and clang-tidy ran against stale `-I` paths.

## Changes

* **`library.properties` for every driver under `lib/`**.
  * Implemented drivers — HTS221 already had one; **wsen-pads** now ships its own at `version=1.0.0` with the full paragraph + `includes=WSEN_PADS.h`.
  * Stub drivers (apds9960, bme280, bq27441, daplink_flash, gc9a01, im34dt05, ism330dl, lis2mdl, mcp23009e, ssd1327, steami_config, vl53l1x, wsen-hids) ship `version=0.0.0` to flag "not yet implemented" — bump on first release.

* **`CONTRIBUTING.md` — *Requirements* bullet on cross-driver deps reworked.**
  Drivers stay self-contained by default, but when one driver needs another's public API (e.g. DAPLink family), the consumer declares it via `depends=<dep library name>` in its `library.properties`. Also documents the required and optional fields of `library.properties` itself, including the `version=0.0.0` convention for stubs.

* **`Makefile` — `compile_commands.json` prerequisite list extended** to include every `lib/*/src/*.h` and every `lib/*/library.properties`. Adding or modifying a header (or a `depends=` entry) now forces a fresh `pio run -t compiledb` before clang-tidy uses it.

## Why now

Aline is currently working on the DAPLink family (PR #161 adds `daplink_bridge`, `daplink_config` and a fleshed-out `daplink_flash` are her next steps). Her clang-tidy was failing on `daplink_flash.h:7: 'daplink_bridge.h' file not found` — exactly the symptom of the missing `depends=` declaration. With this PR landed, she can:

```
# in lib/daplink_flash/library.properties
depends=STeaMi DAPLink Bridge
```

…and LDF resolves the include path for her without further config.

## Test plan

- [x] `make lint` passes (verified locally — clang-format + check-spdx + clang-tidy on the two implemented drivers).
- [x] `rm compile_commands.json && make tidy` regenerates the DB and runs clean.
- [x] On a branch that introduces a new cross-driver `#include` together with the matching `depends=`, clang-tidy resolves the header without `file not found`.

## Out of scope

* Implementing the actual stub drivers — this PR just ships their metadata.
* Adding examples / tests to drivers that don't have any yet.
* Touching `lib/daplink_bridge` (which lives on Aline's PR #161, not on main yet) — once #161 lands, a follow-up will add `depends=` to the consumer drivers.