### PR TITLE
feat(lis2mdl): Implement Arduino driver.  #4

### DIFF
--- a/lib/lis2mdl/README.md
+++ b/lib/lis2mdl/README.md
@@ -1,5 +1,202 @@
-# lis2mdl
+# LIS2MDL
 
-Arduino driver for the lis2mdl component of the STeaMi board.
+Arduino/C++ driver for the ST LIS2MDL 3-axis magnetometer on the STeaMi board.
 
-> **Status**: not yet implemented
+## Hardware
+
+* I2C sensor, default 7-bit address `0x1E`.
+* Fixed ±50 gauss full scale, 1.5 mG/LSB (0.15 µT/LSB).
+* Output Data Rate: 10, 20, 50, or 100 Hz.
+
+## Quick start
+
+On the STeaMi board, the LIS2MDL is routed to the **internal** I2C bus
+(pins `I2C_INT_SDA` / `I2C_INT_SCL` from the variant, not the default
+global `Wire`). Spin up a dedicated `TwoWire` and hand it to the driver:
+
+```cpp
+#include <Wire.h>
+#include <LIS2MDL.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+LIS2MDL sensor(internalI2C);
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial && millis() < 2000) {}
+    internalI2C.begin();
+
+    if (!sensor.begin()) {
+        Serial.println("LIS2MDL not detected");
+        while (true) delay(1000);
+    }
+
+    sensor.setContinuous(10);
+}
+
+void loop() {
+    if (sensor.dataReady()) {
+        MagneticField f = sensor.magneticField();
+        Serial.print(f.x); Serial.print(" ");
+        Serial.print(f.y); Serial.print(" ");
+        Serial.println(f.z);
+    }
+    delay(100);
+}
+```
+
+See [examples/read_magnetic_field/](examples/read_magnetic_field/)
+for the full sketch.
+
+## Examples
+
+| Example | What it does |
+|---------|--------------|
+| [`read_magnetic_field`](examples/read_magnetic_field/) | Print raw X/Y/Z magnetic field values at 10 Hz. |
+| [`compass`](examples/compass/) | Flat 2D compass heading with min/max calibration and cardinal direction label. |
+| [`magnitude`](examples/magnitude/) | Print total field strength in µT — useful to detect nearby magnets or metallic objects. |
+| [`tilt_compensated_compass`](examples/tilt_compensated_compass/) | Heading with tilt compensation using an external accelerometer. |
+
+### Building an example
+
+List available examples:
+
+```bash
+make list-examples
+```
+
+Then flash one:
+
+```bash
+make flash-lis2mdl/compass
+```
+
+To capture the first lines printed at boot:
+
+```bash
+make capture-lis2mdl/compass
+make capture-lis2mdl/compass DURATION=30
+```
+
+## API
+
+All methods follow the collection conventions: `camelCase`, unit suffix
+in method names when they carry ambiguity, no `read` / `get` prefix.
+
+### Lifecycle
+
+| Method | Description |
+|--------|-------------|
+| `LIS2MDL(TwoWire& wire = Wire, uint8_t address = LIS2MDL_I2C_ADDR, uint8_t odrHz = 10, bool tempComp = true, bool lowPower = false, bool drdyEnable = false)` | Construct. Defaults to global `Wire`, address `0x1E`, 10 Hz ODR, temperature compensation enabled. |
+| `bool begin()` | Probe `WHO_AM_I`, configure the sensor, leave it in continuous mode. Returns `false` if the sensor is not detected. |
+| `uint8_t deviceId()` | Reads `WHO_AM_I` (always `0x40`). |
+| `void softReset(uint16_t waitMs = 10)` | Software reset via `SOFT_RST` bit in `CFG_REG_A`. |
+| `void reboot(uint16_t waitMs = 10)` | Reload internal registers via `REBOOT` bit in `CFG_REG_A`. |
+| `void powerOn(const char* mode = "continuous")` | Exit idle mode. Pass `"continuous"` or `"single"`. |
+| `void powerOff()` | Switch to idle mode (low power). |
+| `bool isIdle()` | Returns `true` if `MD1..0 == 0b11`. |
+| `const char* getMode()` | Returns `"continuous"`, `"single"`, or `"idle"`. |
+
+### Reading
+
+If the sensor is idle when a read is requested, the driver automatically
+triggers a one-shot conversion, polls `dataReady()` with a bounded timeout,
+and returns the result. The caller does not have to manage modes manually.
+
+| Method | Return type | Description |
+|--------|-------------|-------------|
+| `magneticField()` | `MagneticField` (`Vec3i`) | Raw X/Y/Z in LSB (int16). |
+| `magneticFieldRaw()` | `MagneticField` | Alias for `magneticField()`. |
+| `magneticFieldUt()` | `MagneticFieldUt` (`Vec3f`) | Field in µT (0.15 µT/LSB). |
+| `calibratedField()` | `CalibratedField` (`Vec3f`) | Offset/scale corrected, unitless. |
+| `magnitudeUt()` | `float` | Total field strength in µT. |
+| `readAll()` | `ReadAll` | All channels in one call: `raw`, `ut`, `cal`, `tempC`, `status`. |
+| `dataReady()` | `bool` | `true` when a fresh XYZ triplet is available (Zyxda bit). |
+| `status()` | `uint8_t` | Raw `STATUS_REG` value. |
+| `readIntSource()` | `uint8_t` | Raw `INT_SOURCE_REG` value. |
+
+### Temperature
+
+The LIS2MDL embeds a temperature sensor intended for internal magnetic
+compensation. It has **no guaranteed absolute offset** (see datasheet
+Table 4) — the driver applies an empirical 25 °C base offset confirmed
+by Zephyr RTOS PR #35912. Use `setTempOffset()` or `calibrateTemperature()`
+to adjust against a reference thermometer.
+
+| Method | Description |
+|--------|-------------|
+| `float temperature()` | Silicon temperature in °C (empirical, not ambient). |
+| `int16_t readTemperatureRaw()` | Raw temperature LSB (8 LSB/°C). |
+| `void setTempOffset(float offset)` | Additive offset in °C (resets gain to 1.0). |
+| `bool calibrateTemperature(float refLow, float measLow, float refHigh, float measHigh)` | Two-point linear correction. Returns `false` if `measLow == measHigh`. |
+
+### Modes
+
+| Method | Description |
+|--------|-------------|
+| `void setContinuous(uint8_t hz = 10)` | Continuous mode at the given ODR (10, 20, 50, or 100 Hz). |
+| `void triggerOneShot()` | Non-blocking: start a single conversion. |
+| `MagneticField readOneShot()` | Trigger + wait + return. Returns `{0, 0, 0}` on timeout. |
+| `void setOdr(int hz)` | Set ODR bits only, without changing mode. |
+
+### Calibration
+
+| Method | Description |
+|--------|-------------|
+| `void setCalibrateStep(float xoff, float yoff, float zoff, float xscale, float yscale, float zscale)` | Set offsets and scales manually. |
+| `void calibrateMinmax2d(uint16_t samples = 300, uint16_t delayMs = 20)` | Min/max calibration on XY only — rotate board flat during acquisition. |
+| `void calibrateMinmax3d(uint16_t samples = 600, uint16_t delayMs = 20)` | Min/max calibration on all 3 axes — rotate board in all directions. |
+| `CalibratedField calibrateApply(float x, float y, float z)` | Apply current offset/scale to a raw triplet. |
+| `CalibrationQuality calibrateQuality(uint16_t samplesCheck = 200, uint16_t delayMs = 10)` | Evaluate calibration quality: center, radius dispersion, anisotropy. |
+| `void calibrateReset()` | Reset offsets to 0 and scales to 1. |
+| `void calibrateStep()` | Alias for `calibrateMinmax3d()`. |
+| `HwOffsets readHwOffsets()` | Read hardware offset registers (`OFFSET_*`). |
+| `void setHwOffsets(int16_t x, int16_t y, int16_t z)` | Write hardware offset registers. |
+
+### Heading / Compass
+
+| Method | Description |
+|--------|-------------|
+| `float headingFlatOnly()` | Compass angle (0–360°) assuming the board is flat. Uses XY only. |
+| `float headingFromVectors(float x, float y, float z, bool calibrated = true)` | Angle from a raw or calibrated triplet. |
+| `float headingWithTiltCompensation(Vec3f (*readAccel)())` | Tilt-compensated heading using an external accelerometer callback. |
+| `void setHeadingOffset(float deg)` | Software heading offset (physical 0° alignment). |
+| `void setDeclination(float deg)` | Magnetic declination correction for true north. |
+| `void setHeadingFilter(float alpha)` | Low-pass filter on heading via cos/sin averaging. `0` = off, `0.1–0.3` = light/medium. |
+| `const char* directionLabel(float angle = -1.0f)` | Returns `"N"`, `"NE"`, `"E"`, … . Pass `angle < 0` to read the sensor automatically. |
+
+### Configuration
+
+| Method | Description |
+|--------|-------------|
+| `void setLowPower(bool enabled)` | Toggle low-power mode (LP bit in `CFG_REG_A`). |
+| `void setLowPass(bool enabled)` | Toggle low-pass filter (LPF bit in `CFG_REG_B`). |
+| `void setOffsetCancellation(bool enabled, bool oneShot = false)` | Toggle hardware offset cancellation. |
+| `void setBdu(bool enabled = true)` | Toggle block data update (BDU bit in `CFG_REG_C`). |
+| `void setEndianness(bool bigEndian)` | Toggle byte order (BLE bit in `CFG_REG_C`). |
+| `void useSpi4wire(bool enable)` | Toggle 4-wire SPI mode. |
+
+## Register constants
+
+`LIS2MDL_const.h` exports register addresses (`LIS2MDL_*_REG`), the
+expected `WHO_AM_I` value (`LIS2MDL_WHO_AM_I_VAL`), and temperature
+conversion constants (`LIS2MDL_TEMP_SENSITIVITY`, `LIS2MDL_TEMP_OFFSET`)
+so applications can access the part directly when needed.
+
+## Testing
+
+Host-side unit tests under [`tests/native/test_lis2mdl/`](../../tests/native/test_lis2mdl/)
+exercise the driver against the `TwoWire` mock from
+`tests/native/helpers/Wire.h`. Hardware validation tests under
+[`tests/hardware/test_lis2mdl/`](../../tests/hardware/test_lis2mdl/)
+run on a real STeaMi and verify device detection, field plausibility,
+and sensor stability. Run them with:
+
+```bash
+make test-native        # host only, no board required
+make test-hardware      # requires a connected STeaMi
+```
+
+## License
+
+GPL-3.0-or-later — see [LICENSE](../../LICENSE).

