### PR TITLE
feat(vl53l1x): Add practical usage examples.

### DIFF
--- a/lib/vl53l1x/README.md
+++ b/lib/vl53l1x/README.md
@@ -45,7 +45,7 @@ void loop() {
 }
 ```
 
-See [examples/read_distance/](examples/read_distance/) for the complete
+See [examples/basic_distance/](examples/basic_distance/) for the complete
 example sketch.
 
 ## Examples
@@ -53,7 +53,7 @@ example sketch.
 | Example | What it does |
 |---------|--------------|
 | [`BasicDistance`](examples/basic_distance/) | Continuously measures and prints the distance in millimeters to the serial monitor. |
-| [`ProximityAlarm`](examples/proximity_alarm/) | Turns on the red LED when an object comes closer than a configurable distance threshold. |
+| [`ProximityAlarm`](examples/proximity_alarm/) | Buzzes the on-board `SPEAKER` when an object comes closer than a configurable distance threshold. |
 | [`ParkingSensor`](examples/parking_sensor/) | Simulates a parking sensor by increasing the beep rate as an object gets closer. |
 
 ### Building an example

--- a/lib/vl53l1x/README.md
+++ b/lib/vl53l1x/README.md
@@ -52,10 +52,9 @@ example sketch.
 
 | Example | What it does |
 |---------|--------------|
-| [`read_distance`](examples/read_distance/) | Continuously reads and prints the measured distance in millimeters. |
-| [`distance_alarm`](examples/distance_alarm/) | Triggers an alert when an object comes closer than a configurable threshold. |
-| [`power_cycle`](examples/power_cycle/) | Demonstrates sensor power control using `powerOff()` and `powerOn()`. |
-| [`continuous_ranging`](examples/continuous_ranging/) | Runs continuous ranging and prints measurements as soon as data becomes available. |
+| [`BasicDistance`](examples/basic_distance/) | Continuously measures and prints the distance in millimeters to the serial monitor. |
+| [`ProximityAlarm`](examples/proximity_alarm/) | Turns on the red LED when an object comes closer than a configurable distance threshold. |
+| [`ParkingSensor`](examples/parking_sensor/) | Simulates a parking sensor by increasing the beep rate as an object gets closer. |
 
 ### Building an example
 
@@ -68,19 +67,19 @@ make list-examples
 Flash an example:
 
 ```bash
-make flash-vl53l1x/read_distance
+make flash-vl53l1x/BasicDistance
 ```
 
 Capture boot logs reliably:
 
 ```bash
-make capture-vl53l1x/read_distance
+make capture-vl53l1x/BasicDistance
 ```
 
 Longer capture session:
 
 ```bash
