### PR TITLE
feat(tooling): Add YAML-driven qualification harness.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 include env.mk
 
 PIO := .venv/bin/pio
+PYTHON := .venv/bin/python3
 EXAMPLES_ROOT := lib
 
 # --- Setup ---
@@ -276,6 +277,27 @@ list-tests: ## List ready-to-run test- targets across all tiers
 	@for k in $(INTEGRATION_TEST_KEYS); do printf 'test-integration/%s\n' "$$k"; done
 	@for k in $(ALL_TEST_KEYS); do printf 'test/%s\n' "$$k"; done
 
+# --- Qualification ---
+
+QUALIFY_DRIVERS := $(notdir $(wildcard tests/qualification/*))
+
+.PHONY: list-qualification
+list-qualification: ## List all available qualification targets
+	@if [ -z "$(QUALIFY_DRIVERS)" ]; then \
+		echo "No qualification scenarios found under tests/qualification/."; \
+		exit 1; \
+	fi
+	@for drv in $(QUALIFY_DRIVERS); do \
+		echo qualify-$$drv; \
+	done
+
+define QUALIFY_template
+.PHONY: qualify-$(1)
+qualify-$(1): ## Run YAML qualification scenario for $(1)
+	@$(PYTHON) scripts/qualify.py $(1)
+endef
+
+$(foreach drv,$(QUALIFY_DRIVERS),$(eval $(call QUALIFY_template,$(drv))))
 # --- CI ---
 
 .PHONY: ci

--- a/Makefile
+++ b/Makefile
@@ -293,7 +293,7 @@ list-qualification: ## List all available qualification targets
 
 define QUALIFY_template
 .PHONY: qualify-$(1)
-qualify-$(1): ## Run YAML qualification scenario for $(1)
+qualify-$(1): setup ## Run YAML qualification scenario for $(1)
 	@$(PYTHON) scripts/qualify.py $(1)
 endef
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ platformio==6.1.19
 clang-format==22.1.3
 clang-tidy==22.1.0.1
 pyserial==3.5
+PyYAML==6.0.2

--- a/scripts/qualify.py
+++ b/scripts/qualify.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Run a YAML-driven human qualification scenario on a real STeaMi board.
+
+Qualification tests sit above unit/integration tiers: they verify that a
+human-induced physical perturbation (breathing on a humidity sensor,
+warming the board, covering a light sensor, moving near a distance
+sensor...) causes a coherent change in the observed measurements.
+
+The runner:
+
+  1. loads tests/qualification/<driver>/qualify.yaml
+  2. flashes the paired qualification sketch
+  3. opens the serial port before reset
+  4. resets the board through OpenOCD
+  5. walks the YAML phases interactively
+  6. evaluates declared assertions
+  7. archives the full session under logs/qualification/
+
+Usage:
+
+    python scripts/qualify.py hts221
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import re
+import statistics
+import subprocess
+import sys
+import time
+import os
+from pathlib import Path
+
+import serial
+import yaml
+from serial.tools import list_ports
+
+DEFAULT_PORT = "/dev/ttyACM0"
+DEFAULT_BAUDRATE = 115200
+ROOT = Path(__file__).resolve().parent.parent
+
+
+# ---------- low-level board plumbing ----------
+
+
+def steami_port(default_port: str) -> str | None:
+    ports = list(list_ports.comports())
+
+    if not ports:
+        return None
+
+    for port in ports:
+        if port.device == default_port:
+            return port.device
+
+    for port in ports:
+        if port.device.startswith("/dev/ttyACM"):
+            return port.device
+
+    return None
+
+
+def reset_board() -> None:
+    cmd = [
+        "openocd",
+        "-f",
+        "interface/cmsis-dap.cfg",
+        "-f",
+        "target/stm32wbx.cfg",
+        "-c",
+        "init; reset; shutdown",
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    if result.returncode != 0:
+        if result.stdout:
+            print(result.stdout, file=sys.stderr, end="")
+        if result.stderr:
+            print(result.stderr, file=sys.stderr, end="")
+        raise SystemExit("Error: OpenOCD reset failed.")
+
+
+def flash_qualification_sketch(driver: str) -> None:
+    src_dir = ROOT / "tests" / "qualification" / driver
+
+    if not src_dir.exists():
+        raise SystemExit(f"Error: qualification directory not found for '{driver}'.")
+
+    cmd = [
+        ".venv/bin/pio",
+        "run",
+        "-e",
+        "steami",
+        "-t",
+        "upload",
+    ]
+
+    env = dict(os.environ)
+    env["PLATFORMIO_SRC_DIR"] = str(src_dir)
+
+    result = subprocess.run(cmd, env=env)
+
+    if result.returncode != 0:
+        raise SystemExit("Error: qualification sketch upload failed.")
+
+
+# ---------- YAML loading ----------
+
+
+def load_scenario(driver: str) -> dict:
+    path = ROOT / "tests" / "qualification" / driver / "qualify.yaml"
+
+    if not path.exists():
+        raise SystemExit(f"Error: {path} not found.")
+
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+
+    if not isinstance(data, dict):
+        raise SystemExit("Error: qualification YAML root must be a mapping.")
+
+    if "phases" not in data or not isinstance(data["phases"], list):
+        raise SystemExit("Error: qualification YAML must define a phases list.")
+
+    return data
+
+
+# ---------- serial parsing ----------
+
+
+PAIR_RE = re.compile(r"([a-zA-Z_]+)=(-?\d+(?:\.\d+)?)")
+
+
+def parse_measurements(line: str) -> dict[str, float]:
+    out: dict[str, float] = {}
+
+    for key, value in PAIR_RE.findall(line):
+        out[key] = float(value)
+
+    return out
+
+
+def capture_phase(
+    ser: serial.Serial,
+    seconds: float,
+    wanted: list[str],
+    log,
+    phase_name: str,
+) -> dict[str, list[float]]:
+    captured = {key: [] for key in wanted}
+
+    ser.reset_input_buffer()
+    time.sleep(0.2)
+    reset_board()
+    deadline = time.monotonic() + seconds
+    
+    while time.monotonic() < deadline:
+        raw = ser.readline()
+        if not raw:
+            continue
+
+        text = raw.decode("utf-8", errors="replace").strip()
+        stamp = timestamp()
+        log.write(f"[{stamp}] SERIAL {phase_name} {text}\n")
+
+        values = parse_measurements(text)
+
+        for key in wanted:
+            if key in values:
+                captured[key].append(values[key])
+
+    return captured
+
+
+# ---------- metrics + assertions ----------
+
+
+def average_metrics(samples: dict[str, list[float]]) -> dict[str, float]:
+    metrics: dict[str, float] = {}
+
+    for key, values in samples.items():
+        if not values:
+            continue
+        metrics[key] = statistics.mean(values)
+
+    return metrics
+
+
+def evaluate_assertions(
+    phase_name: str,
+    phase_cfg: dict,
+    metrics: dict[str, float],
+    prior_metrics: dict[str, dict[str, float]],
+    log,
+) -> bool:
+    assertions = phase_cfg.get("assert")
+    if not assertions:
+        return True
+
+    passed = True
+
+    for raw_key, expected in assertions.items():
+        signal = raw_key.split("_")[0]
+
+        if signal not in metrics:
+            print(f"  FAIL: no captured values for '{signal}'")
+            log.write(f"[{timestamp()}] ASSERT FAIL {raw_key} missing-signal\n")
+            passed = False
+            continue
+
+        actual = metrics[signal]
+
+        if raw_key.endswith("_delta_min"):
+            ref_name = assertions.get(f"{signal}_delta_vs")
+            if ref_name not in prior_metrics or signal not in prior_metrics[ref_name]:
+                print(f"  FAIL: reference phase '{ref_name}' missing")
+                log.write(f"[{timestamp()}] ASSERT FAIL {raw_key} missing-reference\n")
+                passed = False
+                continue
+
+            delta = actual - prior_metrics[ref_name][signal]
+            ok = delta >= float(expected)
+            verdict = "PASS" if ok else "FAIL"
+            print(f"  {verdict}: {signal} delta >= {expected} (actual {delta:.2f})")
+            log.write(
+                f"[{timestamp()}] ASSERT {verdict} {raw_key} expected={expected} actual={delta:.2f}\n"
+            )
+            passed &= ok
+
+        elif raw_key.endswith("_delta_max"):
+            ref_name = assertions.get(f"{signal}_delta_vs")
+            if ref_name not in prior_metrics or signal not in prior_metrics[ref_name]:
+                print(f"  FAIL: reference phase '{ref_name}' missing")
+                log.write(f"[{timestamp()}] ASSERT FAIL {raw_key} missing-reference\n")
+                passed = False
+                continue
+
+            delta = actual - prior_metrics[ref_name][signal]
+            ok = delta <= float(expected)
+            verdict = "PASS" if ok else "FAIL"
+            print(f"  {verdict}: {signal} delta <= {expected} (actual {delta:.2f})")
+            log.write(
+                f"[{timestamp()}] ASSERT {verdict} {raw_key} expected={expected} actual={delta:.2f}\n"
+            )
+            passed &= ok
+
+        elif raw_key.endswith("_min"):
+            ok = actual >= float(expected)
+            verdict = "PASS" if ok else "FAIL"
+            print(f"  {verdict}: {signal} avg >= {expected} (actual {actual:.2f})")
+            log.write(
+                f"[{timestamp()}] ASSERT {verdict} {raw_key} expected={expected} actual={actual:.2f}\n"
+            )
+            passed &= ok
+
+        elif raw_key.endswith("_max"):
+            ok = actual <= float(expected)
+            verdict = "PASS" if ok else "FAIL"
+            print(f"  {verdict}: {signal} avg <= {expected} (actual {actual:.2f})")
+            log.write(
+                f"[{timestamp()}] ASSERT {verdict} {raw_key} expected={expected} actual={actual:.2f}\n"
+            )
+            passed &= ok
+
+    return passed
+
+
+# ---------- misc ----------
+
+
+def timestamp() -> str:
+    return dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def open_log(driver: str):
+    log_dir = ROOT / "logs" / "qualification"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    name = dt.datetime.now().strftime(f"{driver}-%Y-%m-%dT%H-%M-%S.log")
+    path = log_dir / name
+    return path, path.open("w", encoding="utf-8")
+
+
+# ---------- main runner ----------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run a YAML-driven qualification scenario."
+    )
+    parser.add_argument("driver", help="Driver qualification scenario to run")
+    parser.add_argument(
+        "--port",
+        default=DEFAULT_PORT,
+        help=f"Serial port to use (default: {DEFAULT_PORT})",
+    )
+    args = parser.parse_args()
+
+    scenario = load_scenario(args.driver)
+    baudrate = int(scenario.get("baud", DEFAULT_BAUDRATE))
+
+    port_name = steami_port(args.port)
+    if port_name is None:
+        print(
+            "Error: no STeaMi serial device detected. "
+            "Check that the board is connected and visible as /dev/ttyACM*.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Flashing qualification sketch for {args.driver}...")
+    flash_qualification_sketch(args.driver)
+
+    log_path, log = open_log(args.driver)
+
+    phase_metrics: dict[str, dict[str, float]] = {}
+    overall_pass = True
+
+    try:
+        with serial.Serial(port_name, baudrate=baudrate, timeout=0.1) as ser:
+            for phase in scenario["phases"]:
+                name = phase["name"]
+                prompt = phase["prompt"]
+                duration = float(phase.get("capture_seconds", 5))
+                wanted = phase.get("record", [])
+
+                print()
+                print(f"=== Phase: {name} ===")
+                print(prompt)
+                input()
+
+                log.write(f"[{timestamp()}] PHASE {name}\n")
+                log.write(f"[{timestamp()}] PROMPT {prompt}\n")
+
+                samples = capture_phase(ser, duration, wanted, log, name)
+                metrics = average_metrics(samples)
+                phase_metrics[name] = metrics
+
+                for key, value in metrics.items():
+                    print(f"  {key}: avg={value:.2f}")
+                    log.write(f"[{timestamp()}] METRIC {name} {key} avg={value:.2f}\n")
+
+                phase_ok = evaluate_assertions(name, phase, metrics, phase_metrics, log)
+
+                if phase.get("wait_for_confirm", False):
+                    answer = input("Reading coherent? [y/N] ").strip().lower()
+                    human_ok = answer == "y"
+                    log.write(f"[{timestamp()}] HUMAN_CONFIRM {name} {answer}\n")
+                    phase_ok &= human_ok
+
+                overall_pass &= phase_ok
+
+    finally:
+        log.close()
+
+    print()
+    print(f"Qualification log archived to: {log_path}")
+
+    return 0 if overall_pass else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qualify.py
+++ b/scripts/qualify.py
@@ -74,7 +74,7 @@ def reset_board() -> None:
         "init; reset; shutdown",
     ]
 
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = subprocess.run(cmd, capture_output=True, text=True, cwd=ROOT)
 
     if result.returncode != 0:
         if result.stdout:
@@ -90,8 +90,13 @@ def flash_qualification_sketch(driver: str) -> None:
     if not src_dir.exists():
         raise SystemExit(f"Error: qualification directory not found for '{driver}'.")
 
+    pio = ROOT / ".venv" / "bin" / "pio"
+    
+    if not pio.exists():
+        raise SystemExit("Error: .venv/bin/pio not found. Run 'make setup' first.")
+    
     cmd = [
-        ".venv/bin/pio",
+        str(pio),
         "run",
         "-e",
         "steami",
@@ -102,7 +107,11 @@ def flash_qualification_sketch(driver: str) -> None:
     env = dict(os.environ)
     env["PLATFORMIO_SRC_DIR"] = str(src_dir)
 
-    result = subprocess.run(cmd, env=env)
+    result = subprocess.run(
+        cmd,
+        env=env,
+        cwd=ROOT,
+    )
 
     if result.returncode != 0:
         raise SystemExit("Error: qualification sketch upload failed.")
@@ -215,10 +224,30 @@ def evaluate_assertions(
         actual = metrics[signal]
 
         if raw_key.endswith("_delta_min"):
-            ref_name = assertions.get(f"{signal}_delta_vs")
-            if ref_name not in prior_metrics or signal not in prior_metrics[ref_name]:
-                print(f"  FAIL: reference phase '{ref_name}' missing")
-                log.write(f"[{timestamp()}] ASSERT FAIL [{raw_key}] missing-reference\n")
+            ref_key = f"{signal}_delta_vs"
+            ref_name = assertions.get(ref_key)
+
+            if not isinstance(ref_name, str):
+                print(f"  FAIL: missing '{ref_key}' for assertion '{raw_key}'")
+                log.write(
+                    f"[{timestamp()}] ASSERT FAIL [{phase_name}] {raw_key} missing-{ref_key}\n"
+                )
+                passed = False
+                continue
+
+            if ref_name not in prior_metrics:
+                print(f"  FAIL: reference phase '{ref_name}' not found")
+                log.write(
+                    f"[{timestamp()}] ASSERT FAIL [{phase_name}] {raw_key} unknown-phase={ref_name}\n"
+                )
+                passed = False
+                continue
+
+            if signal not in prior_metrics[ref_name]:
+                print(f"  FAIL: reference phase '{ref_name}' has no '{signal}' data")
+                log.write(
+                    f"[{timestamp()}] ASSERT FAIL [{phase_name}] {raw_key} missing-signal={signal}\n"
+                )
                 passed = False
                 continue
 

--- a/scripts/qualify.py
+++ b/scripts/qualify.py
@@ -165,7 +165,7 @@ def capture_phase(
 
         text = raw.decode("utf-8", errors="replace").strip()
         stamp = timestamp()
-        log.write(f"[{stamp}] SERIAL {phase_name} {text}\n")
+        log.write(f"[{stamp}] SERIAL [{phase_name}] {text}\n")
 
         values = parse_measurements(text)
 
@@ -208,7 +208,7 @@ def evaluate_assertions(
 
         if signal not in metrics:
             print(f"  FAIL: no captured values for '{signal}'")
-            log.write(f"[{timestamp()}] ASSERT FAIL {raw_key} missing-signal\n")
+            log.write(f"[{timestamp()}] ASSERT FAIL [{raw_key}] missing-signal\n")
             passed = False
             continue
 
@@ -218,7 +218,7 @@ def evaluate_assertions(
             ref_name = assertions.get(f"{signal}_delta_vs")
             if ref_name not in prior_metrics or signal not in prior_metrics[ref_name]:
                 print(f"  FAIL: reference phase '{ref_name}' missing")
-                log.write(f"[{timestamp()}] ASSERT FAIL {raw_key} missing-reference\n")
+                log.write(f"[{timestamp()}] ASSERT FAIL [{raw_key}] missing-reference\n")
                 passed = False
                 continue
 
@@ -227,7 +227,7 @@ def evaluate_assertions(
             verdict = "PASS" if ok else "FAIL"
             print(f"  {verdict}: {signal} delta >= {expected} (actual {delta:.2f})")
             log.write(
-                f"[{timestamp()}] ASSERT {verdict} {raw_key} expected={expected} actual={delta:.2f}\n"
+                f"[{timestamp()}] ASSERT {verdict} [{raw_key}] expected={expected} actual={delta:.2f}\n"
             )
             passed &= ok
 
@@ -235,7 +235,7 @@ def evaluate_assertions(
             ref_name = assertions.get(f"{signal}_delta_vs")
             if ref_name not in prior_metrics or signal not in prior_metrics[ref_name]:
                 print(f"  FAIL: reference phase '{ref_name}' missing")
-                log.write(f"[{timestamp()}] ASSERT FAIL {raw_key} missing-reference\n")
+                log.write(f"[{timestamp()}] ASSERT FAIL [{raw_key}] missing-reference\n")
                 passed = False
                 continue
 
@@ -244,7 +244,7 @@ def evaluate_assertions(
             verdict = "PASS" if ok else "FAIL"
             print(f"  {verdict}: {signal} delta <= {expected} (actual {delta:.2f})")
             log.write(
-                f"[{timestamp()}] ASSERT {verdict} {raw_key} expected={expected} actual={delta:.2f}\n"
+                f"[{timestamp()}] ASSERT {verdict} [{raw_key}] expected={expected} actual={delta:.2f}\n"
             )
             passed &= ok
 
@@ -253,7 +253,7 @@ def evaluate_assertions(
             verdict = "PASS" if ok else "FAIL"
             print(f"  {verdict}: {signal} avg >= {expected} (actual {actual:.2f})")
             log.write(
-                f"[{timestamp()}] ASSERT {verdict} {raw_key} expected={expected} actual={actual:.2f}\n"
+                f"[{timestamp()}] ASSERT {verdict} [{raw_key}] expected={expected} actual={actual:.2f}\n"
             )
             passed &= ok
 
@@ -262,7 +262,7 @@ def evaluate_assertions(
             verdict = "PASS" if ok else "FAIL"
             print(f"  {verdict}: {signal} avg <= {expected} (actual {actual:.2f})")
             log.write(
-                f"[{timestamp()}] ASSERT {verdict} {raw_key} expected={expected} actual={actual:.2f}\n"
+                f"[{timestamp()}] ASSERT {verdict} [{raw_key}] expected={expected} actual={actual:.2f}\n"
             )
             passed &= ok
 
@@ -333,8 +333,8 @@ def main() -> int:
                 print(prompt)
                 input()
 
-                log.write(f"[{timestamp()}] PHASE {name}\n")
-                log.write(f"[{timestamp()}] PROMPT {prompt}\n")
+                log.write(f"[{timestamp()}] PHASE [{name}]\n")
+                log.write(f"[{timestamp()}] PROMPT [{prompt}]\n")
 
                 samples = capture_phase(ser, duration, wanted, log, name)
                 metrics = average_metrics(samples)
@@ -342,14 +342,14 @@ def main() -> int:
 
                 for key, value in metrics.items():
                     print(f"  {key}: avg={value:.2f}")
-                    log.write(f"[{timestamp()}] METRIC {name} {key} avg={value:.2f}\n")
+                    log.write(f"[{timestamp()}] METRIC [{name}] [{key}] avg={value:.2f}\n")
 
                 phase_ok = evaluate_assertions(name, phase, metrics, phase_metrics, log)
 
                 if phase.get("wait_for_confirm", False):
                     answer = input("Reading coherent? [y/N] ").strip().lower()
                     human_ok = answer == "y"
-                    log.write(f"[{timestamp()}] HUMAN_CONFIRM {name} {answer}\n")
+                    log.write(f"[{timestamp()}] HUMAN_CONFIRM [{name}] [{answer}]\n")
                     phase_ok &= human_ok
 
                 overall_pass &= phase_ok

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -173,6 +173,34 @@ These tests answer:
 
 Integration tests complement hardware unit tests rather than replace them.
 
+### 4. Qualification tests (`tests/qualification/`)
+
+Qualification tests are YAML-driven human-in-the-loop physical coherence
+checks run on a real STeaMi board.
+
+They validate a higher-level question than hardware/integration suites:
+
+> "Does a real environmental perturbation cause the sensor reading to react
+> coherently?"
+
+Typical examples:
+
+* breathing on a humidity sensor should increase %RH,
+* warming the board should raise temperature,
+* covering a light sensor should reduce luminosity.
+
+Each qualification scenario consists of:
+
+* a `qualify.ino` sketch streaming machine-readable measurements,
+* a `qualify.yaml` file declaring interactive phases, prompts, capture
+  windows, and assertions.
+
+Run available scenarios with:
+
+```bash
+make list-qualification
+make qualify-hts221
+
 ---
 
 ## Shared Driver Checks

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -200,7 +200,7 @@ Run available scenarios with:
 ```bash
 make list-qualification
 make qualify-hts221
-
+```
 ---
 
 ## Shared Driver Checks

--- a/tests/qualification/hts221/qualify.ino
+++ b/tests/qualification/hts221/qualify.ino
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <Arduino.h>
+#include <HTS221.h>
+#include <Wire.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+HTS221 sensor(internalI2C);
+
+void setup() {
+    Serial.begin(115200);
+    delay(500);
+
+    internalI2C.begin();
+
+    if (!sensor.begin()) {
+        Serial.println("begin_failed=1");
+        while (true) {
+            delay(1000);
+        }
+    }
+
+    sensor.setContinuous(HTS221_ODR_1_HZ);
+
+    Serial.println("ready=1");
+}
+
+void loop() {
+    if (!sensor.dataReady()) {
+        delay(10);
+        return;
+    }
+
+    auto reading = sensor.read();
+
+    Serial.print("temperature=");
+    Serial.print(reading.temperature, 2);
+    Serial.print(" ");
+
+    Serial.print("humidity=");
+    Serial.print(reading.humidity, 2);
+    Serial.println();
+
+    delay(50);
+}

--- a/tests/qualification/hts221/qualify.yaml
+++ b/tests/qualification/hts221/qualify.yaml
@@ -1,0 +1,36 @@
+baud: 115200
+
+phases:
+  - name: Baseline
+    prompt: "Press Enter, then leave the board undisturbed on the desk."
+    capture_seconds: 5
+    record:
+      - temperature
+      - humidity
+    assert:
+      temperature_min: 10
+      temperature_max: 50
+      humidity_min: 10
+      humidity_max: 90
+
+  - name: Breathing
+    prompt: "Press Enter, then breathe directly on the HTS221 sensor for ~5 seconds."
+    capture_seconds: 5
+    record:
+      - humidity
+    assert:
+      humidity_delta_vs: Baseline
+      humidity_delta_min: 1.0
+      humidity_delta_max: 10
+    wait_for_confirm: true
+
+  - name: Warm fingers
+    prompt: "Press Enter, then hold two fingers on the sensor area for ~5 seconds."
+    capture_seconds: 5
+    record:
+      - temperature
+    assert:
+      temperature_delta_vs: Baseline
+      temperature_delta_min: 0.5
+      temperature_delta_max: 5
+    wait_for_confirm: true


### PR DESCRIPTION
Closes #124
Closes #125

## Summary

Add a fourth validation tier to the tooling: YAML-driven human-in-the-loop qualification sessions for checking that a real sensor reacts coherently to real-world perturbations.

Unlike unit tests and scripted hardware captures, qualification tests intentionally involve an operator (breathe on the sensor, warm the board, cover it, etc.) and compare the observed measurements against declarative per-phase assertions.

This PR introduces the generic Python harness, Makefile integration, session logging, and a first reference scenario for HTS221.

## Changes

* Added `scripts/qualify.py`, a YAML-driven qualification runner that:

  * loads `tests/qualification/<driver>/qualify.yaml`
  * flashes the paired `qualify.ino`
  * opens serial before OpenOCD reset
  * walks interactive human-guided phases
  * captures serial measurements during each phase
  * evaluates declarative assertions (`min`, `max`, `delta_vs`, `delta_min`, `delta_max`)
  * archives the full session under `logs/qualification/`
  * exits non-zero on any failed assertion or failed operator confirmation
* Added `PyYAML` to `requirements.txt`
* Added dynamic Makefile qualification integration:

  * `make list-qualification`
  * auto-generated `make qualify-<driver>` targets from `tests/qualification/*`
* Added qualification documentation section to `tests/TESTING.md`
* Added first end-to-end reference qualification scenario for HTS221:

  * `tests/qualification/hts221/qualify.yaml`
  * `tests/qualification/hts221/qualify.ino`
* Added `logs/qualification/.gitkeep` for archived session outputs
* Reused the existing flash/reset plumbing introduced by the recent tooling stack (`flash-*` / `capture-*` family)

## Checklist

* [x] `make lint` passes (clang-format)
* [x] `make build` passes (PlatformIO)
* [ ] `make test-native` passes (if native tests exist)
* [ ] `make test-hardware` passes on a connected STeaMi (if hardware tests exist)
* [x] README updated (if adding/changing public API)
* [x] Examples added/updated (if applicable)
* [x] Commit messages follow conventional commits format
