### PR TITLE
examples(lis2mdl): Add practical Arduino examples.

### DIFF
--- a/lib/lis2mdl/README.md
+++ b/lib/lis2mdl/README.md
@@ -52,10 +52,10 @@ for the full sketch.
 
 | Example | What it does |
 |---------|--------------|
-| [`read_magnetic_field`](examples/read_magnetic_field/) | Print raw X/Y/Z magnetic field values at 10 Hz. |
-| [`compass`](examples/compass/) | Flat 2D compass heading with min/max calibration and cardinal direction label. |
-| [`magnitude`](examples/magnitude/) | Print total field strength in µT — useful to detect nearby magnets or metallic objects. |
-| [`tilt_compensated_compass`](examples/tilt_compensated_compass/) | Heading with tilt compensation using an external accelerometer. |
+| [`BasicReader`](examples/BasicReader/) | Read X/Y/Z magnetic field and temperature, then print the values to the Serial Monitor. |
+| [`DigitalCompass`](examples/DigitalCompass/) | Perform a 2D min/max calibration, compute the compass heading, and display the heading and cardinal direction on Serial (and OLED on STeaMi when available). |
+| [`MetalDetector`](examples/MetalDetector/) | Measure the magnetic field magnitude, learn a baseline, and detect nearby metallic or magnetic objects. |
+| [`MagneticCalibration`](examples/MagneticCalibration/) | Perform a guided hard-iron calibration by rotating the board, then compute and display the calibration offsets. |
 
 ### Building an example
 
@@ -68,14 +68,14 @@ make list-examples
 Then flash one:
 
 ```bash
-make flash-lis2mdl/compass
+make flash-lis2mdl/BasicReader
 ```
 
 To capture the first lines printed at boot:
 
 ```bash
-make capture-lis2mdl/compass
-make capture-lis2mdl/compass DURATION=30
+make capture-lis2mdl/BasicReader
+make capture-lis2mdl/BasicReader DURATION=30
 ```
 
 ## API

--- a/lib/lis2mdl/examples/BasicReader/BasicReader.ino
+++ b/lib/lis2mdl/examples/BasicReader/BasicReader.ino
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// BasicReader.ino
+// Read LIS2MDL magnetic field XYZ and temperature, then print to Serial.
+
+#include <Arduino.h>
+#include <LIS2MDL.h>
+#include <Wire.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+LIS2MDL magnetometer(internalI2C);
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial && millis() < 2000) {
+    }
+
+    internalI2C.begin();
+
+    if (!magnetometer.begin()) {
+        Serial.println("LIS2MDL not detected. Check the internal I2C bus.");
+        while (true) {
+            delay(1000);
+        }
+    }
+
+    magnetometer.setContinuous(10);
+
+    Serial.println("LIS2MDL Basic Reader");
+    Serial.println("X_uT,Y_uT,Z_uT,temperature_C,magnitude_uT");
+}
+
+void loop() {
+    if (!magnetometer.dataReady()) {
+        delay(10);
+        return;
+    }
+
+    MagneticFieldUt field = magnetometer.magneticFieldUt();
+    float temperatureC = magnetometer.temperature();
+    float magnitude = magnetometer.magnitudeUt();
+
+    Serial.print(field.x, 2);
+    Serial.print(',');
+    Serial.print(field.y, 2);
+    Serial.print(',');
+    Serial.print(field.z, 2);
+    Serial.print(',');
+    Serial.print(temperatureC, 2);
+    Serial.print(',');
+    Serial.println(magnitude, 2);
+
+    delay(100);
+}

--- a/lib/lis2mdl/examples/DigitalCompass/DigitalCompass.ino
+++ b/lib/lis2mdl/examples/DigitalCompass/DigitalCompass.ino
@@ -61,13 +61,13 @@ void setup() {
         }
     }
 
-    magnetometer.setContinuous(20);
+    magnetometer.setContinuous(50);
     magnetometer.setHeadingFilter(0.2f);
 
     delay(1000);
 
     Serial.println("Rotate the board flat in a full circle for calibration for 30 seconds...");
-    magnetometer.calibrateMinmax2d(300, 20);
+    magnetometer.calibrateMinmax2d(1000, 20);
     Serial.println("Calibration done.");
 
     Serial.println("Rotate the board flat in a full circle for best results.");

