### PR TITLE
ci: Move CodeQL from default setup to an explicit workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,6 +16,12 @@ permissions:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
+    # GITHUB_TOKEN cannot be granted security-events: write on
+    # pull_request runs from forks, so the SARIF upload would fail with
+    # "Resource not accessible by integration". Skip fork PRs — they get
+    # CodeQL coverage via the push run after the merge into main, and
+    # the schedule keeps the base branch scanned weekly.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    # Weekly Monday 12:00 UTC — matches the cadence the previous default
+    # setup was configured to use, so the security tab doesn't get a
+    # stale finding without a fresh scan to confirm it.
+    - cron: '0 12 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, c-cpp, javascript-typescript, python]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # `none` skips the build step for compiled languages and runs
+          # static analysis directly on the sources. Mirrors the previous
+          # default setup behaviour (no PlatformIO toolchain needed in
+          # the CodeQL runner) and keeps wall-clock under a couple of
+          # minutes per language.
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Move CodeQL code scanning from GitHub's UI-managed "default setup" to
an explicit workflow file under `.github/workflows/codeql.yml`.

## Why

During today's GitHub Actions authentication incident, the four
`Analyze (...)` CodeQL jobs on PR #131 ended up stuck in a failed
state with the error _"workflow file may be broken"_ and could not
be retried via `gh run rerun` — there was no YAML for GitHub to
re-evaluate. Default setup only re-runs on a fresh push.

Owning the workflow in-repo means:
- Re-runnable like every other workflow (`gh run rerun`).
- Reviewable via PR — no opaque UI-only setting.
- Version-controlled alongside the rest of CI.

## Shape

Mirrors what default setup was running:

- **Languages**: `actions`, `c-cpp`, `javascript-typescript`, `python`
  (the previous setup also listed `javascript` and `typescript`
  separately; those are subsumed by `javascript-typescript`).
- **`build-mode: none`** for every language — runs static analysis
  directly against the sources. No PlatformIO toolchain needed in
  the CodeQL runner, and each language finishes in ~2 min, matching
  the previous wall-clock.
- **Schedule**: weekly Monday 12:00 UTC, matching the previous
  default-setup cadence.

## Cutover

Before merging this PR the existing default setup has to be turned
off — otherwise CodeQL runs twice on every push. The intent is to
disable it via the code-scanning default-setup API once CI on this
PR confirms the new workflow runs cleanly. The PR will not be ready
to merge until that swap is done.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(...)"` — YAML valid.
- [ ] GitHub Actions runs the new workflow on this PR and all four
      `Analyze (...)` jobs pass.
- [ ] Default setup disabled via `PATCH
      /repos/{owner}/{repo}/code-scanning/default-setup` with
      `{"state": "not-configured"}`.
- [ ] Subsequent push to this PR confirms only the workflow-driven
      CodeQL runs (no duplicate from default setup).