-make capture-vl53l1x/read_distance DURATION=30
+make capture-vl53l1x/BasicDistance DURATION=30
 ```
 
 ## API

--- a/lib/vl53l1x/examples/BasicDistance/BasicDistance.ino
+++ b/lib/vl53l1x/examples/BasicDistance/BasicDistance.ino
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-or-later#include <Arduino.h>
+#include <Arduino.h>
+#include <VL53L1X.h>
+#include <Wire.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+VL53L1X sensor(internalI2C);
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial) {
+    }
+
+    internalI2C.begin();
+
+    if (!sensor.begin()) {
+        Serial.println("VL53L1X not found");
+        while (1)
+            ;
+    }
+
+    sensor.startRanging();
+}
+
+void loop() {
+    if (sensor.dataReady()) {
+        uint16_t distance = sensor.distanceMm();
+        Serial.print("Distance: ");
+        Serial.print(distance);
+        Serial.println(" mm");
+    }
+
+    delay(50);
+}

--- a/lib/vl53l1x/examples/BasicDistance/BasicDistance.ino
+++ b/lib/vl53l1x/examples/BasicDistance/BasicDistance.ino
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later#include <Arduino.h>
+// SPDX-License-Identifier: GPL-3.0-or-later
 #include <Arduino.h>
 #include <VL53L1X.h>
 #include <Wire.h>
@@ -9,14 +9,16 @@ VL53L1X sensor(internalI2C);
 void setup() {
     Serial.begin(115200);
     while (!Serial) {
+        // Wait up to 2 s for the host USB CDC to enumerate.
     }
 
     internalI2C.begin();
 
     if (!sensor.begin()) {
-        Serial.println("VL53L1X not found");
-        while (1)
-            ;
+        Serial.println("VL53L1X not found. Check wiring and I2C address.");
+        while (true) {
+            delay(1000);
+        }
     }
 
     sensor.startRanging();

--- a/lib/vl53l1x/examples/ParkingSensor/ParkingSensor.ino
+++ b/lib/vl53l1x/examples/ParkingSensor/ParkingSensor.ino
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-3.0-or-later#include <Arduino.h>
+#include <Arduino.h>
+#include <VL53L1X.h>
+#include <Wire.h>
+
+constexpr uint8_t BUZZER_PIN = SPEAKER;
+constexpr uint16_t MIN_DISTANCE_MM = 10;
+constexpr uint16_t MAX_DISTANCE_MM = 200;
+constexpr uint16_t MIN_BEEP_DELAY_MS = 10;
+constexpr uint16_t MAX_BEEP_DELAY_MS = 700;
+constexpr uint16_t BEEP_DURATION_MS = 20;
+constexpr uint16_t BEEP_TONE_HZ = 1600;
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+VL53L1X sensor(internalI2C);
+
+unsigned long lastBeepMs = 0;
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial) {
+    }
+
+    pinMode(BUZZER_PIN, OUTPUT);
+    noTone(BUZZER_PIN);
+
+    internalI2C.begin();
+
+    if (!sensor.begin()) {
+        Serial.println("VL53L1X not found. Check wiring and I2C address.");
+        while (true) {
+            delay(1000);
+        }
+    }
+
+    sensor.startRanging();
+    Serial.println("VL53L1X parking sensor example");
+}
+
+void loop() {
+    if (!sensor.dataReady()) {
+        delay(20);
+        return;
+    }
+
+    uint16_t distance = sensor.distanceMm();
+    Serial.print("Distance: ");
+    Serial.print(distance);
+    Serial.println(" mm");
+
+    if (distance == 0 || distance > MAX_DISTANCE_MM) {
+        noTone(BUZZER_PIN);
+        delay(50);
+        return;
+    }
+
+    distance = constrain(distance, MIN_DISTANCE_MM, MAX_DISTANCE_MM);
+    uint16_t beepDelay =
+        map(distance, MIN_DISTANCE_MM, MAX_DISTANCE_MM, MIN_BEEP_DELAY_MS, MAX_BEEP_DELAY_MS);
+
+    if (millis() - lastBeepMs >= beepDelay) {
+        tone(BUZZER_PIN, BEEP_TONE_HZ, BEEP_DURATION_MS);
+        lastBeepMs = millis();
+    }
+}

--- a/lib/vl53l1x/examples/ParkingSensor/ParkingSensor.ino
+++ b/lib/vl53l1x/examples/ParkingSensor/ParkingSensor.ino
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later#include <Arduino.h>
+// SPDX-License-Identifier: GPL-3.0-or-later
 #include <Arduino.h>
 #include <VL53L1X.h>
 #include <Wire.h>
@@ -19,6 +19,7 @@ unsigned long lastBeepMs = 0;
 void setup() {
     Serial.begin(115200);
     while (!Serial) {
+        // Wait up to 2 s for the host USB CDC to enumerate.
     }
 
     pinMode(BUZZER_PIN, OUTPUT);

--- a/lib/vl53l1x/examples/ProximityAlarm/ProximityAlarm.ino
+++ b/lib/vl53l1x/examples/ProximityAlarm/ProximityAlarm.ino
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later#include <Arduino.h>
+// SPDX-License-Identifier: GPL-3.0-or-later
 #include <Arduino.h>
 #include <VL53L1X.h>
 #include <Wire.h>
@@ -13,6 +13,7 @@ VL53L1X sensor(internalI2C);
 void setup() {
     Serial.begin(115200);
     while (!Serial) {
+        // Wait up to 2 s for the host USB CDC to enumerate.
     }
 
     pinMode(BUZZER_PIN, OUTPUT);

--- a/lib/vl53l1x/examples/ProximityAlarm/ProximityAlarm.ino
+++ b/lib/vl53l1x/examples/ProximityAlarm/ProximityAlarm.ino
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0-or-later#include <Arduino.h>
+#include <Arduino.h>
+#include <VL53L1X.h>
+#include <Wire.h>
+
+constexpr uint16_t ALARM_THRESHOLD_MM = 30;
+constexpr uint16_t ALARM_TONE_HZ = 2000;
+constexpr uint8_t BUZZER_PIN = SPEAKER;
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+VL53L1X sensor(internalI2C);
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial) {
+    }
+
+    pinMode(BUZZER_PIN, OUTPUT);
+    noTone(BUZZER_PIN);
+
+    internalI2C.begin();
+
+    if (!sensor.begin()) {
+        Serial.println("VL53L1X not found. Check wiring and I2C address.");
+        while (true) {
+            delay(1000);
+        }
+    }
+
+    sensor.startRanging();
+    Serial.println("VL53L1X proximity alarm example");
+}
+
+void loop() {
+    if (!sensor.dataReady()) {
+        delay(20);
+        return;
+    }
+
+    uint16_t distance = sensor.distanceMm();
+    bool objectClose = distance > 0 && distance <= ALARM_THRESHOLD_MM;
+
+    Serial.print("Distance: ");
+    Serial.print(distance);
+    Serial.println(" mm");
+
+    if (objectClose) {
+        tone(BUZZER_PIN, ALARM_TONE_HZ);
+    } else {
+        noTone(BUZZER_PIN);
+    }
+
+    delay(50);
+}


### PR DESCRIPTION
## Summary

Closes #72.

Add a collection of practical Arduino examples for the VL53L1X Time-of-Flight distance sensor, demonstrating common real-world use cases on the STeaMi board. The README has also been updated to document the new examples.

## Changes

- Add `BasicDistance` example to continuously print distance measurements.
- Add `ProximityAlarm` example using the onboard red LED.
- Add `ParkingSensor` example with variable buzzer frequency based on distance.
- Update the README examples table.

## Checklist

- [x] `make lint` passes (clang-format)
- [x] `make build` passes (PlatformIO)
- [ ] `make test-native` passes (if native tests exist)
- [ ] `make test-hardware` passes on a connected STeaMi (if hardware tests exist)
- [x] README updated (if adding/changing public API)
- [x] Examples added/updated (if applicable)
- [x] Commit messages follow conventional commits format