### PR TITLE
style(ble): Restore alphabetical include order in BleBeacon.

### DIFF
--- a/lib/ble/examples/BleBeacon/BleBeacon.ino
+++ b/lib/ble/examples/BleBeacon/BleBeacon.ino
@@ -11,8 +11,8 @@
 
 #include <Arduino.h>
 #include <STM32duinoBLE.h>
-#include <WsenHids.h>
 #include <Wire.h>
+#include <WsenHids.h>
 
 TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
 WsenHids sensor(internalI2C);


### PR DESCRIPTION
## Summary

`make lint` has been failing on `main` since PR #139 was merged. The cause: my HTS221 → WSEN-HIDS migration in that PR left `<WsenHids.h>` before `<Wire.h>`, which the pinned `clang-format 22.1.3` (see `requirements.txt`) sorts strictly.

This PR restores the alphabetical order. One-line change.

## Verification

Before:
```cpp
#include <Arduino.h>
#include <STM32duinoBLE.h>
#include <WsenHids.h>
#include <Wire.h>
```

After (matches `clang-format -i` output with the project `.clang-format`):
```cpp
#include <Arduino.h>
#include <STM32duinoBLE.h>
#include <Wire.h>
#include <WsenHids.h>
```

Running `clang-format --dry-run --Werror` against `find lib/ src/ tests/ -name '*.h' -o -name '*.cpp' -o -name '*.ino'` is silent locally after the fix.

## Follow-up

Once merged, PR #141 (Hot/Cold rework) will rebase to pick up the fix and turn its lint check green.

## Checklist

- [x] `make lint` passes locally
- [x] No semantic change (only include sort order)