--- a/lib/lis2mdl/examples/DigitalCompass/DigitalCompass.ino
+++ b/lib/lis2mdl/examples/DigitalCompass/DigitalCompass.ino
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// DigitalCompass.ino
+// Flat compass using the LIS2MDL. Prints heading and cardinal direction to Serial.
+// If the SSD1327 display library is available, it also displays the heading on OLED.
+
+#include <Arduino.h>
+#include <LIS2MDL.h>
+#include <Wire.h>
+
+#if __has_include(<SSD1327.h>)
+#include <SSD1327.h>
+#define HAS_STEAMI_OLED 1
+#else
+#define HAS_STEAMI_OLED 0
+#endif
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+LIS2MDL magnetometer(internalI2C);
+
+#if HAS_STEAMI_OLED
+// Adjust this constructor if your SSD1327 driver exposes a different STeaMi preset.
+SSD1327 display;
+#endif
+
+static void showOnOled(float headingDeg, const char* direction) {
+#if HAS_STEAMI_OLED
+    display.fill(0);
+    display.setCursor(0, 10);
+    display.print("Compass");
+    display.setCursor(0, 35);
+    display.print(headingDeg, 1);
+    display.print(" deg");
+    display.setCursor(0, 60);
+    display.print(direction);
+    display.show();
+#else
+    (void)headingDeg;
+    (void)direction;
+#endif
+}
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial && millis() < 2000) {
+    }
+
+    internalI2C.begin();
+
+#if HAS_STEAMI_OLED
+    display.begin();
+    display.fill(0);
+    display.setCursor(0, 0);
+    display.print("Starting compass...");
+    display.show();
+#endif
+
+    if (!magnetometer.begin()) {
+        Serial.println("LIS2MDL not detected. Check the internal I2C bus.");
+        while (true) {
+            delay(1000);
+        }
+    }
+
+    magnetometer.setContinuous(20);
+    magnetometer.setHeadingFilter(0.2f);
+
+    delay(1000);
+
+    Serial.println("Rotate the board flat in a full circle for calibration for 30 seconds...");
+    magnetometer.calibrateMinmax2d(300, 20);
+    Serial.println("Calibration done.");
+
+    Serial.println("Rotate the board flat in a full circle for best results.");
+    Serial.println("heading_deg,direction");
+}
+
+void loop() {
+    float heading = magnetometer.headingFlatOnly();
+    const char* direction = magnetometer.directionLabel(heading);
+
+    Serial.print(heading, 1);
+    Serial.print(',');
+    Serial.println(direction);
+
+    showOnOled(heading, direction);
+    delay(250);
+}

--- a/lib/lis2mdl/examples/MagneticCalibration/MagneticCalibration.ino
+++ b/lib/lis2mdl/examples/MagneticCalibration/MagneticCalibration.ino
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// MagneticCalibration.ino
+// Guided hard-iron calibration. Rotate the board in all directions.
+// The computed offsets/scales are printed and can be stored in steami_config later.
+
+#include <Arduino.h>
+#include <LIS2MDL.h>
+#include <Wire.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+LIS2MDL magnetometer(internalI2C);
+
+static void printCalibration() {
+    Serial.println("Calibration values:");
+    Serial.print("xOff=");
+    Serial.println(magnetometer.xOff, 6);
+    Serial.print("yOff=");
+    Serial.println(magnetometer.yOff, 6);
+    Serial.print("zOff=");
+    Serial.println(magnetometer.zOff, 6);
+    Serial.print("xScale=");
+    Serial.println(magnetometer.xScale, 6);
+    Serial.print("yScale=");
+    Serial.println(magnetometer.yScale, 6);
+    Serial.print("zScale=");
+    Serial.println(magnetometer.zScale, 6);
+}
+
+static void printQuality() {
+    CalibrationQuality quality = magnetometer.calibrateQuality(200, 10);
+    Serial.println("Calibration quality:");
+    Serial.print("center=(");
+    Serial.print(quality.meanX, 3);
+    Serial.print(", ");
+    Serial.print(quality.meanY, 3);
+    Serial.print(", ");
+    Serial.print(quality.meanZ, 3);
+    Serial.println(")");
+    Serial.print("XY radius mean=");
+    Serial.print(quality.rMeanXY, 3);
+    Serial.print(" std=");
+    Serial.print(quality.rStdXY, 3);
+    Serial.print(" anisotropy=");
+    Serial.println(quality.anisotropyXY, 3);
+}
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial && millis() < 4000) {
+    }
+
+    internalI2C.begin();
+
+    if (!magnetometer.begin()) {
+        Serial.println("LIS2MDL not detected. Check the internal I2C bus.");
+        while (true) {
+            delay(1000);
+        }
+    }
+
+    magnetometer.setContinuous(50);
+
+    Serial.println("Hard-iron calibration");
+    Serial.println("Rotate the board slowly in every direction until the countdown ends.");
+    for (int second = 5; second > 0; --second) {
+        Serial.print("Starting in ");
+        Serial.println(second);
+        delay(1000);
+    }
+
+    Serial.println("Calibrating for about 12 seconds...");
+    magnetometer.calibrateMinmax3d(600, 20);
+    Serial.println("Done.");
+
+    printCalibration();
+    printQuality();
+
+    Serial.println();
+    Serial.println("TODO steami_config: save these six values in the board configuration zone.");
+    Serial.println(
+        "Paste them into your sketch or persist them once the steami_config API is available.");
+}
+
+void loop() {
+    float heading = magnetometer.headingFlatOnly();
+    MagneticFieldUt field = magnetometer.magneticFieldUt();
+
+    Serial.print("heading=");
+    Serial.print(heading, 1);
+    Serial.print(" deg direction=");
+    Serial.print(magnetometer.directionLabel(heading));
+    Serial.print(" field_uT=(");
+    Serial.print(field.x, 1);
+    Serial.print(", ");
+    Serial.print(field.y, 1);
+    Serial.print(", ");
+    Serial.print(field.z, 1);
+    Serial.println(")");
+
+    delay(500);
+}