--- a/lib/lis2mdl/src/LIS2MDL.cpp
+++ b/lib/lis2mdl/src/LIS2MDL.cpp
@@ -1,0 +1,704 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "LIS2MDL.h"
+
+#include <math.h>
+
+LIS2MDL::LIS2MDL(TwoWire& wire, uint8_t address, uint8_t odrHz, bool tempComp, bool lowPower,
+                 bool drdyEnable)
+    : _wire(&wire),
+      _address(address),
+      _odrHz(odrHz),
+      _tempComp(tempComp),
+      _lowPower(lowPower),
+      _drdyEnable(drdyEnable),
+      _writeBuffer{0},
+      _readBuffer{0},
+      _tempGain(1.0f),
+      _tempOffset(0.0f),
+      _tempBaseOffset(static_cast<float>(LIS2MDL_TEMP_OFFSET)),
+      _headingOffsetDeg(0.0f),
+      _declinationDeg(0.0f),
+      _hfAlpha(0.0f),
+      _hfCos(0.0f),
+      _hfSin(0.0f) {}
+
+void LIS2MDL::begin() {
+    writeReg(LIS2MDL_CFG_REG_A, 0x20);
+    delay(10);
+
+    uint8_t odrBits;
+    switch (_odrHz) {
+        case 20:
+            odrBits = 0b01;
+            break;
+        case 50:
+            odrBits = 0b10;
+            break;
+        case 100:
+            odrBits = 0b11;
+            break;
+        default:
+            odrBits = 0b00;
+            break;
+    }
+
+    uint8_t comp = _tempComp ? 1 : 0;
+    uint8_t lp   = _lowPower ? 1 : 0;
+    uint8_t cfgA = (comp << 7) | (lp << 4) | (odrBits << 2);
+    writeReg(LIS2MDL_CFG_REG_A, cfgA);
+
+    writeReg(LIS2MDL_CFG_REG_B, 0x00);
+
+    uint8_t cfgC = 0x10 | (_drdyEnable ? 0x01 : 0x00);
+    writeReg(LIS2MDL_CFG_REG_C, cfgC);
+}
+
+//--------------------------------------------------------
+// -------------------- SET functions --------------------
+//--------------------------------------------------------
+
+void LIS2MDL::setMode(const String& mode) {
+    uint8_t md;
+    if (mode == "continuous") {
+        md = 0b00;
+    } else if (mode == "single") {
+        md = 0b01;
+    } else if (mode == "powerdown") {
+        md = 0b11;
+    } else {
+        md = 0b00;
+    }
+
+    uint8_t reg = readReg(LIS2MDL_CFG_REG_A);
+    reg         = (reg & ~0b11) | md;
+    writeReg(LIS2MDL_CFG_REG_A, reg);
+}
+
+void LIS2MDL::setOdr(int hz) {
+    uint8_t odrBits;
+    switch (hz) {
+        case 10:
+            odrBits = 0b00;
+            break;
+        case 20:
+            odrBits = 0b01;
+            break;
+        case 50:
+            odrBits = 0b10;
+            break;
+        case 100:
+            odrBits = 0b11;
+            break;
+        default:
+            odrBits = 0b00;
+            break;
+    }
+
+    uint8_t reg = readReg(LIS2MDL_CFG_REG_A);
+    reg         = (reg & ~(0b11 << 2)) | (odrBits << 2);
+    writeReg(LIS2MDL_CFG_REG_A, reg);
+}
+
+void LIS2MDL::setContinuous(uint8_t hz) {
+    setOdr(hz);
+    setMode("continuous");
+}
+
+void LIS2MDL::triggerOneShot() {
+    setMode("single");
+}
+
+MagneticField LIS2MDL::readOneShot() {
+    triggerOneShot();
+    for (int i = 0; i < 50; i++) {
+        if (dataReady())
+            return magneticField();
+        delay(2);
+    }
+    return {0, 0, 0};
+}
+
+void LIS2MDL::setLowPower(bool enabled) {
+    uint8_t reg = readReg(LIS2MDL_CFG_REG_A);
+    if (enabled) {
+        reg |= 1 << 4;
+    } else {
+        reg &= ~(1 << 4);
+    }
+    writeReg(LIS2MDL_CFG_REG_A, reg);
+}
+
+void LIS2MDL::setLowPass(bool enabled) {
+    uint8_t reg = readReg(LIS2MDL_CFG_REG_B);
+    if (enabled) {
+        reg |= 1 << 0;
+    } else {
+        reg &= ~(1 << 0);
+    }
+    writeReg(LIS2MDL_CFG_REG_B, reg);
+}
+
+void LIS2MDL::setOffsetCancellation(bool enabled, bool oneShot) {
+    uint8_t reg = readReg(LIS2MDL_CFG_REG_B);
+    if (enabled) {
+        reg |= 1 << 1;
+    } else {
+        reg &= ~(1 << 1);
+    }
+    if (oneShot) {
+        reg |= 1 << 2;
+    } else {
+        reg &= ~(1 << 2);
+    }
+    writeReg(LIS2MDL_CFG_REG_B, reg);
+}
+
+void LIS2MDL::setBdu(bool enabled) {
+    uint8_t reg = readReg(LIS2MDL_CFG_REG_C);
+    if (enabled) {
+        reg |= 1 << 4;
+    } else {
+        reg &= ~(1 << 4);
+    }
+    writeReg(LIS2MDL_CFG_REG_C, reg);
+}
+
+void LIS2MDL::setEndianness(bool bigEndian) {
+    uint8_t reg = readReg(LIS2MDL_CFG_REG_C);
+    if (bigEndian) {
+        reg |= 1 << 3;
+    } else {
+        reg &= ~(1 << 3);
+    }
+    writeReg(LIS2MDL_CFG_REG_C, reg);
+}
+
+void LIS2MDL::useSpi4wire(bool enable) {
+    uint8_t reg = readReg(LIS2MDL_CFG_REG_C);
+    if (enable) {
+        reg |= 1 << 2;
+    } else {
+        reg &= ~(1 << 2);
+    }
+    writeReg(LIS2MDL_CFG_REG_C, reg);
+}
+
+void LIS2MDL::setHeadingOffset(float deg) {
+    _headingOffsetDeg = deg;
+}
+
+void LIS2MDL::setDeclination(float deg) {
+    _declinationDeg = deg;
+}
+
+void LIS2MDL::writeReg(uint8_t reg, uint8_t data) {
+    _writeBuffer[0] = data;
+    _wire->beginTransmission(_address);
+    _wire->write(reg);
+    _wire->write(_writeBuffer[0]);
+    _wire->endTransmission();
+}
+
+void LIS2MDL::write16(uint8_t regL, int16_t value) {
+    _wire->beginTransmission(_address);
+    _wire->write(regL);
+    _wire->write(value & 0xFF);
+    _wire->write(regL + 1);
+    _wire->write((value >> 8) & 0xFF);
+    _wire->endTransmission();
+}
+
+void LIS2MDL::setHwOffsets(int16_t x, int16_t y, int16_t z) {
+    write16(LIS2MDL_OFFSET_X_REG_L, x);
+    write16(LIS2MDL_OFFSET_Y_REG_L, y);
+    write16(LIS2MDL_OFFSET_Z_REG_L, z);
+}
+
+//--------------------------------------------------------
+// -------------------- READ functions --------------------
+//--------------------------------------------------------
+
+bool LIS2MDL::ensureData() {
+    // Trigger a single conversion if the sensor is in idle mode.
+    if (isIdle()) {
+        setMode("single");
+        for (int i = 0; i < 50; i++) {
+            if (dataReady())
+                return true;
+            delay(2);
+        }
+        return false;
+    }
+    return true;
+}
+
+MagneticField LIS2MDL::magneticFieldRaw() {
+    // Reads the raw magnetic field (LSB). Same as magnetic_field(), but more explicit.
+    return magneticField();
+}
+
+uint8_t LIS2MDL::status() {
+    return readReg(LIS2MDL_STATUS_REG);
+}
+
+bool LIS2MDL::dataReady() {
+    // True if a new XYZ triplet is ready (Zyxda bit).
+    return (status() & (1 << 3)) != 0;
+}
+
+uint8_t LIS2MDL::readIntSource() {
+    // Reads INT_SOURCE_REG (0x64): source of the interrupt.
+    return readReg(LIS2MDL_INT_SOURCE_REG);
+}
+
+uint8_t LIS2MDL::readReg(uint8_t reg) {
+    _wire->beginTransmission(_address);
+    _wire->write(reg);
+    _wire->endTransmission(false);
+    _wire->requestFrom(_address, (uint8_t)1);
+    if (_wire->available())
+        return _wire->read();
+    return 0;
+}
+
+MagneticFieldUt LIS2MDL::magneticFieldUt() {
+    // Reads the magnetic field in µT, uncalibrated (simple conversion from LSB).
+    MagneticField   raw = magneticField();
+    MagneticFieldUt f;
+    f.x = raw.x * _MAG_LSB_TO_uT;
+    f.y = raw.y * _MAG_LSB_TO_uT;
+    f.z = raw.z * _MAG_LSB_TO_uT;
+    return f;
+}
+
+CalibratedField LIS2MDL::calibratedField() {
+    // Reads the calibrated field (offset/scale per axis), normalized (unitless, ~circle in XY).
+    MagneticField   raw = magneticField();
+    CalibratedField f;
+    f.x = (raw.x - xOff) / (xScale != 0 ? xScale : 1.0f);
+    f.y = (raw.y - yOff) / (yScale != 0 ? yScale : 1.0f);
+    f.z = (raw.z - zOff) / (zScale != 0 ? zScale : 1.0f);
+    return f;
+}
+
+float LIS2MDL::magnitudeUt() {
+    // Total magnetic field strength (µT).
+    MagneticFieldUt f = magneticFieldUt();
+    return sqrt(f.x * f.x + f.y * f.y + f.z * f.z);
+}
+
+int16_t LIS2MDL::toInt16(uint16_t v) {
+    // Convert an unsigned 16-bit value to a signed 16-bit value.
+    return (v & 0x8000) ? (int16_t)(v - 0x10000) : (int16_t)v;
+}
+
+MagneticField LIS2MDL::magneticField() {
+    // Read the raw magnetic field data (X, Y, Z) from the sensor.
+    ensureData();
+    MagneticField f;
+    f.x = toInt16(readReg(LIS2MDL_OUTX_L_REG) | ((uint16_t)readReg(LIS2MDL_OUTX_H_REG) << 8));
+    f.y = toInt16(readReg(LIS2MDL_OUTY_L_REG) | ((uint16_t)readReg(LIS2MDL_OUTY_H_REG) << 8));
+    f.z = toInt16(readReg(LIS2MDL_OUTZ_L_REG) | ((uint16_t)readReg(LIS2MDL_OUTZ_H_REG) << 8));
+    return f;
+}
+
+int16_t LIS2MDL::readTemperatureRaw() {
+    // Reads the raw temperature (LSB), 8 LSB/°C, absolute offset not guaranteed.
+    ensureData();
+    uint16_t lo = readReg(LIS2MDL_TEMP_OUT_L_REG);
+    uint16_t hi = readReg(LIS2MDL_TEMP_OUT_H_REG);
+    return toInt16((hi << 8) | lo);
+}
+
+float LIS2MDL::temperature() {
+    /* Temperature in °C (8 LSB/°C + empirical offset).
+
+        The LIS2MDL temperature sensor has no guaranteed absolute zero
+        point (see datasheet Table 4).  The offset defaults to 25 °C
+        based on empirical observation (confirmed by Zephyr RTOS
+        PR #35912).  Use ``set_temp_offset()`` or ``calibrate_temperature()``
+        to calibrate against a reference thermometer.
+        */
+    float factory =
+        _tempBaseOffset + static_cast<float>(readTemperatureRaw()) / LIS2MDL_TEMP_SENSITIVITY;
+    return _tempGain * factory + _tempOffset;
+}
+
+void LIS2MDL::setTempOffset(float offset) {
+    /*Set a temperature offset in °C (gain remains 1.0).
+
+        Args:
+            offset_c: offset value in degrees Celsius.*/
+    _tempGain   = 1.0f;
+    _tempOffset = offset;
+}
+
+bool LIS2MDL::calibrateTemperature(float refLow, float measuredLow, float refHigh,
+                                   float measuredHigh) {
+    /*Two-point calibration from reference measurements.
+
+        Computes gain and offset so that the sensor reading is adjusted
+        to match reference values at two temperature points.
+
+        Args:
+            ref_low: reference temperature at the low point (°C).
+            measured_low: sensor reading at the low point (°C).
+            ref_high: reference temperature at the high point (°C).
+            measured_high: sensor reading at the high point (°C).*/
+    float delta = measuredHigh - measuredLow;
+    if (delta == 0.0f)
+        return false;
+    _tempGain   = (refHigh - refLow) / delta;
+    _tempOffset = refLow - _tempGain * measuredLow;
+    return true;
+}
+
+uint8_t LIS2MDL::deviceId() {
+    // Reads WHO_AM_I (should be 0x40).
+    return readReg(LIS2MDL_WHO_AM_I);
+}
+
+int16_t LIS2MDL::read16(uint8_t reg) {
+    // Reads a signed 16-bit value from a _L (LSB) register.
+    uint16_t lo = readReg(reg);
+    uint16_t hi = readReg(reg + 1);
+    return toInt16((hi << 8) | lo);
+}
+
+HwOffsets LIS2MDL::readHwOffsets() {
+    // Reads the hardware offsets (OFFSET_* registers).
+    HwOffsets o;
+    o.x = read16(LIS2MDL_OFFSET_X_REG_L);
+    o.y = read16(LIS2MDL_OFFSET_Y_REG_L);
+    o.z = read16(LIS2MDL_OFFSET_Z_REG_L);
+    return o;
+}
+
+void LIS2MDL::readRegisters(uint8_t startAddr, uint8_t length, uint8_t* buffer) {
+    // Dump of consecutive registers (useful for debugging).
+    _wire->beginTransmission(_address);
+    _wire->write(startAddr);
+    _wire->endTransmission(false);
+    _wire->requestFrom(_address, length);
+    for (uint8_t i = 0; i < length && _wire->available(); i++) {
+        buffer[i] = _wire->read();
+    }
+}
+
+ReadAll LIS2MDL::readAll() {
+    // Grouped reading useful for debug & logs.
+    ReadAll r;
+    r.raw    = magneticFieldRaw();
+    r.ut     = magneticFieldUt();
+    r.cal    = calibratedField();
+    r.tempC  = temperature();
+    r.status = status();
+    return r;
+}
+
+bool LIS2MDL::isIdle() {
+    return (readReg(LIS2MDL_CFG_REG_A) & 0b11) == 0b11;
+}
+
+//--------------------------------------------------------
+// -------------------- CALIBRATIONS ---------------------
+//--------------------------------------------------------
+
+void LIS2MDL::setCalibrateStep(float xoff, float yoff, float zoff, float xscale, float yscale,
+                               float zscale) {
+    // Set the calibration offsets and scales manually.
+    xOff   = xoff;
+    yOff   = yoff;
+    zOff   = zoff;
+    xScale = xscale;
+    yScale = yscale;
+    zScale = zscale;
+}
+
+void LIS2MDL::calibrateMinmax2d(uint16_t samples, uint16_t delayMs) {
+    /*MIN/MAX calibration while flat (XY only).
+        Slowly rotate the board FLAT during acquisition.
+        Updates x_off, y_off, x_scale, y_scale (leaves Z unchanged).*/
+
+    float xmin = 1e9f, ymin = 1e9f;
+    float xmax = -1e9f, ymax = -1e9f;
+
+    for (uint16_t i = 0; i < samples; i++) {
+        MagneticField f = magneticField();
+        if (f.x < xmin) xmin = f.x;
+        if (f.x > xmax) xmax = f.x;
+        if (f.y < ymin) ymin = f.y;
+        if (f.y > ymax) ymax = f.y;
+        delay(delayMs);
+    }
+
+    xOff   = (xmin + xmax) / 2.0f;
+    yOff   = (ymin + ymax) / 2.0f;
+    xScale = (xmax - xmin) / 2.0f != 0.0f ? (xmax - xmin) / 2.0f : 1.0f;
+    yScale = (ymax - ymin) / 2.0f != 0.0f ? (ymax - ymin) / 2.0f : 1.0f;
+
+    float avg = (xScale + yScale) / 2.0f;
+    xScale    = (xScale != 0.0f) ? avg : 1.0f;
+    yScale    = (yScale != 0.0f) ? avg : 1.0f;
+}
+
+void LIS2MDL::calibrateMinmax3d(uint16_t samples, uint16_t delayMs) {
+    /*MIN/MAX calibration on 3 axes (rotate the board in ALL directions).
+        Updates offsets + scales for X, Y, Z.*/
+
+    float xmin = 1e9f, ymin = 1e9f, zmin = 1e9f;
+    float xmax = -1e9f, ymax = -1e9f, zmax = -1e9f;
+
+    for (uint16_t i = 0; i < samples; i++) {
+        MagneticField f = magneticField();
+        if (f.x < xmin) xmin = f.x;
+        if (f.x > xmax) xmax = f.x;
+        if (f.y < ymin) ymin = f.y;
+        if (f.y > ymax) ymax = f.y;
+        if (f.z < zmin) zmin = f.z;
+        if (f.z > zmax) zmax = f.z;
+        delay(delayMs);
+    }
+
+    xOff   = (xmin + xmax) / 2.0f;
+    yOff   = (ymin + ymax) / 2.0f;
+    zOff   = (zmin + zmax) / 2.0f;
+    xScale = (xmax - xmin) / 2.0f != 0.0f ? (xmax - xmin) / 2.0f : 1.0f;
+    yScale = (ymax - ymin) / 2.0f != 0.0f ? (ymax - ymin) / 2.0f : 1.0f;
+    zScale = (zmax - zmin) / 2.0f != 0.0f ? (zmax - zmin) / 2.0f : 1.0f;
+}
+
+CalibratedField LIS2MDL::calibrateApply(float x, float y, float z) {
+    /*Applies the current calibration (offset + scale per axis).
+        Returns normalized ~unitless values.*/
+    CalibratedField f;
+    f.x = (x - xOff) / (xScale != 0.0f ? xScale : 1.0f);
+    f.y = (y - yOff) / (yScale != 0.0f ? yScale : 1.0f);
+    f.z = (z - zOff) / (zScale != 0.0f ? zScale : 1.0f);
+    return f;
+}
+
+CalibrationQuality LIS2MDL::calibrateQuality(uint16_t samplesCheck, uint16_t delayMs) {
+    /* Evaluates the quality of the current calibration over a short sample.
+        Returns a dict with useful metrics: center (mean), anisotropy, XY radius dispersion.
+        (Move the board a bit while flat during the measurement.)*/
+
+    float xs[samplesCheck], ys[samplesCheck], zs[samplesCheck];
+    for (uint16_t i = 0; i < samplesCheck; i++) {
+        CalibratedField cal = calibratedField();
+        xs[i]               = cal.x;
+        ys[i]               = cal.y;
+        zs[i]               = cal.z;
+        delay(delayMs);
+    }
+
+    float mx = 0.0f, my = 0.0f, mz = 0.0f;
+    for (uint16_t i = 0; i < samplesCheck; i++) {
+        mx += xs[i];
+        my += ys[i];
+        mz += zs[i];
+    }
+    mx /= samplesCheck;
+    my /= samplesCheck;
+    mz /= samplesCheck;
+
+    float rMean = 0.0f;
+    for (uint16_t i = 0; i < samplesCheck; i++) {
+        rMean += sqrt(xs[i] * xs[i] + ys[i] * ys[i]);
+    }
+    rMean /= samplesCheck;
+
+    float rVar = 0.0f;
+    for (uint16_t i = 0; i < samplesCheck; i++) {
+        float r = sqrt(xs[i] * xs[i] + ys[i] * ys[i]);
+        rVar += (r - rMean) * (r - rMean);
+    }
+    rVar /= samplesCheck;
+
+    float sx = 0.0f, sy = 0.0f, sz = 0.0f;
+    for (uint16_t i = 0; i < samplesCheck; i++) {
+        sx += (xs[i] - mx) * (xs[i] - mx);
+        sy += (ys[i] - my) * (ys[i] - my);
+        sz += (zs[i] - mz) * (zs[i] - mz);
+    }
+    sx = sqrt(sx / samplesCheck);
+    sy = sqrt(sy / samplesCheck);
+    sz = sqrt(sz / samplesCheck);
+
+    float minSxy = (sx < sy ? sx : sy);
+    float maxSxy = (sx > sy ? sx : sy);
+
+    CalibrationQuality q;
+    q.meanX        = mx;
+    q.meanY        = my;
+    q.meanZ        = mz;
+    q.stdX         = sx;
+    q.stdY         = sy;
+    q.stdZ         = sz;
+    q.rMeanXY      = rMean;
+    q.rStdXY       = sqrt(rVar);
+    q.anisotropyXY = maxSxy / (minSxy + 1e-9f);
+    return q;
+}
+
+void LIS2MDL::calibrateReset() {
+    // Resets to a 'neutral' calibration (useful before re-calibrating).
+    xOff   = 0.0f;
+    yOff   = 0.0f;
+    zOff   = 0.0f;
+    xScale = 1.0f;
+    yScale = 1.0f;
+    zScale = 1.0f;
+}
+
+void LIS2MDL::calibrateStep() {
+    calibrateMinmax3d();
+}
+
+//--------------------------------------------------------
+// -------------------- Heading functions ----------------
+//--------------------------------------------------------
+
+void LIS2MDL::setHeadingFilter(float alpha) {
+    /*alpha=0 -> no filtering. 0.1..0.3 = light/medium smoothing.
+        Filter by averaging cos/sin to avoid artifacts at 0/360°.*/
+    _hfAlpha = (alpha < 0.0f) ? 0.0f : (alpha > 1.0f) ? 1.0f : alpha;
+    _hfCos   = 0.0f;
+    _hfSin   = 0.0f;
+}
+
+float LIS2MDL::normalizeDeg(float a) {
+    a = fmod(a, 360.0f);
+    return a < 0.0f ? a + 360.0f : a;
+}
+
+float LIS2MDL::applyHeadingOffsets(float angleDeg) {
+    angleDeg = angleDeg + _headingOffsetDeg + _declinationDeg;
+    return normalizeDeg(angleDeg);
+}
+
+float LIS2MDL::filterHeading(float angleDeg) {
+    // Filters the angle via vector averaging; returns filtered angle (or raw if alpha=0).
+    if (_hfAlpha <= 0.0f) {
+        return angleDeg;
+    }
+    float c = cos(radians(angleDeg));
+    float s = sin(radians(angleDeg));
+
+    if (_hfCos == 0.0f && _hfSin == 0.0f) {
+        _hfCos = c;
+        _hfSin = s;
+    } else {
+        float a = _hfAlpha;
+        _hfCos  = (1.0f - a) * _hfCos + a * c;
+        _hfSin  = (1.0f - a) * _hfSin + a * s;
+
+        float norm = sqrt(_hfCos * _hfCos + _hfSin * _hfSin);
+        if (norm > 1e-6f) {
+            _hfCos /= norm;
+            _hfSin /= norm;
+        }
+    }
+    return normalizeDeg(degrees(atan2(_hfSin, _hfCos)));
+}
+
+float LIS2MDL::headingFromVectors(float x, float y, float z, bool calibrated) {
+    /*Computes the angle (0..360°) from a triplet.
+        - calibrated=True: applies offset/scale per axis (recommended)
+        - flat only (uses XY)*/
+    if (calibrated) {
+        x = (x - xOff) / (xScale != 0.0f ? xScale : 1.0f);
+        y = (y - yOff) / (yScale != 0.0f ? yScale : 1.0f);
+    }
+    float angle = degrees(atan2(y, x));
+    angle       = applyHeadingOffsets(angle);
+    return filterHeading(angle);
+}
+
+float LIS2MDL::headingFlatOnly() {
+    /*Reads the sensor and returns the angle (0..360°) assuming the board is FLAT.
+        Uses XY (no tilt compensation).*/
+    MagneticField f = magneticField();
+    return headingFromVectors(f.x, f.y, f.z, true);
+}
+
+float LIS2MDL::headingWithTiltCompensation(Vec3f (*readAccel)()) {
+    /*Tilt-compensated compass (if an accelerometer is available).
+        readAccel() must return (ax, ay, az) ~g.*/
+    MagneticField raw = magneticField();
+    float x = (raw.x - xOff) / (xScale != 0.0f ? xScale : 1.0f);
+    float y = (raw.y - yOff) / (yScale != 0.0f ? yScale : 1.0f);
+    float z = (raw.z - zOff) / (zScale != 0.0f ? zScale : 1.0f);
+
+    Vec3f accel = readAccel();
+    float roll  = atan2(accel.y, accel.z);
+    float pitch = atan2(-accel.x, sqrt(accel.y * accel.y + accel.z * accel.z));
+
+    float xh    = x * cos(pitch) + z * sin(pitch);
+    float yh    = x * sin(roll) * sin(pitch) + y * cos(roll) - z * sin(roll) * cos(pitch);
+    float angle = degrees(atan2(yh, xh));
+    angle       = applyHeadingOffsets(angle);
+    return filterHeading(angle);
+}
+
+String LIS2MDL::directionLabel(float angle) {
+    // Returns N/NE/E/... ; if angle=-1, reads headingFlatOnly().
+    if (angle < 0.0f) {
+        angle = headingFlatOnly();
+    }
+    const String dirs[] = {"N", "NE", "E", "SE", "S", "SW", "W", "NW"};
+    return dirs[(int)(angle / 45.0f) % 8];
+}
+
+//--------------------------------------------------------
+// -------------------- Power/reset functions ------------
+//--------------------------------------------------------
+
+String LIS2MDL::getMode() {
+    uint8_t r  = readReg(LIS2MDL_CFG_REG_A);
+    uint8_t md = r & 0b11;
+    if (md == 0b00) return "continuous";
+    if (md == 0b01) return "single";
+    return "idle";
+}
+
+void LIS2MDL::powerOff() {
+    // Switches to IDLE mode (low power).
+    uint8_t r = readReg(LIS2MDL_CFG_REG_A);
+    r         = (r & ~0b11) | 0b11;
+    writeReg(LIS2MDL_CFG_REG_A, r);
+}
+
+void LIS2MDL::powerOn(const String& mode) {
+    // Power on the sensor: 'continuous' (default) or 'single'.
+    uint8_t md;
+    if (mode == "single") {
+        md = 0b01;
+    } else {
+        md = 0b00;
+    }
+    uint8_t r = readReg(LIS2MDL_CFG_REG_A);
+    r         = (r & ~0b11) | md;
+    writeReg(LIS2MDL_CFG_REG_A, r);
+}
+
+void LIS2MDL::softReset(uint16_t waitMs) {
+    /*SOFT_RST (bit5) in CFG_REG_A.
+        The bit auto-clears; after reset, the sensor returns to default values (idle mode expected).
+        */
+    uint8_t r = readReg(LIS2MDL_CFG_REG_A);
+    r |= 1 << 5;
+    writeReg(LIS2MDL_CFG_REG_A, r);
+    delay(waitMs);
+}
+
+void LIS2MDL::reboot(uint16_t waitMs) {
+    /*REBOOT (bit6) in CFG_REG_A: reload internal registers.
+        The bit auto-clears.
+        */
+    uint8_t r = readReg(LIS2MDL_CFG_REG_A);
+    r |= 1 << 6;
+    writeReg(LIS2MDL_CFG_REG_A, r);
+    delay(waitMs);
+}

