### PR TITLE
test(tooling): Add VERBOSE mode for hardware tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,13 @@ $(foreach k,$(EXAMPLE_KEYS),$(eval $(call CAPTURE_RULE,$(k))))
 # (`wsen-pads`, `wsen-hids`) so a flat `verb-driver-suite` form would be
 # visually ambiguous; `/` is the unambiguous separator.
 
+# --- Test verbosity ---
+
+ifeq ($(VERBOSE),1)
+	PIO_TEST_FLAGS += -v
+	export PLATFORMIO_BUILD_FLAGS=-DTEST_VERBOSE=1
+endif
+
 NATIVE_TEST_KEYS := $(patsubst tests/native/test_%,%,$(wildcard tests/native/test_*))
 
 .PHONY: test-native
@@ -208,7 +215,7 @@ test-hardware: .venv/bin/pio ## Run all on-board hardware-unit tests (skipped if
 		echo "STeaMi not detected — skipping hardware tests."
 		exit 0
 	fi
-	$(PIO) test -e steami --filter hardware/test_*
+	$(PIO) test -e steami $(PIO_TEST_FLAGS) --filter hardware/test_* $(PIO_TEST_EXTRA_OPTS)
 
 # Per-suite hardware test targets — `make test-hardware/<name>` runs
 # only that suite. Same shape as test-native/<name>, with the added
@@ -222,7 +229,7 @@ test-hardware/$(1): .venv/bin/pio
 		echo "STeaMi not detected — skipping hardware tests."
 		exit 0
 	fi
-	$$(PIO) test -e steami --filter hardware/test_$(1)
+	$$(PIO) test -e steami $$(PIO_TEST_FLAGS) --filter hardware/test_$(1) $$(PIO_TEST_EXTRA_OPTS)
 endef
 $(foreach k,$(HARDWARE_TEST_KEYS),$(eval $(call HARDWARE_TEST_RULE,$(k))))
 

--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ test-integration: .venv/bin/pio ## Run all on-board integration tests (skipped i
 		echo "STeaMi not detected — skipping integration tests."
 		exit 0
 	fi
-	$(PIO) test -e steami --filter integration/test_*
+	$(PIO) test -e steami $(PIO_TEST_FLAGS) --filter integration/test_* $(PIO_TEST_EXTRA_OPTS)
 
 # Per-suite integration test targets — same shape as test-hardware/<name>.
 # Integration suites validate runtime behaviour over time (acquisition
@@ -254,7 +254,7 @@ test-integration/$(1): .venv/bin/pio
 		echo "STeaMi not detected — skipping integration tests."
 		exit 0
 	fi
-	$$(PIO) test -e steami --filter integration/test_$(1)
+	$$(PIO) test -e steami $$(PIO_TEST_FLAGS) --filter integration/test_$(1) $$(PIO_TEST_EXTRA_OPTS)
 endef
 $(foreach k,$(INTEGRATION_TEST_KEYS),$(eval $(call INTEGRATION_TEST_RULE,$(k))))
 

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -123,27 +123,36 @@ pio test -e steami --filter integration/test_<driver>
 
 ---
 
-## Debugging a failing hardware test
+## Debugging a failing on-board test
 
-By default, hardware test output is intentionally minimal: Unity captures the
+By default, on-board test output is intentionally minimal: Unity captures the
 serial channel and only prints test names with a final PASS/FAIL status.
 
 This keeps output clean, but makes debugging harder.
 
 ### Verbose mode
 
-To see the full Unity stream and debug messages:
+To see the full Unity stream and debug messages, set `VERBOSE=1` on any
+on-board test target — hardware or integration, full suite or per-driver:
 
 ```bash
 make test-hardware/<suite> VERBOSE=1
+make test-integration/<suite> VERBOSE=1
+make test-hardware VERBOSE=1
 ```
 
 This enables:
 
 * full Unity output (`-v`)
-* preservation of debug messages
+* preservation of debug messages via the `TEST_VERBOSE` build flag
 * raw (non-humanised) output
 
+For one-off extra flags to PlatformIO test (e.g. `--without-flashing`, a
+specific test case filter), pass them through `PIO_TEST_EXTRA_OPTS`:
+
+```bash
+make test-hardware/wsen_hids PIO_TEST_EXTRA_OPTS="--without-flashing"
+```
 
 ### Safe debug prints (Unity-compatible)
 
@@ -170,7 +179,7 @@ void test_example() {
 This will:
 
 * print safely without breaking Unity
-* are visible in `VERBOSE=1` mode
+* be visible in `VERBOSE=1` mode
 * keep normal test runs clean
 
 ---

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -123,6 +123,58 @@ pio test -e steami --filter integration/test_<driver>
 
 ---
 
+## Debugging a failing hardware test
+
+By default, hardware test output is intentionally minimal: Unity captures the
+serial channel and only prints test names with a final PASS/FAIL status.
+
+This keeps output clean, but makes debugging harder.
+
+### Verbose mode
+
+To see the full Unity stream and debug messages:
+
+```bash
+make test-hardware/<suite> VERBOSE=1
+```
+
+This enables:
+
+* full Unity output (`-v`)
+* preservation of debug messages
+* raw (non-humanised) output
+
+
+### Safe debug prints (Unity-compatible)
+
+Do **not** use `Serial.println()` inside tests.
+
+Unity uses the serial channel for its protocol. Writing directly to it will
+corrupt the output and can break test parsing.
+
+Instead, use Unity-safe debug helpers:
+
+```cpp
+#include <unity.h>
+
+void test_example() {
+    int state = 42;
+
+    TEST_MESSAGE("Starting test");
+    TEST_MESSAGE("state: 42");
+
+    TEST_ASSERT_EQUAL(42, state);
+}
+```
+
+This will:
+
+* print safely without breaking Unity
+* are visible in `VERBOSE=1` mode
+* keep normal test runs clean
+
+---
+
 ## Test Tier Responsibilities
 
 ### 1. Native tests (`tests/native/`)


### PR DESCRIPTION
## Add VERBOSE mode for hardware tests + debugging docs

Closes #126
Closes #154 (I created this one before seeing on was already adressing it)

### Problem

When a hardware test fails (`pio test -e steami`), it's hard to debug:
- Unity captures the serial channel
- `Serial.println()` breaks the protocol and corrupts output
- Only PASS/FAIL is visible by default

### Solution

Introduce a `VERBOSE=1` mode:

```bash
make test-hardware/<suite> VERBOSE=1
```
This:

- Enables full Unity output (-v)
- Preserves debug messages
- Injects -DTEST_VERBOSE=1 via PLATFORMIO_BUILD_FLAGS

### Changes

#### Makefile:
- Add VERBOSE switch
- Pass -v to pio test
- Inject TEST_VERBOSE build flag

#### Documentation:
- Add "Debugging a failing hardware test" section
- Explain safe debug methods (TEST_MESSAGE, UnityPrint)
- Warn against Serial.println() in tests