### PR TITLE
examples(ism330dl): Add practical usage examples

### DIFF
--- a/lib/ism330dl/examples/BasicReader/BasicReader.ino
+++ b/lib/ism330dl/examples/BasicReader/BasicReader.ino
@@ -8,6 +8,10 @@ ISM330DL imu(internalI2C);
 
 void setup() {
     Serial.begin(115200);
+    while (!Serial && millis() < 2000) {
+        // Wait up to 2 s for a connected monitor — on the STeaMi USB CDC
+        // !Serial stays true until the host enumerates.
+    }
 
     internalI2C.begin();
 

--- a/lib/ism330dl/examples/BasicReader/BasicReader.ino
+++ b/lib/ism330dl/examples/BasicReader/BasicReader.ino
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <ISM330DL.h>
+#include <Wire.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+ISM330DL imu(internalI2C);
+
+void setup() {
+    Serial.begin(115200);
+
+    internalI2C.begin();
+
+    if (!imu.begin()) {
+        Serial.println("ISM330DL not detected.");
+        while (true) {
+            delay(1000);
+        }
+    }
+
+    Serial.println("ISM330DL ready.");
+}
+
+void loop() {
+    ISM330DL::Vector3 accel;
+    ISM330DL::Vector3 gyro;
+    float temperature;
+
+    if (imu.accelerationG(accel) && imu.gyroscopeDps(gyro) && imu.temperature(temperature)) {
+        Serial.println("Acceleration (g)");
+        Serial.print("X: ");
+        Serial.println(accel.x, 3);
+        Serial.print("Y: ");
+        Serial.println(accel.y, 3);
+        Serial.print("Z: ");
+        Serial.println(accel.z, 3);
+
+        Serial.println();
+
+        Serial.println("Gyroscope (dps)");
+        Serial.print("X: ");
+        Serial.println(gyro.x, 2);
+        Serial.print("Y: ");
+        Serial.println(gyro.y, 2);
+        Serial.print("Z: ");
+        Serial.println(gyro.z, 2);
+
+        Serial.println();
+
+        Serial.print("Temperature: ");
+        Serial.print(temperature, 1);
+        Serial.println(" °C");
+
+        Serial.println();
+    }
+
+    delay(300);
+}

--- a/lib/ism330dl/examples/Motion/Motion.ino
+++ b/lib/ism330dl/examples/Motion/Motion.ino
@@ -9,6 +9,10 @@ ISM330DL::MotionType lastMotion = ISM330DL::MotionType::STABLE;
 
 void setup() {
     Serial.begin(115200);
+    while (!Serial && millis() < 2000) {
+        // Wait up to 2 s for a connected monitor — on the STeaMi USB CDC
+        // !Serial stays true until the host enumerates.
+    }
 
     internalI2C.begin();
 

--- a/lib/ism330dl/examples/Motion/Motion.ino
+++ b/lib/ism330dl/examples/Motion/Motion.ino
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include <ISM330DL.h>
+#include <Wire.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+ISM330DL imu(internalI2C);
+
+ISM330DL::MotionType lastMotion = ISM330DL::MotionType::STABLE;
+
+void setup() {
+    Serial.begin(115200);
+
+    internalI2C.begin();
+
+    if (!imu.begin()) {
+        Serial.println("ISM330DL not detected.");
+        while (true) {
+            delay(1000);
+        }
+    }
+
+    Serial.println("Move the board...");
+}
+
+void loop() {
+    ISM330DL::Motion motion;
+
+    if (imu.motion(motion) && motion.type != lastMotion) {
+        lastMotion = motion.type;
+
+        Serial.print("Motion: ");
+        Serial.print(ISM330DL::motionToString(motion.type));
+
+        if (motion.type != ISM330DL::MotionType::STABLE) {
+            Serial.print(" (");
+            Serial.print(motion.value, 1);
+            Serial.print(" dps)");
+        }
+
+        Serial.println();
+    }
+
+    delay(100);
+}

--- a/lib/ism330dl/examples/Orientation/Orientation.ino
+++ b/lib/ism330dl/examples/Orientation/Orientation.ino
@@ -9,6 +9,10 @@ ISM330DL::Orientation lastOrientation = ISM330DL::Orientation::MOVING;
 
 void setup() {
     Serial.begin(115200);
+    while (!Serial && millis() < 2000) {
+        // Wait up to 2 s for a connected monitor — on the STeaMi USB CDC
+        // !Serial stays true until the host enumerates.
+    }
 
     internalI2C.begin();
 

--- a/lib/ism330dl/examples/Orientation/Orientation.ino
+++ b/lib/ism330dl/examples/Orientation/Orientation.ino
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include <ISM330DL.h>
+#include <Wire.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+ISM330DL imu(internalI2C);
+
+ISM330DL::Orientation lastOrientation = ISM330DL::Orientation::MOVING;
+
+void setup() {
+    Serial.begin(115200);
+
+    internalI2C.begin();
+
+    if (!imu.begin()) {
+        Serial.println("ISM330DL not detected.");
+        while (true) {
+            delay(1000);
+        }
+    }
+
+    Serial.println("Rotate the board...");
+}
+
+void loop() {
+    ISM330DL::Orientation orientation;
+
+    if (imu.orientation(orientation) && orientation != lastOrientation) {
+        lastOrientation = orientation;
+
+        Serial.print("Orientation: ");
+        Serial.println(ISM330DL::orientationToString(orientation));
+    }
+
+    delay(300);
+}


### PR DESCRIPTION
## Summary

Adds practical Arduino examples demonstrating the main features of the ISM330DL accelerometer and gyroscope driver.

The examples are based on the reference MicroPython implementations and adapted to the Arduino API and STeaMi internal I2C bus.

This PR depends on #199 and must be merged after the ISM330DL driver implementation.

Closes #75
Depends on #199

Opens #200 : to build cross drivers examples

## Changes

* Add `BasicReader` example to print:

  * acceleration on the X, Y, and Z axes in g;
  * angular velocity on the X, Y, and Z axes in dps;
  * sensor temperature in °C.
* Add `orientation` example to detect the static orientation of the STeaMi board using the accelerometer.
* Add `motion` example to classify rotations and tilting movements using the gyroscope.
* Use the STeaMi internal I2C bus through `I2C_INT_SDA` and `I2C_INT_SCL`.
* Add sensor initialization and error handling to each example.
* Avoid repeated serial output by printing orientation and motion only when their detected state changes.
* Update the ISM330DL README example table.

The examples requiring other STeaMi drivers, such as the OLED display, buzzer, LEDs, or DAPLink flash, are tracked separately as cross-driver examples.

## Checklist

* [x] `make lint` passes (clang-format)
* [x] `make build` passes (PlatformIO)
* [ ] `make test-native` passes (if native tests exist)
* [ ] `make test-hardware` passes on a connected STeaMi (if hardware tests exist)
* [x] README updated (if adding/changing public API)
* [x] Examples added/updated (if applicable)
* [x] Commit messages follow conventional commits format
