### PR TITLE
examples(ssd1327): Add practical usage examples.

### DIFF
--- a/lib/ssd1327/README.md
+++ b/lib/ssd1327/README.md
@@ -95,7 +95,7 @@ See [examples/](examples/) for full sketches.
 
 | Example | What it does |
 |---------|--------------|
-| [`framebuf_pixels`](examples/framebuf_pixels/) | Draw individual pixels at various positions and grayscale levels. |
+| [`framebuf_pixels`](examples/framebuf_pixels/) | Draw individual pixel at various positions and grayscale levels. |
 | [`framebuf_lines`](examples/framebuf_lines/) | Draw diagonal and intersecting lines across the display. |
 | [`framebuf_rects`](examples/framebuf_rects/) | Draw filled and outlined rectangles using different grayscale levels. |
 | [`framebuf_text`](examples/framebuf_text/) | Render text strings at different positions on the display. |

--- a/lib/ssd1327/README.md
+++ b/lib/ssd1327/README.md
@@ -95,22 +95,29 @@ See [examples/](examples/) for full sketches.
 
 | Example | What it does |
 |---------|--------------|
-| [`fill_and_show`](examples/fill_and_show/) | Fill the screen with a uniform grayscale level and display it. |
-| [`draw_shapes`](examples/draw_shapes/) | Draw pixels, lines, and rectangles at various grayscale levels. |
-| [`scroll`](examples/scroll/) | Software-scroll the framebuffer horizontally and/or vertically. |
-| [`contrast`](examples/contrast/) | Cycle through contrast levels to demonstrate brightness control. |
+| [`framebuf_pixels`](examples/framebuf_pixels/) | Draw individual pixels at various positions and grayscale levels. |
+| [`framebuf_lines`](examples/framebuf_lines/) | Draw diagonal and intersecting lines across the display. |
+| [`framebuf_rects`](examples/framebuf_rects/) | Draw filled and outlined rectangles using different grayscale levels. |
+| [`framebuf_text`](examples/framebuf_text/) | Render text strings at different positions on the display. |
+| [`framebuf_scroll`](examples/framebuf_scroll/) | Demonstrate software scrolling of the framebuffer with text. |
+| [`invert`](examples/invert/) | Toggle the display between normal and inverted modes. |
+| [`rotation`](examples/rotation/) | Demonstrate 180° display rotation. |
+| [`shades`](examples/shades/) | Display vertical bands covering all 16 shades of gray. |
+| [`random_pixels`](examples/random_pixels/) | Display one randomly positioned grayscale pixels on each iteration. |
+| [`illusion`](examples/illusion/) | Render an optical illusion pattern using alternating squares and horizontal lines. |
+| [`rotating_3d_cube`](examples/rotating_3d_cube/) | Animate a rotating wireframe 3D cube. |
 
 ### Building an example
 
 ```bash
 make list-examples
-make flash-ssd1327/fill_and_show
+make flash-ssd1327/rotating_3d_cube
 ```
 
 To capture serial output from boot:
 
 ```bash
-make capture-ssd1327/fill_and_show
+make capture-ssd1327/rotating_3d_cube
 ```
 
 ## API

--- a/lib/ssd1327/examples/framebuf_lines/framebuf_lines.ino
+++ b/lib/ssd1327/examples/framebuf_lines/framebuf_lines.ino
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include <Arduino.h>
+#include <SSD1327.h>
+
+#ifndef DATA_COMMAND_DISPLAY
+#define DATA_COMMAND_DISPLAY SPI_INT_MISO
+#endif
+
+WS_OLED_128X128_STEAMI display;
+
+void setup() {
+    Serial.begin(115200);
+    delay(2000);
+
+    if (!display.begin()) {
+        Serial.println("SSD1327 not found");
+        while (true) {
+        }
+    }
+
+    display.fill(0);
+    for (uint8_t i = 0; i < 128; i += 16) {
+        display.line(0, i, 127, 127 - i, 15);
+        display.line(i, 0, 127 - i, 127, 8);
+    }
+    display.show();
+
+    Serial.println("SSD1327 lines example : displaying stars pattern");
+}
+
+void loop() {}