--- a/lib/lis2mdl/src/LIS2MDL.cpp
+++ b/lib/lis2mdl/src/LIS2MDL.cpp
@@ -3,6 +3,17 @@
 #include "LIS2MDL.h"
 
 #include <math.h>
+#include <string.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+#ifndef radians
+#define radians(deg) ((deg) * M_PI / 180.0f)
+#endif
+#ifndef degrees
+#define degrees(rad) ((rad) * 180.0f / M_PI)
+#endif
 
 LIS2MDL::LIS2MDL(TwoWire& wire, uint8_t address, uint8_t odrHz, bool tempComp, bool lowPower,
                  bool drdyEnable)
@@ -16,14 +27,13 @@ LIS2MDL::LIS2MDL(TwoWire& wire, uint8_t address, uint8_t odrHz, bool tempComp, b
       _readBuffer{0},
       _tempGain(1.0f),
       _tempOffset(0.0f),
-      _tempBaseOffset(static_cast<float>(LIS2MDL_TEMP_OFFSET)),
-      _headingOffsetDeg(0.0f),
-      _declinationDeg(0.0f),
-      _hfAlpha(0.0f),
-      _hfCos(0.0f),
-      _hfSin(0.0f) {}
+      _tempBaseOffset(static_cast<float>(LIS2MDL_TEMP_OFFSET)) {}
 
-void LIS2MDL::begin() {
+bool LIS2MDL::begin() {
+    if (deviceId() != LIS2MDL_WHO_AM_I_VAL) {
+        return false;
+    }
+
     writeReg(LIS2MDL_CFG_REG_A, 0x20);
     delay(10);
 
@@ -44,7 +54,7 @@ void LIS2MDL::begin() {
     }
 
     uint8_t comp = _tempComp ? 1 : 0;
-    uint8_t lp   = _lowPower ? 1 : 0;
+    uint8_t lp = _lowPower ? 1 : 0;
     uint8_t cfgA = (comp << 7) | (lp << 4) | (odrBits << 2);
     writeReg(LIS2MDL_CFG_REG_A, cfgA);
 
@@ -52,26 +62,24 @@ void LIS2MDL::begin() {
 
     uint8_t cfgC = 0x10 | (_drdyEnable ? 0x01 : 0x00);
     writeReg(LIS2MDL_CFG_REG_C, cfgC);
+
+    return true;
 }
 
 //--------------------------------------------------------
 // -------------------- SET functions --------------------
 //--------------------------------------------------------
 
-void LIS2MDL::setMode(const String& mode) {
-    uint8_t md;
-    if (mode == "continuous") {
-        md = 0b00;
-    } else if (mode == "single") {
+void LIS2MDL::setMode(const char* mode) {
+    uint8_t md = 0b00;
+    if (strcmp(mode, "single") == 0) {
         md = 0b01;
-    } else if (mode == "powerdown") {
+    } else if (strcmp(mode, "powerdown") == 0) {
         md = 0b11;
-    } else {
-        md = 0b00;
     }
 
     uint8_t reg = readReg(LIS2MDL_CFG_REG_A);
-    reg         = (reg & ~0b11) | md;
+    reg = (reg & ~0b11) | md;
     writeReg(LIS2MDL_CFG_REG_A, reg);
 }
 
@@ -96,7 +104,7 @@ void LIS2MDL::setOdr(int hz) {
     }
 
     uint8_t reg = readReg(LIS2MDL_CFG_REG_A);
-    reg         = (reg & ~(0b11 << 2)) | (odrBits << 2);
+    reg = (reg & ~(0b11 << 2)) | (odrBits << 2);
     writeReg(LIS2MDL_CFG_REG_A, reg);
 }
 
@@ -204,7 +212,6 @@ void LIS2MDL::write16(uint8_t regL, int16_t value) {
     _wire->beginTransmission(_address);
     _wire->write(regL);
     _wire->write(value & 0xFF);
-    _wire->write(regL + 1);
     _wire->write((value >> 8) & 0xFF);
     _wire->endTransmission();
 }
@@ -264,7 +271,7 @@ uint8_t LIS2MDL::readReg(uint8_t reg) {
 
 MagneticFieldUt LIS2MDL::magneticFieldUt() {
     // Reads the magnetic field in µT, uncalibrated (simple conversion from LSB).
-    MagneticField   raw = magneticField();
+    MagneticField raw = magneticField();
     MagneticFieldUt f;
     f.x = raw.x * _MAG_LSB_TO_uT;
     f.y = raw.y * _MAG_LSB_TO_uT;
@@ -274,7 +281,7 @@ MagneticFieldUt LIS2MDL::magneticFieldUt() {
 
 CalibratedField LIS2MDL::calibratedField() {
     // Reads the calibrated field (offset/scale per axis), normalized (unitless, ~circle in XY).
-    MagneticField   raw = magneticField();
+    MagneticField raw = magneticField();
     CalibratedField f;
     f.x = (raw.x - xOff) / (xScale != 0 ? xScale : 1.0f);
     f.y = (raw.y - yOff) / (yScale != 0 ? yScale : 1.0f);
@@ -330,7 +337,7 @@ void LIS2MDL::setTempOffset(float offset) {
 
         Args:
             offset_c: offset value in degrees Celsius.*/
-    _tempGain   = 1.0f;
+    _tempGain = 1.0f;
     _tempOffset = offset;
 }
 
@@ -349,7 +356,7 @@ bool LIS2MDL::calibrateTemperature(float refLow, float measuredLow, float refHig
     float delta = measuredHigh - measuredLow;
     if (delta == 0.0f)
         return false;
-    _tempGain   = (refHigh - refLow) / delta;
+    _tempGain = (refHigh - refLow) / delta;
     _tempOffset = refLow - _tempGain * measuredLow;
     return true;
 }
@@ -389,10 +396,10 @@ void LIS2MDL::readRegisters(uint8_t startAddr, uint8_t length, uint8_t* buffer) 
 ReadAll LIS2MDL::readAll() {
     // Grouped reading useful for debug & logs.
     ReadAll r;
-    r.raw    = magneticFieldRaw();
-    r.ut     = magneticFieldUt();
-    r.cal    = calibratedField();
-    r.tempC  = temperature();
+    r.raw = magneticFieldRaw();
+    r.ut = magneticFieldUt();
+    r.cal = calibratedField();
+    r.tempC = temperature();
     r.status = status();
     return r;
 }
@@ -408,9 +415,9 @@ bool LIS2MDL::isIdle() {
 void LIS2MDL::setCalibrateStep(float xoff, float yoff, float zoff, float xscale, float yscale,
                                float zscale) {
     // Set the calibration offsets and scales manually.
-    xOff   = xoff;
-    yOff   = yoff;
-    zOff   = zoff;
+    xOff = xoff;
+    yOff = yoff;
+    zOff = zoff;
     xScale = xscale;
     yScale = yscale;
     zScale = zscale;
@@ -426,21 +433,25 @@ void LIS2MDL::calibrateMinmax2d(uint16_t samples, uint16_t delayMs) {
 
     for (uint16_t i = 0; i < samples; i++) {
         MagneticField f = magneticField();
-        if (f.x < xmin) xmin = f.x;
-        if (f.x > xmax) xmax = f.x;
-        if (f.y < ymin) ymin = f.y;
-        if (f.y > ymax) ymax = f.y;
+        if (f.x < xmin)
+            xmin = f.x;
+        if (f.x > xmax)
+            xmax = f.x;
+        if (f.y < ymin)
+            ymin = f.y;
+        if (f.y > ymax)
+            ymax = f.y;
         delay(delayMs);
     }
 
-    xOff   = (xmin + xmax) / 2.0f;
-    yOff   = (ymin + ymax) / 2.0f;
+    xOff = (xmin + xmax) / 2.0f;
+    yOff = (ymin + ymax) / 2.0f;
     xScale = (xmax - xmin) / 2.0f != 0.0f ? (xmax - xmin) / 2.0f : 1.0f;
     yScale = (ymax - ymin) / 2.0f != 0.0f ? (ymax - ymin) / 2.0f : 1.0f;
 
     float avg = (xScale + yScale) / 2.0f;
-    xScale    = (xScale != 0.0f) ? avg : 1.0f;
-    yScale    = (yScale != 0.0f) ? avg : 1.0f;
+    xScale = (xScale != 0.0f) ? avg : 1.0f;
+    yScale = (yScale != 0.0f) ? avg : 1.0f;
 }
 
 void LIS2MDL::calibrateMinmax3d(uint16_t samples, uint16_t delayMs) {
@@ -452,18 +463,24 @@ void LIS2MDL::calibrateMinmax3d(uint16_t samples, uint16_t delayMs) {
 
     for (uint16_t i = 0; i < samples; i++) {
         MagneticField f = magneticField();
-        if (f.x < xmin) xmin = f.x;
-        if (f.x > xmax) xmax = f.x;
-        if (f.y < ymin) ymin = f.y;
-        if (f.y > ymax) ymax = f.y;
-        if (f.z < zmin) zmin = f.z;
-        if (f.z > zmax) zmax = f.z;
+        if (f.x < xmin)
+            xmin = f.x;
+        if (f.x > xmax)
+            xmax = f.x;
+        if (f.y < ymin)
+            ymin = f.y;
+        if (f.y > ymax)
+            ymax = f.y;
+        if (f.z < zmin)
+            zmin = f.z;
+        if (f.z > zmax)
+            zmax = f.z;
         delay(delayMs);
     }
 
-    xOff   = (xmin + xmax) / 2.0f;
-    yOff   = (ymin + ymax) / 2.0f;
-    zOff   = (zmin + zmax) / 2.0f;
+    xOff = (xmin + xmax) / 2.0f;
+    yOff = (ymin + ymax) / 2.0f;
+    zOff = (zmin + zmax) / 2.0f;
     xScale = (xmax - xmin) / 2.0f != 0.0f ? (xmax - xmin) / 2.0f : 1.0f;
     yScale = (ymax - ymin) / 2.0f != 0.0f ? (ymax - ymin) / 2.0f : 1.0f;
     zScale = (zmax - zmin) / 2.0f != 0.0f ? (zmax - zmin) / 2.0f : 1.0f;
@@ -487,9 +504,9 @@ CalibrationQuality LIS2MDL::calibrateQuality(uint16_t samplesCheck, uint16_t del
     float xs[samplesCheck], ys[samplesCheck], zs[samplesCheck];
     for (uint16_t i = 0; i < samplesCheck; i++) {
         CalibratedField cal = calibratedField();
-        xs[i]               = cal.x;
-        ys[i]               = cal.y;
-        zs[i]               = cal.z;
+        xs[i] = cal.x;
+        ys[i] = cal.y;
+        zs[i] = cal.z;
         delay(delayMs);
     }
 
@@ -530,23 +547,23 @@ CalibrationQuality LIS2MDL::calibrateQuality(uint16_t samplesCheck, uint16_t del
     float maxSxy = (sx > sy ? sx : sy);
 
     CalibrationQuality q;
-    q.meanX        = mx;
-    q.meanY        = my;
-    q.meanZ        = mz;
-    q.stdX         = sx;
-    q.stdY         = sy;
-    q.stdZ         = sz;
-    q.rMeanXY      = rMean;
-    q.rStdXY       = sqrt(rVar);
+    q.meanX = mx;
+    q.meanY = my;
+    q.meanZ = mz;
+    q.stdX = sx;
+    q.stdY = sy;
+    q.stdZ = sz;
+    q.rMeanXY = rMean;
+    q.rStdXY = sqrt(rVar);
     q.anisotropyXY = maxSxy / (minSxy + 1e-9f);
     return q;
 }
 
 void LIS2MDL::calibrateReset() {
     // Resets to a 'neutral' calibration (useful before re-calibrating).
-    xOff   = 0.0f;
-    yOff   = 0.0f;
-    zOff   = 0.0f;
+    xOff = 0.0f;
+    yOff = 0.0f;
+    zOff = 0.0f;
     xScale = 1.0f;
     yScale = 1.0f;
     zScale = 1.0f;
@@ -564,8 +581,8 @@ void LIS2MDL::setHeadingFilter(float alpha) {
     /*alpha=0 -> no filtering. 0.1..0.3 = light/medium smoothing.
         Filter by averaging cos/sin to avoid artifacts at 0/360°.*/
     _hfAlpha = (alpha < 0.0f) ? 0.0f : (alpha > 1.0f) ? 1.0f : alpha;
-    _hfCos   = 0.0f;
-    _hfSin   = 0.0f;
+    _hfCos = 0.0f;
+    _hfSin = 0.0f;
 }
 
 float LIS2MDL::normalizeDeg(float a) {
@@ -591,8 +608,8 @@ float LIS2MDL::filterHeading(float angleDeg) {
         _hfSin = s;
     } else {
         float a = _hfAlpha;
-        _hfCos  = (1.0f - a) * _hfCos + a * c;
-        _hfSin  = (1.0f - a) * _hfSin + a * s;
+        _hfCos = (1.0f - a) * _hfCos + a * c;
+        _hfSin = (1.0f - a) * _hfSin + a * s;
 
         float norm = sqrt(_hfCos * _hfCos + _hfSin * _hfSin);
         if (norm > 1e-6f) {
@@ -612,7 +629,7 @@ float LIS2MDL::headingFromVectors(float x, float y, float z, bool calibrated) {
         y = (y - yOff) / (yScale != 0.0f ? yScale : 1.0f);
     }
     float angle = degrees(atan2(y, x));
-    angle       = applyHeadingOffsets(angle);
+    angle = applyHeadingOffsets(angle);
     return filterHeading(angle);
 }
 
@@ -632,22 +649,22 @@ float LIS2MDL::headingWithTiltCompensation(Vec3f (*readAccel)()) {
     float z = (raw.z - zOff) / (zScale != 0.0f ? zScale : 1.0f);
 
     Vec3f accel = readAccel();
-    float roll  = atan2(accel.y, accel.z);
+    float roll = atan2(accel.y, accel.z);
     float pitch = atan2(-accel.x, sqrt(accel.y * accel.y + accel.z * accel.z));
 
-    float xh    = x * cos(pitch) + z * sin(pitch);
-    float yh    = x * sin(roll) * sin(pitch) + y * cos(roll) - z * sin(roll) * cos(pitch);
+    float xh = x * cos(pitch) + z * sin(pitch);
+    float yh = x * sin(roll) * sin(pitch) + y * cos(roll) - z * sin(roll) * cos(pitch);
     float angle = degrees(atan2(yh, xh));
-    angle       = applyHeadingOffsets(angle);
+    angle = applyHeadingOffsets(angle);
     return filterHeading(angle);
 }
 
-String LIS2MDL::directionLabel(float angle) {
+const char* LIS2MDL::directionLabel(float angle) {
     // Returns N/NE/E/... ; if angle=-1, reads headingFlatOnly().
     if (angle < 0.0f) {
         angle = headingFlatOnly();
     }
-    const String dirs[] = {"N", "NE", "E", "SE", "S", "SW", "W", "NW"};
+    const char* dirs[] = {"N", "NE", "E", "SE", "S", "SW", "W", "NW"};
     return dirs[(int)(angle / 45.0f) % 8];
 }
 
@@ -655,22 +672,24 @@ String LIS2MDL::directionLabel(float angle) {
 // -------------------- Power/reset functions ------------
 //--------------------------------------------------------
 
-String LIS2MDL::getMode() {
-    uint8_t r  = readReg(LIS2MDL_CFG_REG_A);
+const char* LIS2MDL::getMode() {
+    uint8_t r = readReg(LIS2MDL_CFG_REG_A);
     uint8_t md = r & 0b11;
-    if (md == 0b00) return "continuous";
-    if (md == 0b01) return "single";
+    if (md == 0b00)
+        return "continuous";
+    if (md == 0b01)
+        return "single";
     return "idle";
 }
 
 void LIS2MDL::powerOff() {
     // Switches to IDLE mode (low power).
     uint8_t r = readReg(LIS2MDL_CFG_REG_A);
-    r         = (r & ~0b11) | 0b11;
+    r = (r & ~0b11) | 0b11;
     writeReg(LIS2MDL_CFG_REG_A, r);
 }
 
-void LIS2MDL::powerOn(const String& mode) {
+void LIS2MDL::powerOn(const char* mode) {
     // Power on the sensor: 'continuous' (default) or 'single'.
     uint8_t md;
     if (mode == "single") {
@@ -679,7 +698,7 @@ void LIS2MDL::powerOn(const String& mode) {
         md = 0b00;
     }
     uint8_t r = readReg(LIS2MDL_CFG_REG_A);
-    r         = (r & ~0b11) | md;
+    r = (r & ~0b11) | md;
     writeReg(LIS2MDL_CFG_REG_A, r);
 }
 

--- a/lib/lis2mdl/src/LIS2MDL.cpp
+++ b/lib/lis2mdl/src/LIS2MDL.cpp
@@ -384,6 +384,9 @@ HwOffsets LIS2MDL::readHwOffsets() {
 
 void LIS2MDL::readRegisters(uint8_t startAddr, uint8_t length, uint8_t* buffer) {
     // Dump of consecutive registers (useful for debugging).
+    for (uint8_t i = 0; i < length; i++) {
+        buffer[i] = 0;
+    }
     _wire->beginTransmission(_address);
     _wire->write(startAddr);
     _wire->endTransmission(false);
@@ -501,7 +504,14 @@ CalibrationQuality LIS2MDL::calibrateQuality(uint16_t samplesCheck, uint16_t del
         Returns a dict with useful metrics: center (mean), anisotropy, XY radius dispersion.
         (Move the board a bit while flat during the measurement.)*/
 
-    float xs[samplesCheck], ys[samplesCheck], zs[samplesCheck];
+    static constexpr uint16_t MAX_SAMPLES = 200;
+    if (samplesCheck == 0) {
+        return {0, 0, 0, 0, 0, 0, 0, 0, 0};
+    }
+    if (samplesCheck > MAX_SAMPLES) {
+        samplesCheck = MAX_SAMPLES;
+    }
+    float xs[MAX_SAMPLES], ys[MAX_SAMPLES], zs[MAX_SAMPLES];
     for (uint16_t i = 0; i < samplesCheck; i++) {
         CalibratedField cal = calibratedField();
         xs[i] = cal.x;
@@ -692,7 +702,7 @@ void LIS2MDL::powerOff() {
 void LIS2MDL::powerOn(const char* mode) {
     // Power on the sensor: 'continuous' (default) or 'single'.
     uint8_t md;
-    if (mode == "single") {
+    if (mode != nullptr && strcmp(mode, "single") == 0) {
         md = 0b01;
     } else {
         md = 0b00;

--- a/lib/lis2mdl/src/LIS2MDL.h
+++ b/lib/lis2mdl/src/LIS2MDL.h
@@ -47,8 +47,8 @@ class LIS2MDL {
     LIS2MDL(TwoWire& wire = Wire, uint8_t address = LIS2MDL_I2C_ADDR, uint8_t odrHz = 10,
             bool tempComp = true, bool lowPower = false, bool drdyEnable = false);
 
-    void begin();
-    void setMode(const String& mode);
+    bool begin();
+    void setMode(const char* mode);
     void setOdr(int hz);
     void setContinuous(uint8_t hz = 10);
     void triggerOneShot();
@@ -93,10 +93,10 @@ class LIS2MDL {
     float headingFromVectors(float x, float y, float z, bool calibrated = true);
     float headingFlatOnly();
     float headingWithTiltCompensation(Vec3f (*readAccel)());
-    String directionLabel(float angle = -1.0f);
-    String getMode();
+    const char* directionLabel(float angle = -1.0f);
+    const char* getMode();
     void powerOff();
-    void powerOn(const String& mode = "continuous");
+    void powerOn(const char* mode = "continuous");
     void softReset(uint16_t waitMs = 10);
     void reboot(uint16_t waitMs = 10);
     bool isIdle();

--- a/lib/lis2mdl/src/LIS2MDL.h
+++ b/lib/lis2mdl/src/LIS2MDL.h
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <Arduino.h>
+#include <Wire.h>
+
+#include "LIS2MDL_const.h"
+
+struct Vec3i {
+    int16_t x, y, z;
+};
+struct Vec3f {
+    float x, y, z;
+};
+
+struct CalibrationQuality {
+    float meanX, meanY, meanZ;
+    float stdX, stdY, stdZ;
+    float rMeanXY;
+    float rStdXY;
+    float anisotropyXY;
+};
+
+using MagneticField = Vec3i;
+using HwOffsets = Vec3i;
+using MagneticFieldUt = Vec3f;
+using CalibratedField = Vec3f;
+
+struct ReadAll {
+    MagneticField raw;
+    MagneticFieldUt ut;
+    CalibratedField cal;
+    float tempC;
+    uint8_t status;
+};
+
+class LIS2MDL {
+   public:
+    float xOff = 0.0f;
+    float yOff = 0.0f;
+    float zOff = 0.0f;
+    float xScale = 1.0f;
+    float yScale = 1.0f;
+    float zScale = 1.0f;
+
+    LIS2MDL(TwoWire& wire = Wire, uint8_t address = LIS2MDL_I2C_ADDR, uint8_t odrHz = 10,
+            bool tempComp = true, bool lowPower = false, bool drdyEnable = false);
+
+    void begin();
+    void setMode(const String& mode);
+    void setOdr(int hz);
+    void setContinuous(uint8_t hz = 10);
+    void triggerOneShot();
+    MagneticField readOneShot();
+    void setLowPower(bool enabled);
+    void setLowPass(bool enabled);
+    void setOffsetCancellation(bool enabled, bool oneShot = false);
+    void setBdu(bool enabled = true);
+    void setEndianness(bool bigEndian);
+    void useSpi4wire(bool enable);
+    void setHeadingOffset(float deg);
+    void setDeclination(float deg);
+    void setHwOffsets(int16_t x, int16_t y, int16_t z);
+
+    MagneticField magneticField();
+    MagneticField magneticFieldRaw();
+    MagneticFieldUt magneticFieldUt();
+    CalibratedField calibratedField();
+    float magnitudeUt();
+    uint8_t status();
+    bool dataReady();
+    uint8_t readIntSource();
+    int16_t readTemperatureRaw();
+    float temperature();
+    void setTempOffset(float offset);
+    bool calibrateTemperature(float refLow, float measuredLow, float refHigh, float measuredHigh);
+    uint8_t deviceId();
+    HwOffsets readHwOffsets();
+    void readRegisters(uint8_t startAddr, uint8_t length, uint8_t* buffer);
+    ReadAll readAll();
+
+    void setCalibrateStep(float xoff, float yoff, float zoff, float xscale, float yscale,
+                          float zscale);
+    void calibrateMinmax2d(uint16_t samples = 300, uint16_t delayMs = 20);
+    void calibrateMinmax3d(uint16_t samples = 600, uint16_t delayMs = 20);
+    CalibratedField calibrateApply(float x, float y, float z);
+    CalibrationQuality calibrateQuality(uint16_t samplesCheck = 200, uint16_t delayMs = 10);
+    void calibrateReset();
+    void calibrateStep();
+
+    void setHeadingFilter(float alpha);
+    float headingFromVectors(float x, float y, float z, bool calibrated = true);
+    float headingFlatOnly();
+    float headingWithTiltCompensation(Vec3f (*readAccel)());
+    String directionLabel(float angle = -1.0f);
+    String getMode();
+    void powerOff();
+    void powerOn(const String& mode = "continuous");
+    void softReset(uint16_t waitMs = 10);
+    void reboot(uint16_t waitMs = 10);
+    bool isIdle();
+
+   private:
+    TwoWire* _wire;
+    uint8_t _address;
+    uint8_t _odrHz;
+    bool _tempComp;
+    bool _lowPower;
+    bool _drdyEnable;
+
+    uint8_t _writeBuffer[1];
+    uint8_t _readBuffer[1];
+
+    float _tempGain;
+    float _tempOffset;
+    float _tempBaseOffset;
+
+    float _headingOffsetDeg = 0.0f;
+    float _declinationDeg = 0.0f;
+
+    float _hfAlpha = 0.0f;
+    float _hfCos = 0.0f;
+    float _hfSin = 0.0f;
+
+    static constexpr float _MAG_LSB_TO_uT = 0.15f;
+
+    void writeReg(uint8_t reg, uint8_t data);
+    void write16(uint8_t regL, int16_t value);
+    uint8_t readReg(uint8_t reg);
+    int16_t read16(uint8_t reg);
+    bool ensureData();
+    int16_t toInt16(uint16_t v);
+    float normalizeDeg(float a);
+    float applyHeadingOffsets(float angleDeg);
+    float filterHeading(float angleDeg);
+};

--- a/lib/lis2mdl/src/LIS2MDL_const.h
+++ b/lib/lis2mdl/src/LIS2MDL_const.h
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <stdint.h>
+
+// LIS2MDL I2C address
+constexpr uint8_t LIS2MDL_I2C_ADDR = 0x1E;
+
+// Register addresses
+constexpr uint8_t LIS2MDL_WHO_AM_I = 0x4F;    // Device identification register
+constexpr uint8_t LIS2MDL_CFG_REG_A = 0x60;   // Configuration register A
+constexpr uint8_t LIS2MDL_CFG_REG_B = 0x61;   // Configuration register B
+constexpr uint8_t LIS2MDL_CFG_REG_C = 0x62;   // Configuration register C
+constexpr uint8_t LIS2MDL_STATUS_REG = 0x67;  // Status register
+
+// Output data registers
+constexpr uint8_t LIS2MDL_OUTX_L_REG = 0x68;  // X-axis output low byte
+constexpr uint8_t LIS2MDL_OUTX_H_REG = 0x69;  // X-axis output high byte
+constexpr uint8_t LIS2MDL_OUTY_L_REG = 0x6A;  // Y-axis output low byte
+constexpr uint8_t LIS2MDL_OUTY_H_REG = 0x6B;  // Y-axis output high byte
+constexpr uint8_t LIS2MDL_OUTZ_L_REG = 0x6C;  // Z-axis output low byte
+constexpr uint8_t LIS2MDL_OUTZ_H_REG = 0x6D;  // Z-axis output high byte
+
+// Offset registers
+constexpr uint8_t LIS2MDL_OFFSET_X_REG_L = 0x45;  // X-axis offset low byte
+constexpr uint8_t LIS2MDL_OFFSET_X_REG_H = 0x46;  // X-axis offset high byte
+constexpr uint8_t LIS2MDL_OFFSET_Y_REG_L = 0x47;  // Y-axis offset low byte
+constexpr uint8_t LIS2MDL_OFFSET_Y_REG_H = 0x48;  // Y-axis offset high byte
+constexpr uint8_t LIS2MDL_OFFSET_Z_REG_L = 0x49;  // Z-axis offset low byte
+constexpr uint8_t LIS2MDL_OFFSET_Z_REG_H = 0x4A;  // Z-axis offset high byte
+
+// Temperature output registers
+constexpr uint8_t LIS2MDL_TEMP_OUT_L_REG = 0x6E;  // Temperature output low byte
+constexpr uint8_t LIS2MDL_TEMP_OUT_H_REG = 0x6F;  // Temperature output high byte
+
+// Temperature conversion
+constexpr int LIS2MDL_TEMP_SENSITIVITY = 8;  // LSB/°C
+constexpr int LIS2MDL_TEMP_OFFSET = 25;      // °C (not guaranteed by datasheet, empirical default)
+
+// Interrupt control and source registers
+constexpr uint8_t LIS2MDL_INT_CTRL_REG = 0x63;    // Interrupt control register
+constexpr uint8_t LIS2MDL_INT_SOURCE_REG = 0x64;  // Interrupt source register
+constexpr uint8_t LIS2MDL_INT_THS_L_REG = 0x65;   // Interrupt threshold low byte
+constexpr uint8_t LIS2MDL_INT_THS_H_REG = 0x66;   // Interrupt threshold high byte

--- a/lib/lis2mdl/src/LIS2MDL_const.h
+++ b/lib/lis2mdl/src/LIS2MDL_const.h
@@ -8,11 +8,12 @@
 constexpr uint8_t LIS2MDL_I2C_ADDR = 0x1E;
 
 // Register addresses
-constexpr uint8_t LIS2MDL_WHO_AM_I = 0x4F;    // Device identification register
-constexpr uint8_t LIS2MDL_CFG_REG_A = 0x60;   // Configuration register A
-constexpr uint8_t LIS2MDL_CFG_REG_B = 0x61;   // Configuration register B
-constexpr uint8_t LIS2MDL_CFG_REG_C = 0x62;   // Configuration register C
-constexpr uint8_t LIS2MDL_STATUS_REG = 0x67;  // Status register
+constexpr uint8_t LIS2MDL_WHO_AM_I = 0x4F;      // Device identification register
+constexpr uint8_t LIS2MDL_WHO_AM_I_VAL = 0x40;  // Expected value of WHO_AM_I register
+constexpr uint8_t LIS2MDL_CFG_REG_A = 0x60;     // Configuration register A
+constexpr uint8_t LIS2MDL_CFG_REG_B = 0x61;     // Configuration register B
+constexpr uint8_t LIS2MDL_CFG_REG_C = 0x62;     // Configuration register C
+constexpr uint8_t LIS2MDL_STATUS_REG = 0x67;    // Status register
 
 // Output data registers
 constexpr uint8_t LIS2MDL_OUTX_L_REG = 0x68;  // X-axis output low byte

--- a/tests/hardware/test_lis2mdl/test_main.cpp
+++ b/tests/hardware/test_lis2mdl/test_main.cpp
@@ -3,6 +3,7 @@
 #include <Arduino.h>
 #include <LIS2MDL.h>
 #include <Wire.h>
+#include <math.h>
 #include <unity.h>
 
 #include "driver_checks.h"

--- a/tests/hardware/test_lis2mdl/test_main.cpp
+++ b/tests/hardware/test_lis2mdl/test_main.cpp
@@ -44,10 +44,10 @@ void test_lis2mdl_magnitude_ut_plausible(void) {
 
     float avgMag = (mag1 + mag2 + mag3) / 3.0f;
     float tolerance = avgMag * 0.1f;
-    TEST_ASSERT_TRUE_MESSAGE(avgMag > 5.0f, "magnitude trop faible");
-    TEST_ASSERT_TRUE_MESSAGE(fabs(mag1 - avgMag) < tolerance, "lecture 1 instable");
-    TEST_ASSERT_TRUE_MESSAGE(fabs(mag2 - avgMag) < tolerance, "lecture 2 instable");
-    TEST_ASSERT_TRUE_MESSAGE(fabs(mag3 - avgMag) < tolerance, "lecture 3 instable");
+    TEST_ASSERT_TRUE_MESSAGE(avgMag > 5.0f, "magnitude too low");
+    TEST_ASSERT_TRUE_MESSAGE(fabs(mag1 - avgMag) < tolerance, "reading 1 unstable");
+    TEST_ASSERT_TRUE_MESSAGE(fabs(mag2 - avgMag) < tolerance, "reading 2 unstable");
+    TEST_ASSERT_TRUE_MESSAGE(fabs(mag3 - avgMag) < tolerance, "reading 3 unstable");
 }
 
 void test_lis2mdl_heading_flat_only_in_range(void) {

--- a/tests/hardware/test_lis2mdl/test_main.cpp
+++ b/tests/hardware/test_lis2mdl/test_main.cpp
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <Arduino.h>
+#include <LIS2MDL.h>
+#include <Wire.h>
+#include <unity.h>
+
+#include "driver_checks.h"
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+LIS2MDL sensor(internalI2C);
+
+void setUp(void) {
+    sensor.begin();
+    sensor.setContinuous(10);
+}
+
+void tearDown(void) {}
+
+void test_lis2mdl_begin() {
+    check_begin(sensor);
+}
+
+void test_lis2mdl_who_am_i() {
+    check_who_am_i(sensor, LIS2MDL_WHO_AM_I_VAL);
+}
+
+void test_lis2mdl_read_plausible_magnetic_field(void) {
+    check_read_plausible(sensor, &LIS2MDL::magnitudeUt, 5.0f, 300.0f);
+}
+
+void test_lis2mdl_read_plausible_temperature(void) {
+    check_read_plausible(sensor, &LIS2MDL::temperature, -40.0f, 95.0f);
+}
+
+void test_lis2mdl_magnitude_ut_plausible(void) {
+    float mag1 = sensor.magnitudeUt();
+    delay(50);
+    float mag2 = sensor.magnitudeUt();
+    delay(50);
+    float mag3 = sensor.magnitudeUt();
+    delay(50);
+
+    float avgMag = (mag1 + mag2 + mag3) / 3.0f;
+    float tolerance = avgMag * 0.1f;
+    TEST_ASSERT_TRUE_MESSAGE(avgMag > 5.0f, "magnitude trop faible");
+    TEST_ASSERT_TRUE_MESSAGE(fabs(mag1 - avgMag) < tolerance, "lecture 1 instable");
+    TEST_ASSERT_TRUE_MESSAGE(fabs(mag2 - avgMag) < tolerance, "lecture 2 instable");
+    TEST_ASSERT_TRUE_MESSAGE(fabs(mag3 - avgMag) < tolerance, "lecture 3 instable");
+}
+
+void test_lis2mdl_heading_flat_only_in_range(void) {
+    check_read_plausible(sensor, &LIS2MDL::headingFlatOnly, 0.0f, 360.0f);
+}
+
+void setup() {
+    delay(2000);
+    internalI2C.begin();
+
+    UNITY_BEGIN();
+    RUN_TEST(test_lis2mdl_begin);
+    RUN_TEST(test_lis2mdl_who_am_i);
+    RUN_TEST(test_lis2mdl_read_plausible_magnetic_field);
+    RUN_TEST(test_lis2mdl_read_plausible_temperature);
+    RUN_TEST(test_lis2mdl_magnitude_ut_plausible);
+    RUN_TEST(test_lis2mdl_heading_flat_only_in_range);
+    UNITY_END();
+}
+
+void loop() {}

--- a/tests/native/test_lis2mdl/test_main.cpp
+++ b/tests/native/test_lis2mdl/test_main.cpp
@@ -1,0 +1,437 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <math.h>
+#include <unity.h>
+
+#include "LIS2MDL.h"
+#include "Wire.h"
+#include "driver_checks.h"
+
+constexpr uint8_t ADDR = LIS2MDL_I2C_ADDR;
+constexpr uint8_t WHO_AM_I_VAL = LIS2MDL_WHO_AM_I_VAL;
+
+static void preloadWhoAmI(bool valid = true) {
+    Wire.setRegister(ADDR, LIS2MDL_WHO_AM_I, valid ? LIS2MDL_WHO_AM_I_VAL : 0x00);
+}
+
+LIS2MDL sensor;
+
+void setUp(void) {
+    Wire = TwoWire();
+    preloadWhoAmI(true);
+    sensor = LIS2MDL(Wire, ADDR);
+}
+
+void tearDown(void) {}
+
+void test_begin_detects_device(void) {
+    check_begin(sensor);
+}
+
+void test_begin_rejects_wrong_who_am_i(void) {
+    preloadWhoAmI(false);
+    TEST_ASSERT_FALSE(sensor.begin());
+}
+
+void test_device_id_returns_who_am_i(void) {
+    check_who_am_i(sensor, LIS2MDL_WHO_AM_I_VAL);
+}
+
+void test_power_on_sets_continuous_mode(void) {
+    sensor.begin();
+    sensor.powerOn();
+    uint8_t cfgA = Wire.getRegister(ADDR, LIS2MDL_CFG_REG_A);
+    TEST_ASSERT_EQUAL_HEX8(0b00, cfgA & 0b11);
+}
+
+void test_power_off_sets_idle_mode(void) {
+    sensor.begin();
+    sensor.powerOff();
+    uint8_t cfgA = Wire.getRegister(ADDR, LIS2MDL_CFG_REG_A);
+    TEST_ASSERT_EQUAL_HEX8(0b11, cfgA & 0b11);
+}
+
+void test_set_continuous_writes_expected_cfg_reg_a(void) {
+    sensor.begin();
+    sensor.setContinuous(50);
+    uint8_t cfgA = Wire.getRegister(ADDR, LIS2MDL_CFG_REG_A);
+    TEST_ASSERT_EQUAL_HEX8(0b10 << 2, cfgA & (0b11 << 2));
+}
+
+void test_set_odr_writes_expected_bits(void) {
+    sensor.begin();
+    sensor.setOdr(100);
+    uint8_t cfgA = Wire.getRegister(ADDR, LIS2MDL_CFG_REG_A);
+    TEST_ASSERT_EQUAL_HEX8(0b11 << 2, cfgA & (0b11 << 2));
+}
+
+void test_trigger_one_shot_sets_single_mode(void) {
+    sensor.begin();
+    sensor.triggerOneShot();
+    uint8_t cfgA = Wire.getRegister(ADDR, LIS2MDL_CFG_REG_A);
+    TEST_ASSERT_EQUAL_HEX8(0b01, cfgA & 0b11);
+}
+
+void test_data_ready_reflects_status_register(void) {
+    sensor.begin();
+    Wire.setRegister(ADDR, LIS2MDL_STATUS_REG, 0b1000);
+    TEST_ASSERT_TRUE(sensor.dataReady());
+    Wire.setRegister(ADDR, LIS2MDL_STATUS_REG, 0b0000);
+    TEST_ASSERT_FALSE(sensor.dataReady());
+}
+
+void test_magnetic_field_returns_signed_values(void) {
+    sensor.begin();
+    Wire.setRegister(ADDR, LIS2MDL_OUTX_L_REG, 0x34);
+    Wire.setRegister(ADDR, LIS2MDL_OUTX_H_REG, 0x12);
+    Wire.setRegister(ADDR, LIS2MDL_OUTY_L_REG, 0x78);
+    Wire.setRegister(ADDR, LIS2MDL_OUTY_H_REG, 0x56);
+    Wire.setRegister(ADDR, LIS2MDL_OUTZ_L_REG, 0xBC);
+    Wire.setRegister(ADDR, LIS2MDL_OUTZ_H_REG, 0x9A);
+
+    MagneticField field = sensor.magneticField();
+    TEST_ASSERT_EQUAL_INT16(0x1234, field.x);
+    TEST_ASSERT_EQUAL_INT16(0x5678, field.y);
+    TEST_ASSERT_EQUAL_INT16((int16_t)0x9ABC, field.z);
+}
+
+void test_magnetic_field_ut_applies_lsb_conversion(void) {
+    sensor.begin();
+    Wire.setRegister(ADDR, LIS2MDL_OUTX_L_REG, 0x34);
+    Wire.setRegister(ADDR, LIS2MDL_OUTX_H_REG, 0x12);
+
+    MagneticFieldUt field = sensor.magneticFieldUt();
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 0.15f * 0x1234, field.x);
+}
+
+void test_calibrated_field_applies_offset_and_scale(void) {
+    sensor.begin();
+    sensor.setCalibrateStep(10.0f, 20.0f, 30.0f, 2.0f, 3.0f, 4.0f);
+    Wire.setRegister(ADDR, LIS2MDL_OUTX_L_REG, 0x34);
+    Wire.setRegister(ADDR, LIS2MDL_OUTX_H_REG, 0x12);
+    Wire.setRegister(ADDR, LIS2MDL_OUTY_L_REG, 0x78);
+    Wire.setRegister(ADDR, LIS2MDL_OUTY_H_REG, 0x56);
+    Wire.setRegister(ADDR, LIS2MDL_OUTZ_L_REG, 0xBC);
+    Wire.setRegister(ADDR, LIS2MDL_OUTZ_H_REG, 0x9A);
+
+    CalibratedField field = sensor.calibratedField();
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, (0x1234 - 10.0f) / 2.0f, field.x);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, (0x5678 - 20.0f) / 3.0f, field.y);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, ((int16_t)0x9ABC - 30.0f) / 4.0f, field.z);
+}
+
+void test_magnitude_ut_is_positive(void) {
+    sensor.begin();
+    Wire.setRegister(ADDR, LIS2MDL_OUTX_L_REG, 0x34);
+    Wire.setRegister(ADDR, LIS2MDL_OUTX_H_REG, 0x12);
+    Wire.setRegister(ADDR, LIS2MDL_OUTY_L_REG, 0x78);
+    Wire.setRegister(ADDR, LIS2MDL_OUTY_H_REG, 0x56);
+    Wire.setRegister(ADDR, LIS2MDL_OUTZ_L_REG, 0xBC);
+    Wire.setRegister(ADDR, LIS2MDL_OUTZ_H_REG, 0x9A);
+
+    float mag = sensor.magnitudeUt();
+    TEST_ASSERT_TRUE(mag > 0.0f);
+}
+
+void test_read_all_returns_all_channels(void) {
+    sensor.begin();
+    Wire.setRegister(ADDR, LIS2MDL_STATUS_REG, 0b1000);
+    Wire.setRegister(ADDR, LIS2MDL_OUTX_L_REG, 0x34);
+    Wire.setRegister(ADDR, LIS2MDL_OUTX_H_REG, 0x12);
+    Wire.setRegister(ADDR, LIS2MDL_OUTY_L_REG, 0x78);
+    Wire.setRegister(ADDR, LIS2MDL_OUTY_H_REG, 0x56);
+    Wire.setRegister(ADDR, LIS2MDL_OUTZ_L_REG, 0xBC);
+    Wire.setRegister(ADDR, LIS2MDL_OUTZ_H_REG, 0x9A);
+    Wire.setRegister(ADDR, LIS2MDL_TEMP_OUT_L_REG, 0x00);
+    Wire.setRegister(ADDR, LIS2MDL_TEMP_OUT_H_REG, 0x00);
+
+    ReadAll all = sensor.readAll();
+    TEST_ASSERT_EQUAL_INT16(0x1234, all.raw.x);
+    TEST_ASSERT_EQUAL_INT16(0x5678, all.raw.y);
+    TEST_ASSERT_EQUAL_INT16((int16_t)0x9ABC, all.raw.z);
+    TEST_ASSERT_TRUE(all.status == 0b1000);
+}
+
+void test_read_one_shot_returns_magnetic_field(void) {
+    sensor.begin();
+    Wire.setRegister(ADDR, LIS2MDL_STATUS_REG, 0b1000);
+    Wire.setRegister(ADDR, LIS2MDL_OUTX_L_REG, 0x34);
+    Wire.setRegister(ADDR, LIS2MDL_OUTX_H_REG, 0x12);
+    Wire.setRegister(ADDR, LIS2MDL_OUTY_L_REG, 0x78);
+    Wire.setRegister(ADDR, LIS2MDL_OUTY_H_REG, 0x56);
+    Wire.setRegister(ADDR, LIS2MDL_OUTZ_L_REG, 0xBC);
+    Wire.setRegister(ADDR, LIS2MDL_OUTZ_H_REG, 0x9A);
+
+    MagneticField field = sensor.readOneShot();
+    TEST_ASSERT_EQUAL_INT16(0x1234, field.x);
+    TEST_ASSERT_EQUAL_INT16(0x5678, field.y);
+    TEST_ASSERT_EQUAL_INT16((int16_t)0x9ABC, field.z);
+}
+
+void test_read_one_shot_returns_zeros_on_timeout(void) {
+    sensor.begin();
+    Wire.setRegister(ADDR, LIS2MDL_STATUS_REG, 0b0000);
+    Wire.setRegister(ADDR, LIS2MDL_OUTX_L_REG, 0x34);
+    Wire.setRegister(ADDR, LIS2MDL_OUTX_H_REG, 0x12);
+    Wire.setRegister(ADDR, LIS2MDL_OUTY_L_REG, 0x78);
+    Wire.setRegister(ADDR, LIS2MDL_OUTY_H_REG, 0x56);
+    Wire.setRegister(ADDR, LIS2MDL_OUTZ_L_REG, 0xBC);
+    Wire.setRegister(ADDR, LIS2MDL_OUTZ_H_REG, 0x9A);
+
+    MagneticField field = sensor.readOneShot();
+    TEST_ASSERT_EQUAL_INT16(0x0000, field.x);
+    TEST_ASSERT_EQUAL_INT16(0x0000, field.y);
+    TEST_ASSERT_EQUAL_INT16(0x0000, field.z);
+}
+
+void test_ensure_data_returns_false_on_timeout(void) {
+    sensor.begin();
+    sensor.setMode("powerdown");
+    Wire.setRegister(ADDR, LIS2MDL_STATUS_REG, 0b0000);
+    MagneticField field = sensor.magneticField();
+
+    TEST_ASSERT_EQUAL_INT16(0x0000, field.x);
+    TEST_ASSERT_EQUAL_INT16(0x0000, field.y);
+    TEST_ASSERT_EQUAL_INT16(0x0000, field.z);
+}
+
+void test_temperature_raw_is_signed(void) {
+    sensor.begin();
+    Wire.setRegister(ADDR, LIS2MDL_TEMP_OUT_L_REG, 0x34);
+    Wire.setRegister(ADDR, LIS2MDL_TEMP_OUT_H_REG, 0x12);
+
+    int16_t tempRaw = sensor.readTemperatureRaw();
+    TEST_ASSERT_EQUAL_INT16(0x1234, tempRaw);
+}
+
+void test_set_temp_offset_shifts_reading(void) {
+    sensor.begin();
+    Wire.setRegister(ADDR, LIS2MDL_TEMP_OUT_L_REG, 0x00);
+    Wire.setRegister(ADDR, LIS2MDL_TEMP_OUT_H_REG, 0x00);
+    Wire.setRegister(ADDR, LIS2MDL_STATUS_REG, 0b1000);
+    float baseTemp = sensor.temperature();
+
+    sensor.setTempOffset(10.0f);
+    float tempC = sensor.temperature();
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, baseTemp + 10.0f, tempC);
+}
+
+void test_calibrate_temperature_applies_two_point_correction(void) {
+    sensor.begin();
+    Wire.setRegister(ADDR, LIS2MDL_TEMP_OUT_L_REG, 0x00);
+    Wire.setRegister(ADDR, LIS2MDL_TEMP_OUT_H_REG, 0x00);
+
+    sensor.calibrateTemperature(21.0f, 20.0f, 27.0f, 25.0f);
+
+    float tempC = sensor.temperature();
+    TEST_ASSERT_FLOAT_WITHIN(0.05f, 27.0f, tempC);
+}
+
+void test_set_low_power_sets_bit4_cfg_reg_a(void) {
+    sensor.begin();
+    sensor.setLowPower(true);
+    uint8_t cfgA = Wire.getRegister(ADDR, LIS2MDL_CFG_REG_A);
+    TEST_ASSERT_EQUAL_HEX8(0b1 << 4, cfgA & (0b1 << 4));
+}
+
+void test_set_low_pass_sets_bit0_cfg_reg_b(void) {
+    sensor.begin();
+    sensor.setLowPass(true);
+    uint8_t cfgB = Wire.getRegister(ADDR, LIS2MDL_CFG_REG_B);
+    TEST_ASSERT_EQUAL_HEX8(0b1, cfgB & 0b1);
+}
+
+void test_set_offset_cancellation_sets_bits_cfg_reg_b(void) {
+    sensor.begin();
+    sensor.setOffsetCancellation(true, false);
+    uint8_t cfgB = Wire.getRegister(ADDR, LIS2MDL_CFG_REG_B);
+    TEST_ASSERT_EQUAL_HEX8(0b10, cfgB & 0b110);
+
+    sensor.setOffsetCancellation(true, true);
+    cfgB = Wire.getRegister(ADDR, LIS2MDL_CFG_REG_B);
+    TEST_ASSERT_EQUAL_HEX8(0b110, cfgB & 0b110);
+}
+
+void test_set_bdu_sets_bit4_cfg_reg_c(void) {
+    sensor.begin();
+    sensor.setBdu(true);
+    uint8_t cfgC = Wire.getRegister(ADDR, LIS2MDL_CFG_REG_C);
+    TEST_ASSERT_EQUAL_HEX8(0b1 << 4, cfgC & (0b1 << 4));
+}
+
+void test_set_hw_offsets_writes_offset_registers(void) {
+    sensor.begin();
+    sensor.setHwOffsets(0x12, 0x34, 0x56);
+    uint8_t xOffsetL = Wire.getRegister(ADDR, LIS2MDL_OFFSET_X_REG_L);
+    uint8_t xOffsetH = Wire.getRegister(ADDR, LIS2MDL_OFFSET_X_REG_H);
+    uint8_t yOffsetL = Wire.getRegister(ADDR, LIS2MDL_OFFSET_Y_REG_L);
+    uint8_t yOffsetH = Wire.getRegister(ADDR, LIS2MDL_OFFSET_Y_REG_H);
+    uint8_t zOffsetL = Wire.getRegister(ADDR, LIS2MDL_OFFSET_Z_REG_L);
+    uint8_t zOffsetH = Wire.getRegister(ADDR, LIS2MDL_OFFSET_Z_REG_H);
+
+    TEST_ASSERT_EQUAL_HEX8(0x12, xOffsetL);
+    TEST_ASSERT_EQUAL_HEX8(0x00, xOffsetH);
+    TEST_ASSERT_EQUAL_HEX8(0x34, yOffsetL);
+    TEST_ASSERT_EQUAL_HEX8(0x00, yOffsetH);
+    TEST_ASSERT_EQUAL_HEX8(0x56, zOffsetL);
+    TEST_ASSERT_EQUAL_HEX8(0x00, zOffsetH);
+}
+
+void test_read_hw_offsets_returns_written_values(void) {
+    sensor.begin();
+    Wire.setRegister(ADDR, LIS2MDL_OFFSET_X_REG_L, 0x12);
+    Wire.setRegister(ADDR, LIS2MDL_OFFSET_Y_REG_L, 0x34);
+    Wire.setRegister(ADDR, LIS2MDL_OFFSET_Z_REG_L, 0x56);
+
+    HwOffsets offsets = sensor.readHwOffsets();
+    TEST_ASSERT_EQUAL_HEX8(0x12, offsets.x);
+    TEST_ASSERT_EQUAL_HEX8(0x34, offsets.y);
+    TEST_ASSERT_EQUAL_HEX8(0x56, offsets.z);
+}
+
+void test_calibrate_reset_clears_offsets_and_scales(void) {
+    sensor.begin();
+    sensor.setCalibrateStep(10.0f, 20.0f, 30.0f, 2.0f, 3.0f, 4.0f);
+    Wire.setRegister(ADDR, LIS2MDL_OUTX_L_REG, 0x34);
+    Wire.setRegister(ADDR, LIS2MDL_OUTX_H_REG, 0x12);
+    Wire.setRegister(ADDR, LIS2MDL_STATUS_REG, 0b1000);
+
+    sensor.calibrateReset();
+
+    CalibratedField field = sensor.calibratedField();
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, (float)0x1234, field.x);
+}
+
+void test_calibrate_apply_normalizes_values(void) {
+    sensor.begin();
+    sensor.setCalibrateStep(10.0f, 20.0f, 30.0f, 2.0f, 3.0f, 4.0f);
+    Wire.setRegister(ADDR, LIS2MDL_OUTX_L_REG, 0x34);
+    Wire.setRegister(ADDR, LIS2MDL_OUTX_H_REG, 0x12);
+    Wire.setRegister(ADDR, LIS2MDL_OUTY_L_REG, 0x78);
+    Wire.setRegister(ADDR, LIS2MDL_OUTY_H_REG, 0x56);
+    Wire.setRegister(ADDR, LIS2MDL_OUTZ_L_REG, 0xBC);
+    Wire.setRegister(ADDR, LIS2MDL_OUTZ_H_REG, 0x9A);
+
+    CalibratedField field = sensor.calibrateApply(0x1234, 0x5678, (int16_t)0x9ABC);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, (0x1234 - 10.0f) / 2.0f, field.x);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, (0x5678 - 20.0f) / 3.0f, field.y);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, ((int16_t)0x9ABC - 30.0f) / 4.0f, field.z);
+}
+
+void test_heading_flat_only_returns_angle_in_0_360(void) {
+    sensor.begin();
+    Wire.setRegister(ADDR, LIS2MDL_OUTX_L_REG, 0x34);
+    Wire.setRegister(ADDR, LIS2MDL_OUTX_H_REG, 0x12);
+    Wire.setRegister(ADDR, LIS2MDL_OUTY_L_REG, 0x78);
+    Wire.setRegister(ADDR, LIS2MDL_OUTY_H_REG, 0x56);
+    Wire.setRegister(ADDR, LIS2MDL_OUTZ_L_REG, 0xBC);
+    Wire.setRegister(ADDR, LIS2MDL_OUTZ_H_REG, 0x9A);
+
+    float heading = sensor.headingFlatOnly();
+    TEST_ASSERT_TRUE(heading >= 0.0f && heading < 360.0f);
+}
+
+void test_heading_filter_smooths_angle(void) {
+    sensor.begin();
+    sensor.setHeadingFilter(0.5f);
+    Wire.setRegister(ADDR, LIS2MDL_OUTX_L_REG, 0x34);
+    Wire.setRegister(ADDR, LIS2MDL_OUTX_H_REG, 0x12);
+    Wire.setRegister(ADDR, LIS2MDL_OUTY_L_REG, 0x78);
+    Wire.setRegister(ADDR, LIS2MDL_OUTY_H_REG, 0x56);
+    Wire.setRegister(ADDR, LIS2MDL_OUTZ_L_REG, 0xBC);
+    Wire.setRegister(ADDR, LIS2MDL_OUTZ_H_REG, 0x9A);
+
+    float heading1 = sensor.headingFlatOnly();
+    float heading2 = sensor.headingFlatOnly();
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, heading1, heading2);
+}
+
+void test_normalize_deg_wraps_negative_angles(void) {
+    sensor.begin();
+    sensor.setHeadingOffset(-180.0f);
+    float heading = sensor.headingFromVectors(0.0f, 1.0f, 0.0f, false);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 270.0f, heading);
+    sensor.setHeadingOffset(0.0f);
+}
+
+void test_direction_label_returns_correct_cardinal(void) {
+    sensor.begin();
+    const char* label = sensor.directionLabel(45.0f);
+    TEST_ASSERT_EQUAL_STRING("NE", label);
+
+    label = sensor.directionLabel(135.0f);
+    TEST_ASSERT_EQUAL_STRING("SE", label);
+
+    label = sensor.directionLabel(225.0f);
+    TEST_ASSERT_EQUAL_STRING("SW", label);
+
+    label = sensor.directionLabel(315.0f);
+    TEST_ASSERT_EQUAL_STRING("NW", label);
+}
+
+void test_soft_reset_writes_bit5_cfg_reg_a(void) {
+    sensor.begin();
+    sensor.softReset();
+    uint8_t cfgA = Wire.getRegister(ADDR, LIS2MDL_CFG_REG_A);
+    TEST_ASSERT_EQUAL_HEX8(0b1 << 5, cfgA & (0b1 << 5));
+}
+
+void test_reboot_writes_bit6_cfg_reg_a(void) {
+    sensor.begin();
+    sensor.reboot();
+    uint8_t cfgA = Wire.getRegister(ADDR, LIS2MDL_CFG_REG_A);
+    TEST_ASSERT_EQUAL_HEX8(0b1 << 6, cfgA & (0b1 << 6));
+}
+
+void test_get_mode_returns_correct_string(void) {
+    sensor.begin();
+    sensor.powerOff();
+    const char* mode = sensor.getMode();
+    TEST_ASSERT_EQUAL_STRING("idle", mode);
+}
+
+void test_is_idle_returns_true_when_md_bits_are_11(void) {
+    sensor.begin();
+    sensor.setMode("powerdown");
+    TEST_ASSERT_TRUE(sensor.isIdle());
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_begin_detects_device);
+    RUN_TEST(test_begin_rejects_wrong_who_am_i);
+    RUN_TEST(test_device_id_returns_who_am_i);
+    RUN_TEST(test_power_on_sets_continuous_mode);
+    RUN_TEST(test_power_off_sets_idle_mode);
+    RUN_TEST(test_set_continuous_writes_expected_cfg_reg_a);
+    RUN_TEST(test_set_odr_writes_expected_bits);
+    RUN_TEST(test_trigger_one_shot_sets_single_mode);
+    RUN_TEST(test_data_ready_reflects_status_register);
+    RUN_TEST(test_magnetic_field_returns_signed_values);
+    RUN_TEST(test_magnetic_field_ut_applies_lsb_conversion);
+    RUN_TEST(test_calibrated_field_applies_offset_and_scale);
+    RUN_TEST(test_magnitude_ut_is_positive);
+    RUN_TEST(test_read_all_returns_all_channels);
+    RUN_TEST(test_read_one_shot_returns_magnetic_field);
+    RUN_TEST(test_read_one_shot_returns_zeros_on_timeout);
+    RUN_TEST(test_temperature_raw_is_signed);
+    RUN_TEST(test_set_temp_offset_shifts_reading);
+    RUN_TEST(test_calibrate_temperature_applies_two_point_correction);
+    RUN_TEST(test_set_low_power_sets_bit4_cfg_reg_a);
+    RUN_TEST(test_set_low_pass_sets_bit0_cfg_reg_b);
+    RUN_TEST(test_set_offset_cancellation_sets_bits_cfg_reg_b);
+    RUN_TEST(test_set_bdu_sets_bit4_cfg_reg_c);
+    RUN_TEST(test_set_hw_offsets_writes_offset_registers);
+    RUN_TEST(test_read_hw_offsets_returns_written_values);
+    RUN_TEST(test_calibrate_reset_clears_offsets_and_scales);
+    RUN_TEST(test_calibrate_apply_normalizes_values);
+    RUN_TEST(test_heading_flat_only_returns_angle_in_0_360);
+    RUN_TEST(test_heading_filter_smooths_angle);
+    RUN_TEST(test_normalize_deg_wraps_negative_angles);
+    RUN_TEST(test_direction_label_returns_correct_cardinal);
+    RUN_TEST(test_soft_reset_writes_bit5_cfg_reg_a);
+    RUN_TEST(test_reboot_writes_bit6_cfg_reg_a);
+    RUN_TEST(test_get_mode_returns_correct_string);
+    RUN_TEST(test_is_idle_returns_true_when_md_bits_are_11);
+    return UNITY_END();
+}

--- a/tests/native/test_lis2mdl/test_main.cpp
+++ b/tests/native/test_lis2mdl/test_main.cpp
@@ -8,7 +8,6 @@
 #include "driver_checks.h"
 
 constexpr uint8_t ADDR = LIS2MDL_I2C_ADDR;
-constexpr uint8_t WHO_AM_I_VAL = LIS2MDL_WHO_AM_I_VAL;
 
 static void preloadWhoAmI(bool valid = true) {
     Wire.setRegister(ADDR, LIS2MDL_WHO_AM_I, valid ? LIS2MDL_WHO_AM_I_VAL : 0x00);
@@ -414,6 +413,7 @@ int main(void) {
     RUN_TEST(test_read_all_returns_all_channels);
     RUN_TEST(test_read_one_shot_returns_magnetic_field);
     RUN_TEST(test_read_one_shot_returns_zeros_on_timeout);
+    RUN_TEST(test_ensure_data_returns_false_on_timeout);
     RUN_TEST(test_temperature_raw_is_signed);
     RUN_TEST(test_set_temp_offset_shifts_reading);
     RUN_TEST(test_calibrate_temperature_applies_two_point_correction);


### PR DESCRIPTION
## Summary

Adds a full driver for the LIS2MDL 3-axis magnetometer, including native mock tests and hardware validation tests. Closes #4
Close #36 
Close #24

## Changes

- Add `LIS2MDL.h`, `LIS2MDL.cpp`, and `LIS2MDL_const.h` implementing the full driver API
- Add magnetic field reading (`magneticField`, `magneticFieldUt`, `calibratedField`, `magnitudeUt`)
- Add temperature reading with two-point calibration (`temperature`, `setTempOffset`, `calibrateTemperature`)
- Add continuous and one-shot acquisition modes (`setContinuous`, `triggerOneShot`, `readOneShot`)
- Add hard and soft calibration (`calibrateMinmax2d`, `calibrateMinmax3d`, `calibrateApply`, `calibrateQuality`)
- Add tilt-compensated and flat-only compass heading (`headingFlatOnly`, `headingWithTiltCompensation`)
- Add hardware offset registers read/write (`readHwOffsets`, `setHwOffsets`)
- Add power management (`powerOn`, `powerOff`, `softReset`, `reboot`)
- Add native mock test suite covering 34 test cases (register writes, signed values, calibration math, heading, timeout behaviour)
- Add hardware test suite validating device detection, magnetic field plausibility, and sensor stability on real STeaMi silicon

## Checklist

- [x] `make lint` passes (clang-format)
- [x] `make build` passes (PlatformIO)
- [x] `make test-native` passes (if native tests exist)
- [x] `make test-hardware` passes on a connected STeaMi (if hardware tests exist)
- [x] README updated (if adding/changing public API)
- [ ] Examples added/updated (if applicable)
- [x] Commit messages follow conventional commits format