--- a/lib/lis2mdl/examples/MagneticCalibration/MagneticCalibration.ino
+++ b/lib/lis2mdl/examples/MagneticCalibration/MagneticCalibration.ino
@@ -27,7 +27,7 @@ static void printCalibration() {
 }
 
 static void printQuality() {
-    CalibrationQuality quality = magnetometer.calibrateQuality(200, 10);
+    CalibrationQuality quality = magnetometer.calibrateQuality(200, 20);
     Serial.println("Calibration quality:");
     Serial.print("center=(");
     Serial.print(quality.meanX, 3);

--- a/lib/lis2mdl/examples/MetalDetector/MetalDetector.ino
+++ b/lib/lis2mdl/examples/MetalDetector/MetalDetector.ino
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// MetalDetector.ino
+// Calibrate a local magnetic baseline, then buzz when the field magnitude changes.
+
+#include <Arduino.h>
+#include <LIS2MDL.h>
+#include <Wire.h>
+
+#ifndef SPEAKER
+#define SPEAKER LED_BUILTIN
+#endif
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+LIS2MDL magnetometer(internalI2C);
+
+static float baselineUt = 0.0f;
+static float triggerDeltaUt = 20.0f;
+
+static float averageMagnitude(uint16_t samples, uint16_t delayMs) {
+    float sum = 0.0f;
+    for (uint16_t i = 0; i < samples; ++i) {
+        sum += magnetometer.magnitudeUt();
+        delay(delayMs);
+    }
+    return sum / samples;
+}
+
+static void beep(uint16_t frequency, uint16_t durationMs) {
+#if defined(SPEAKER)
+    tone(SPEAKER, frequency, durationMs);
+#else
+    (void)frequency;
+    (void)durationMs;
+#endif
+}
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial && millis() < 2000) {
+    }
+
+    internalI2C.begin();
+
+    if (!magnetometer.begin()) {
+        Serial.println("LIS2MDL not detected. Check the internal I2C bus.");
+        while (true) {
+            delay(1000);
+        }
+    }
+
+    magnetometer.setContinuous(50);
+
+    Serial.println("Keep the board away from metal while baseline is calibrated...");
+    baselineUt = averageMagnitude(100, 20);
+    triggerDeltaUt = max(15.0f, baselineUt * 0.20f);
+
+    Serial.print("Baseline: ");
+    Serial.print(baselineUt, 2);
+    Serial.print(" uT, trigger delta: ");
+    Serial.print(triggerDeltaUt, 2);
+    Serial.println(" uT");
+}
+
+void loop() {
+    float magnitude = magnetometer.magnitudeUt();
+    float delta = fabs(magnitude - baselineUt);
+    bool detected = delta > triggerDeltaUt;
+
+    Serial.print("Magnitude: ");
+    Serial.print(magnitude, 2);
+    Serial.print(" uT | delta: ");
+    Serial.print(delta, 2);
+    Serial.print(" uT | ");
+    Serial.println(detected ? "METAL NEARBY" : "clear");
+
+    if (detected) {
+        uint16_t pitch = 1000 + static_cast<uint16_t>(min(delta * 15.0f, 2500.0f));
+        beep(pitch, 80);
+    }
+
+    delay(100);
+}

--- a/lib/lis2mdl/examples/MetalDetector/MetalDetector.ino
+++ b/lib/lis2mdl/examples/MetalDetector/MetalDetector.ino
@@ -26,12 +26,7 @@ static float averageMagnitude(uint16_t samples, uint16_t delayMs) {
 }
 
 static void beep(uint16_t frequency, uint16_t durationMs) {
-#if defined(SPEAKER)
     tone(SPEAKER, frequency, durationMs);
-#else
-    (void)frequency;
-    (void)durationMs;
-#endif
 }
 
 void setup() {


### PR DESCRIPTION
## Summary

Closes #198

Add 4 practical standalone Arduino examples for the LIS2MDL magnetometer, covering common real-world use cases such as magnetic field reading, digital compass, metal detection, calibration, and magnetic field logging. Also update the README to document the new examples.

## Changes

* Add `BasicReader` example to read magnetic field (X/Y/Z) and temperature.
* Add `DigitalCompass` example with 2D calibration, heading computation, and cardinal direction display.
* Add `MetalDetector` example based on magnetic field magnitude.
* Add `MagneticCalibration` example demonstrating hard-iron calibration.
* Update the README examples section with descriptions of all new examples.

## Checklist

* [x] `make lint` passes (clang-format)
* [x] `make build` passes (PlatformIO)
* [ ] `make test-native` passes (if native tests exist)
* [ ] `make test-hardware` passes on a connected STeaMi (if hardware tests exist)
* [x] README updated (if adding/changing public API)
* [x] Examples added/updated (if applicable)
* [x] Commit messages follow conventional commits format