--- a/lib/ssd1327/examples/framebuf_pixels/framebuf_pixels.ino
+++ b/lib/ssd1327/examples/framebuf_pixels/framebuf_pixels.ino
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include <Arduino.h>
+#include <SSD1327.h>
+
+#ifndef DATA_COMMAND_DISPLAY
+#define DATA_COMMAND_DISPLAY SPI_INT_MISO
+#endif
+
+WS_OLED_128X128_STEAMI display;
+
+void setup() {
+    Serial.begin(115200);
+    delay(2000);
+
+    if (!display.begin()) {
+        Serial.println("SSD1327 not found");
+        while (true) {
+        }
+    }
+
+    display.fill(0);
+    display.pixel(0, 0, 15);
+    display.pixel(127, 0, 15);
+    display.pixel(0, 127, 15);
+    display.pixel(127, 127, 15);
+    display.pixel(64, 64, 15);
+    display.pixel(32, 32, 8);
+    display.pixel(96, 32, 8);
+    display.pixel(32, 96, 8);
+    display.pixel(96, 96, 8);
+    display.show();
+
+    Serial.println("SSD1327 pixels example : displaying corners and center pixels");
+}
+
+void loop() {}

--- a/lib/ssd1327/examples/framebuf_rects/framebuf_rects.ino
+++ b/lib/ssd1327/examples/framebuf_rects/framebuf_rects.ino
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include <Arduino.h>
+#include <SSD1327.h>
+
+#ifndef DATA_COMMAND_DISPLAY
+#define DATA_COMMAND_DISPLAY SPI_INT_MISO
+#endif
+
+WS_OLED_128X128_STEAMI display;
+
+void setup() {
+    Serial.begin(115200);
+    delay(2000);
+
+    if (!display.begin()) {
+        Serial.println("SSD1327 not found");
+        while (true) {
+        }
+    }
+
+    display.fill(0);
+    display.fillRect(8, 8, 112, 112, 2);
+    display.fillRect(20, 20, 88, 88, 5);
+    display.fillRect(32, 32, 64, 64, 8);
+    display.fillRect(44, 44, 40, 40, 12);
+    display.fillRect(56, 56, 16, 16, 15);
+    display.show();
+
+    Serial.println("SSD1327 rects example : displaying nested rectangles");
+}
+
+void loop() {}

--- a/lib/ssd1327/examples/framebuf_scroll/framebuf_scroll.ino
+++ b/lib/ssd1327/examples/framebuf_scroll/framebuf_scroll.ino
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include <Arduino.h>
+#include <SSD1327.h>
+
+#ifndef DATA_COMMAND_DISPLAY
+#define DATA_COMMAND_DISPLAY SPI_INT_MISO
+#endif
+
+WS_OLED_128X128_STEAMI display;
+
+int16_t x = 128;
+
+void setup() {
+    Serial.begin(115200);
+    delay(2000);
+
+    if (!display.begin()) {
+        Serial.println("SSD1327 not found");
+        while (true) {
+        }
+    }
+}
+
+void loop() {
+    display.fill(0);
+    display.text("Scrolling text", x, 56, 15);
+    display.show();
+
+    x -= 2;
+    if (x < -110) {
+        x = 128;
+    }
+
+    delay(40);
+}

--- a/lib/ssd1327/examples/framebuf_text/framebuf_text.ino
+++ b/lib/ssd1327/examples/framebuf_text/framebuf_text.ino
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include <Arduino.h>
+#include <SSD1327.h>
+
+#ifndef DATA_COMMAND_DISPLAY
+#define DATA_COMMAND_DISPLAY SPI_INT_MISO
+#endif
+
+WS_OLED_128X128_STEAMI display;
+
+void setup() {
+    Serial.begin(115200);
+    delay(2000);
+
+    if (!display.begin()) {
+        Serial.println("SSD1327 not found");
+        while (true) {
+        }
+    }
+
+    display.fill(0);
+    display.text("SSD1327", 34, 18, 15);
+    display.text("Arduino", 34, 42, 12);
+    display.text("STeaMi", 38, 66, 8);
+    display.text("OLED 128x128", 18, 90, 5);
+    display.show();
+
+    Serial.println("SSD1327 text example : displaying text with different shades of gray");
+}
+
+void loop() {}

