### PR TITLE
tooling: Pass every lib's include path to clang-tidy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,9 +94,19 @@ DRIVER_LIBPROPS := $(shell find lib -type f -name 'library.properties')
 compile_commands.json: .venv/bin/pio platformio.ini boards/steami.json $(DRIVER_SOURCES) $(DRIVER_HEADERS) $(DRIVER_LIBPROPS)
 	$(PIO) run -t compiledb -e native
 
+# Every driver's src/ directory is added to clang-tidy's include path
+# so that cross-driver `#include`s (e.g. daplink_flash → daplink_bridge)
+# resolve regardless of whether the consumer is in compile_commands.json.
+# PlatformIO only compiles in the native env what the smoke-test sketch
+# pulls in (via LDF), so non-included drivers get default flags from
+# clang-tidy's compile_commands fallback — without these extras a header
+# that references another driver's API would fail with "file not found"
+# even though the include declaration is correct.
+LIB_INCLUDES := $(addprefix --extra-arg-before=-I,$(wildcard lib/*/src))
+
 .PHONY: tidy
 tidy: .venv/bin/clang-tidy compile_commands.json ## Run clang-tidy on every driver source under lib/*/src/
-	@find lib -type f -path '*/src/*.cpp' -exec .venv/bin/clang-tidy -p . --quiet {} +
+	@find lib -type f -path '*/src/*.cpp' -exec .venv/bin/clang-tidy -p . --quiet $(LIB_INCLUDES) {} +
 
 .PHONY: check-spdx
 check-spdx: ## Verify every C++ source carries the SPDX license header


### PR DESCRIPTION
## Summary

Follow-up to #164 — fixes the actual symptom Aline reported.

PlatformIO's native env only compiles in `compile_commands.json` what the smoke-test sketch (`src/main.cpp`) pulls in via LDF. Drivers not referenced by `main.cpp` don't end up in the database, so clang-tidy falls back to default flags when it processes their `.cpp` files. That means a header that legitimately includes another driver's public API (e.g. `daplink_flash.h` → `daplink_bridge.h`) fails with `file not found` even when both libs ship a proper `library.properties` and the consumer declares `depends=`.

The fix: pass `--extra-arg-before=-I<lib>/src` for every driver to the clang-tidy invocation so the include path is uniform across the lint regardless of compile_commands.json coverage.

## Why a follow-up rather than part of #164

The diagnostic only surfaced when reproducing on Aline's `feat/daplink-flash-driver` branch after #164 had already landed. On `main` today only HTS221 and WSEN-PADS exist, neither has cross-driver deps, and `main.cpp` includes HTS221 — so `make tidy` is green. The bug is latent until the first real cross-driver pair lands (DAPLink), which is exactly Aline's case.

## Verified locally

Reproduced Aline's failure on her branch, applied this fix, ran `make tidy` end-to-end:

```
[1/4] Processing file lib/daplink_flash/src/daplink_flash.cpp.
[2/4] Processing file lib/wsen-pads/src/WSEN_PADS.cpp.
[3/4] Processing file lib/daplink_bridge/src/daplink_bridge.cpp.
[4/4] Processing file lib/hts221/src/HTS221.cpp.
exit=0
```

Each `.cpp` is processed without the `daplink_bridge.h: file not found` error. Same `make tidy` on current `main` (no cross-driver deps yet) stays green.

## Note for downstream

There's a stale branch `tooling/library-properties` on origin that I accidentally re-pushed when this commit was on it (the original branch was deleted by GitHub on merge of #164, my push recreated it). Safe to delete from the GitHub UI — its content is exactly this PR's diff.