### PR TITLE
tooling: Extend smoke-test sketch to cover every implemented driver

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,14 @@ lib/<component>/
   the API, and an `includes=` line listing the public header. Stub
   drivers ship a `library.properties` with `version=0.0.0` to mark them
   as not yet implemented; bump to `1.0.0` on first release.
+- When a driver becomes implemented (no longer a stub), add a section
+  to `src/main.cpp` that `#include`s its header, instantiates it on
+  the right bus, and calls `begin()` + a quick identity probe. The
+  sketch is the build smoke test: it links every implemented driver
+  in the steami env and lists every driver `.cpp` in
+  `compile_commands.json` so `make tidy` runs them with the proper
+  compile flags. New drivers that aren't wired in here will lint with
+  default flags only (and miss e.g. a cross-driver include resolution).
 
 ### Example folders
 

--- a/lib/wsen-pads/src/WSEN_PADS.cpp
+++ b/lib/wsen-pads/src/WSEN_PADS.cpp
@@ -4,12 +4,7 @@
 #include <math.h>
 #include <stdint.h>
 
-WSEN_PADS::WSEN_PADS(TwoWire& wire, uint8_t address)
-    : _wire(&wire),
-      _address(address),
-      _tempUserSlope(1.0f),
-      _tempUserOffset(0.0f),
-      _tempOffset(0.0f) {}
+WSEN_PADS::WSEN_PADS(TwoWire& wire, uint8_t address) : _wire(&wire), _address(address) {}
 
 // ---------------------------------------------------------------------
 // Lifecycle

--- a/lib/wsen-pads/src/WSEN_PADS.h
+++ b/lib/wsen-pads/src/WSEN_PADS.h
@@ -56,9 +56,9 @@ class WSEN_PADS {
    private:
     TwoWire* _wire;
     uint8_t _address;
-    float _tempUserSlope;   // two-point user calibration slope
-    float _tempUserOffset;  // two-point user calibration intercept
-    float _tempOffset;      // additive offset on top of user calibration
+    float _tempUserSlope = 1.0f;   // two-point user calibration slope
+    float _tempUserOffset = 0.0f;  // two-point user calibration intercept
+    float _tempOffset = 0.0f;      // additive offset on top of user calibration
 
     // I2C helpers
     bool isPresent();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,19 +1,29 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // Build smoke-test sketch: validates the board definition, the STM32duino
-// variant, and driver linkage for the sensors that have already landed.
-// Not an example — see lib/<component>/examples/ for driver usage.
+// variant, and driver linkage for every implemented driver in the
+// collection. As a side effect, every driver's .cpp file ends up in
+// `compile_commands.json` (the native env follows the includes here),
+// which gives `make tidy` proper compile flags for each driver.
+//
+// When a new driver lands, add its `#include`, instantiate it on the
+// right bus, and add a `begin()` + identity probe section below. The
+// loop stays a simple LED blink — this file is not an example, see
+// lib/<component>/examples/ for driver usage.
 
 #include <Arduino.h>
 #include <HTS221.h>
+#include <WSEN_PADS.h>
 #include <Wire.h>
 
-// The STeaMi routes the HTS221 to its internal I2C bus (pins PB8/PB9,
-// exported as I2C_INT_SCL / I2C_INT_SDA by the variant). The default
-// global Wire sits on a different pair, so spin up a dedicated TwoWire
-// for the on-board peripherals and hand it to the driver.
+// The STeaMi routes its on-board I2C peripherals to an internal bus
+// (pins PB8/PB9, exported as I2C_INT_SCL / I2C_INT_SDA by the variant).
+// The default global Wire sits on a different pair, so spin up a
+// dedicated TwoWire and hand it to every on-board driver.
 TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+
 HTS221 hts221(internalI2C);
+WSEN_PADS wsen_pads(internalI2C);
 
 void setup() {
     Serial.begin(115200);
@@ -26,6 +36,8 @@ void setup() {
     pinMode(LED_BLUE, OUTPUT);
 
     internalI2C.begin();
+
+    // --- HTS221 (humidity + temperature) ---
     if (hts221.begin()) {
         Serial.print("HTS221 detected, WHO_AM_I = 0x");
         Serial.println(hts221.deviceId(), HEX);
@@ -38,6 +50,21 @@ void setup() {
         Serial.println(" %");
     } else {
         Serial.println("HTS221 not detected");
+    }
+
+    // --- WSEN-PADS (pressure + temperature) ---
+    if (wsen_pads.begin()) {
+        Serial.print("WSEN-PADS detected, DEVICE_ID = 0x");
+        Serial.println(wsen_pads.deviceId(), HEX);
+
+        auto r = wsen_pads.read();
+        Serial.print("WSEN-PADS first read: P = ");
+        Serial.print(r.pressure, 2);
+        Serial.print(" hPa, T = ");
+        Serial.print(r.temperature, 2);
+        Serial.println(" C");
+    } else {
+        Serial.println("WSEN-PADS not detected");
     }
 }
 


### PR DESCRIPTION
## Summary

`src/main.cpp` used to instantiate only HTS221, which meant PlatformIO's native env only compiled `HTS221.cpp` + `main.cpp` into `compile_commands.json`. Every other driver got default clang-tidy flags via the include-path fallback added in #165 — workable, but it masked any real lint warning on those drivers and kept the `--extra-arg-before` workaround load-bearing.

This PR makes the smoke-test sketch a real "every implemented driver still links" check.

## What lands

* **`src/main.cpp`** instantiates every implemented driver on the right bus (`internalI2C` for the on-board peripherals), calls `begin()` and a quick identity probe, and prints the result. Today that's HTS221 + WSEN-PADS; the sketch grows by one section per new implemented driver.
* **`lib/wsen-pads/src/WSEN_PADS.{h,cpp}`** — align member init to the in-class default-init style HTS221 already uses. clang-tidy was now seeing WSEN_PADS.cpp under proper compile flags and flagging `modernize-use-default-member-init`. Net result: cleaner header, simpler constructor body.
* **`CONTRIBUTING.md`** — add a bullet under *Driver structure / Requirements* stating that a new implemented driver should ship its smoke section to `main.cpp` on the same PR.

## Side effects

* `compile_commands.json` now lists every implemented driver's `.cpp`, so clang-tidy runs them with the resolved `-I` and `-D` flags PIO would use.
* The steami build now exercises every driver — links in 6 s, stays under 7% flash.
* The `--extra-arg-before=-I<lib>/src` machinery from #165 is still in place as belt-and-suspenders for the case where someone forgets the smoke-test step. Could be removed in a future cleanup if we add a CI check that fails on missing smoke-test sections, but no need to bundle that here.

## Validated on hardware

Flashed onto a connected STeaMi via `make upload`, captured serial via `scripts/capture-serial.py`:

```
STeaMi smoke test
HTS221 detected, WHO_AM_I = 0xBC
HTS221 first read: T = 29.28 C, H = 44.6 %
WSEN-PADS detected, DEVICE_ID = 0xB3
WSEN-PADS first read: P = 995.35 hPa, T = 31.04 C
Blink
Blink
```

Both drivers respond, values plausible (Marseille indoor, low atmospheric pressure today).