--- a/lib/ssd1327/examples/illusion/illusion.ino
+++ b/lib/ssd1327/examples/illusion/illusion.ino
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include <Arduino.h>
+#include <SSD1327.h>
+
+#ifndef DATA_COMMAND_DISPLAY
+#define DATA_COMMAND_DISPLAY SPI_INT_MISO
+#endif
+
+WS_OLED_128X128_STEAMI display;
+
+void setup() {
+    Serial.begin(115200);
+    delay(2000);
+
+    if (!display.begin()) {
+        Serial.println("Display not found");
+        while (true) {
+            delay(1000);
+        }
+    }
+
+    display.fill(15);
+
+    const int sq = 12;
+    int seq = 100;
+
+    for (int y = 0; y < 128; y += sq + 1) {
+        int offset = round(((seq & 3) / 3.0) * sq);
+        seq >>= 2;
+
+        if (seq == 0) {
+            seq = 100;
+        }
+
+        for (int x = 0; x < 128; x += sq * 2) {
+            display.fillRect(x + offset, y, sq, sq, 0);
+        }
+
+        display.fillRect(0, y + sq, 128, 1, 6);
+    }
+
+    display.show();
+}
+
+void loop() {}

--- a/lib/ssd1327/examples/invert/invert.ino
+++ b/lib/ssd1327/examples/invert/invert.ino
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include <Arduino.h>
+#include <SSD1327.h>
+
+#ifndef DATA_COMMAND_DISPLAY
+#define DATA_COMMAND_DISPLAY SPI_INT_MISO
+#endif
+
+WS_OLED_128X128_STEAMI display;
+
+void setup() {
+    Serial.begin(115200);
+    delay(2000);
+
+    if (!display.begin()) {
+        Serial.println("SSD1327 not found");
+        while (true) {
+        }
+    }
+
+    display.fill(0);
+    display.fillRect(54, 54, 10, 10, 15);
+    display.fillRect(64, 64, 10, 10, 10);
+    display.fillRect(54, 64, 10, 10, 5);
+    display.fillRect(64, 54, 10, 10, 1);
+    display.show();
+}
+
+void loop() {
+    display.invert(false);
+    Serial.println("Invert false");
+    delay(1000);
+
+    display.invert(true);
+    Serial.println("Invert true");
+    delay(1000);
+}

--- a/lib/ssd1327/examples/random_pixels/random_pixels.ino
+++ b/lib/ssd1327/examples/random_pixels/random_pixels.ino
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include <Arduino.h>
+#include <SSD1327.h>
+
+#ifndef DATA_COMMAND_DISPLAY
+#define DATA_COMMAND_DISPLAY SPI_INT_MISO
+#endif
+
+WS_OLED_128X128_STEAMI display;
+
+void setup() {
+    Serial.begin(115200);
+    delay(2000);
+
+    if (!display.begin()) {
+        Serial.println("SSD1327 not found");
+        while (true) {
+        }
+    }
+
+    randomSeed(analogRead(A0));
+}
+
+void loop() {
+    uint8_t x = random(0, 128);
+    uint8_t y = random(0, 128);
+    uint8_t c = random(1, 16);
+    display.pixel(x, y, c);
+    display.show();
+    delay(100);
+}

--- a/lib/ssd1327/examples/rotating_3d_cube/rotating_3d_cube.ino
+++ b/lib/ssd1327/examples/rotating_3d_cube/rotating_3d_cube.ino
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include <Arduino.h>
+#include <SSD1327.h>
+
+#ifndef DATA_COMMAND_DISPLAY
+#define DATA_COMMAND_DISPLAY SPI_INT_MISO
+#endif
+
+WS_OLED_128X128_STEAMI display;
+
+struct Point3D {
+    float x;
+    float y;
+    float z;
+};
+
+const Point3D cube[8] = {
+    {-1, -1, -1}, {1, -1, -1}, {1, 1, -1}, {-1, 1, -1},
+    {-1, -1, 1},  {1, -1, 1},  {1, 1, 1},  {-1, 1, 1},
+};
+
+const uint8_t edges[12][2] = {
+    {0, 1}, {1, 2}, {2, 3}, {3, 0}, {4, 5}, {5, 6}, {6, 7}, {7, 4}, {0, 4}, {1, 5}, {2, 6}, {3, 7},
+};
+
+int16_t screenX[8];
+uint8_t screenY[8];
+float angle = 0.0f;
+
+void setup() {
+    Serial.begin(115200);
+    delay(2000);
+
+    if (!display.begin()) {
+        Serial.println("SSD1327 not found");
+        while (true) {
+        }
+    }
+}
+
+void loop() {
+    display.fill(0);
+
+    float sinA = sin(angle);
+    float cosA = cos(angle);
+    float sinB = sin(angle * 0.7f);
+    float cosB = cos(angle * 0.7f);
+
+    for (uint8_t i = 0; i < 8; i++) {
+        float x = cube[i].x;
+        float y = cube[i].y;
+        float z = cube[i].z;
+
+        float x1 = x * cosA - z * sinA;
+        float z1 = x * sinA + z * cosA;
+        float y1 = y * cosB - z1 * sinB;
+        float z2 = y * sinB + z1 * cosB + 4.0f;
+
+        screenX[i] = 64 + (int16_t)(x1 * 42.0f / z2);
+        screenY[i] = 64 + (int16_t)(y1 * 42.0f / z2);
+    }
+
+    for (uint8_t i = 0; i < 12; i++) {
+        uint8_t a = edges[i][0];
+        uint8_t b = edges[i][1];
+        display.line(screenX[a], screenY[a], screenX[b], screenY[b], 15);
+    }
+
+    display.show();
+    angle += 0.06f;
+    delay(30);
+}

--- a/lib/ssd1327/examples/rotation/rotation.ino
+++ b/lib/ssd1327/examples/rotation/rotation.ino
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include <Arduino.h>
+#include <SSD1327.h>
+
+#ifndef DATA_COMMAND_DISPLAY
+#define DATA_COMMAND_DISPLAY SPI_INT_MISO
+#endif
+
+WS_OLED_128X128_STEAMI display;
+
+bool rotated = false;
+
+void drawScreen() {
+    display.fill(0);
+    display.text(rotated ? "Rotated" : "Normal", 34, 16, 15);
+    display.fillRect(10, 36, 30, 30, 15);
+    display.fillRect(88, 88, 30, 30, 8);
+    display.line(0, 0, 127, 127, 12);
+    display.show();
+}
+
+void setup() {
+    Serial.begin(115200);
+    delay(2000);
+
+    if (!display.begin()) {
+        Serial.println("SSD1327 not found");
+        while (true) {
+        }
+    }
+
+    drawScreen();
+}
+
+void loop() {
+    rotated = !rotated;
+    display.rotate(rotated);
+    drawScreen();
+    delay(2000);
+}

--- a/lib/ssd1327/examples/shades/shades.ino
+++ b/lib/ssd1327/examples/shades/shades.ino
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include <Arduino.h>
+#include <SSD1327.h>
+
+#ifndef DATA_COMMAND_DISPLAY
+#define DATA_COMMAND_DISPLAY SPI_INT_MISO
+#endif
+
+WS_OLED_128X128_STEAMI display;
+
+void setup() {
+    Serial.begin(115200);
+    delay(2000);
+
+    if (!display.begin()) {
+        Serial.println("SSD1327 not found");
+        while (true) {
+        }
+    }
+
+    display.fill(0);
+    for (uint8_t shade = 0; shade <= 16; shade++) {
+        display.fillRect((shade) * 8, 0, 8, 128, shade);
+    }
+    display.show();
+}
+
+void loop() {}

--- a/lib/ssd1327/examples/shades/shades.ino
+++ b/lib/ssd1327/examples/shades/shades.ino
@@ -19,7 +19,7 @@ void setup() {
     }
 
     display.fill(0);
-    for (uint8_t shade = 0; shade <= 16; shade++) {
+    for (uint8_t shade = 0; shade <= 15; shade++) {
         display.fillRect((shade) * 8, 0, 8, 128, shade);
     }
     display.show();


### PR DESCRIPTION
## Summary

Add a collection of Arduino examples demonstrating the main features of the SSD1327 driver.

**Depends on:** #192

Closes #77

## Changes

* Add `framebuf_pixels` example demonstrating individual pixel drawing.
* Add `framebuf_lines` example demonstrating line drawing.
* Add `framebuf_rects` example demonstrating rectangle drawing with multiple grayscale levels.
* Add `framebuf_text` example demonstrating text rendering.
* Add `framebuf_scroll` example demonstrating software framebuffer scrolling.
* Add `invert` example demonstrating display inversion.
* Add `rotation` example demonstrating 180° display rotation.
* Add `shades` example displaying grayscale bands.
* Add `random_pixels` example demonstrating random pixel rendering.
* Add `illusion` example reproducing the optical illusion from the MicroPython driver.
* Add `rotating_3d_cube` example demonstrating a rotating wireframe cube animation.
* Update the SSD1327 README with an examples table describing each sketch.

## Checklist

* [x] `make lint` passes (clang-format)
* [x] `make build` passes (PlatformIO)
* [ ] `make test-native` passes (if native tests exist)
* [x] `make test-hardware` passes on a connected STeaMi (if hardware tests exist)
* [x] README updated (if adding/changing public API)
* [x] Examples added/updated (if applicable)
* [x] Commit messages follow conventional commits format
