### PR TITLE
examples(apds9960): Add practical usage examples

### DIFF
--- a/lib/apds9960/examples/ambient_light/ambient_light.ino
+++ b/lib/apds9960/examples/ambient_light/ambient_light.ino
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// AmbientLight — read APDS9960 clear and RGB channels.
+//
+// Open the serial monitor at 115200 baud.
+
+#include <APDS9960.h>
+#include <Wire.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+APDS9960 sensor(internalI2C);
+
+static const uint32_t PRINT_PERIOD_MS = 250;
+uint32_t lastPrintMs = 0;
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial && millis() < 2000)
+        ;
+
+    internalI2C.begin();
+
+    if (!sensor.begin()) {
+        Serial.println("APDS9960 not detected.");
+        while (true)
+            delay(1000);
+    }
+
+    sensor.enableLightSensor(false);
+
+    Serial.println("=======================");
+    Serial.println(" Ambient light and RGB ");
+    Serial.println("=======================");
+}
+
+void loop() {
+    uint32_t now = millis();
+    if (now - lastPrintMs < PRINT_PERIOD_MS)
+        return;
+
+    lastPrintMs = now;
+
+    uint16_t clear = 0;
+    uint16_t red = 0;
+    uint16_t green = 0;
+    uint16_t blue = 0;
+
+    bool ok = sensor.ambientLight(clear) && sensor.redLight(red) && sensor.greenLight(green) &&
+              sensor.blueLight(blue);
+
+    if (!ok) {
+        Serial.println("Light read failed.");
+        return;
+    }
+
+    Serial.print("C=");
+    Serial.print(clear);
+    Serial.print(" | R=");
+    Serial.print(red);
+    Serial.print(" | G=");
+    Serial.print(green);
+    Serial.print(" | B=");
+    Serial.println(blue);
+}

--- a/lib/apds9960/examples/ambient_light/ambient_light.ino
+++ b/lib/apds9960/examples/ambient_light/ambient_light.ino
@@ -35,8 +35,11 @@ void setup() {
 
 void loop() {
     uint32_t now = millis();
-    if (now - lastPrintMs < PRINT_PERIOD_MS)
+    uint32_t elapsed = now - lastPrintMs;
+    if (elapsed < PRINT_PERIOD_MS) {
+        delay(PRINT_PERIOD_MS - elapsed);
         return;
+    }
 
     lastPrintMs = now;
 

--- a/lib/apds9960/examples/gesture/gesture.ino
+++ b/lib/apds9960/examples/gesture/gesture.ino
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Gesture — detect directional gestures with the APDS9960.
+//
+// Swipe a hand over the sensor.
+// Open the serial monitor at 115200 baud.
+
+#include <APDS9960.h>
+#include <Wire.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+APDS9960 sensor(internalI2C);
+
+const char* gestureName(APDS9960::Gesture gesture) {
+    switch (gesture) {
+        case APDS9960::Gesture::LEFT:
+            return "LEFT";
+        case APDS9960::Gesture::RIGHT:
+            return "RIGHT";
+        case APDS9960::Gesture::UP:
+            return "UP";
+        case APDS9960::Gesture::DOWN:
+            return "DOWN";
+        case APDS9960::Gesture::NEAR:
+            return "NEAR";
+        case APDS9960::Gesture::FAR:
+            return "FAR";
+        default:
+            return "NONE";
+    }
+}
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial && millis() < 2000)
+        ;
+
+    internalI2C.begin();
+
+    if (!sensor.begin()) {
+        Serial.println("APDS9960 not detected.");
+        while (true)
+            delay(1000);
+    }
+
+    sensor.enableGestureSensor(false);
+
+    Serial.println("=======================");
+    Serial.println("    Gesture detector   ");
+    Serial.println("=======================");
+    Serial.println("Swipe over the sensor.");
+}
+
+void loop() {
+    if (!sensor.gestureAvailable()) {
+        delay(10);
+        return;
+    }
+
+    APDS9960::Gesture gesture = sensor.readGesture();
+
+    // Ignore FIFO activity that does not decode into a valid gesture.
+    if (gesture == APDS9960::Gesture::NONE)
+        return;
+
+    Serial.print("Gesture: ");
+    Serial.println(gestureName(gesture));
+}

--- a/lib/apds9960/examples/light_theremin/light_theremin.ino
+++ b/lib/apds9960/examples/light_theremin/light_theremin.ino
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// LightTheremin — control the STeaMi buzzer pitch with ambient light.
+//
+// The clear-light channel is mapped to a pentatonic scale.
+// Cover the sensor to mute the buzzer.
+//
+// Open the serial monitor at 115200 baud.
+
+#include <APDS9960.h>
+#include <Wire.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+APDS9960 sensor(internalI2C);
+
+static const int BUZZER_PIN = SPEAKER;
+
+static const uint16_t MIN_LIGHT = 45;
+static const uint16_t MAX_LIGHT = 570;
+static const uint32_t SAMPLE_PERIOD_MS = 20;
+static const uint32_t PRINT_PERIOD_MS = 200;
+
+static const uint16_t PENTATONIC_NOTES[] = {
+    131, 147, 165, 196, 220, 262, 294, 330, 392, 440, 523, 587, 659, 784, 880,
+};
+
+static const size_t NOTE_COUNT = sizeof(PENTATONIC_NOTES) / sizeof(PENTATONIC_NOTES[0]);
+
+uint32_t lastSampleMs = 0;
+uint32_t lastPrintMs = 0;
+uint16_t activeFrequency = 0;
+
+uint16_t clampLight(uint16_t value) {
+    if (value < MIN_LIGHT)
+        return MIN_LIGHT;
+    if (value > MAX_LIGHT)
+        return MAX_LIGHT;
+    return value;
+}
+
+uint16_t lightToFrequency(uint16_t light) {
+    if (light < MIN_LIGHT)
+        return 0;
+
+    uint16_t clamped = clampLight(light);
+    uint32_t range = MAX_LIGHT > MIN_LIGHT ? MAX_LIGHT - MIN_LIGHT : 1;
+
+    size_t index = static_cast<size_t>(
+        (static_cast<uint32_t>(clamped - MIN_LIGHT) * (NOTE_COUNT - 1)) / range);
+
+    return PENTATONIC_NOTES[index];
+}
+
+void setBuzzerFrequency(uint16_t frequency) {
+    if (frequency == activeFrequency)
+        return;
+
+    activeFrequency = frequency;
+
+    if (frequency == 0) {
+        noTone(BUZZER_PIN);
+    } else {
+        tone(BUZZER_PIN, frequency);
+    }
+}
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial && millis() < 2000)
+        ;
+
+    pinMode(BUZZER_PIN, OUTPUT);
+    internalI2C.begin();
+
+    if (!sensor.begin()) {
+        Serial.println("APDS9960 not detected.");
+        while (true)
+            delay(1000);
+    }
+
+    sensor.enableLightSensor(false);
+
+    Serial.println("=======================");
+    Serial.println("    Light theremin     ");
+    Serial.println("=======================");
+    Serial.println("Move your hand over the sensor.");
+    Serial.println("Cover it completely to mute.");
+}
+
+void loop() {
+    uint32_t now = millis();
+    if (now - lastSampleMs < SAMPLE_PERIOD_MS)
+        return;
+
+    lastSampleMs = now;
+
+    uint16_t light = 0;
+    if (!sensor.ambientLight(light)) {
+        setBuzzerFrequency(0);
+        return;
+    }
+
+    uint16_t frequency = lightToFrequency(light);
+    setBuzzerFrequency(frequency);
+
+    if (now - lastPrintMs >= PRINT_PERIOD_MS) {
+        lastPrintMs = now;
+
+        Serial.print("Light=");
+        Serial.print(light);
+        Serial.print(" | ");
+
+        if (frequency == 0) {
+            Serial.println("Muted");
+        } else {
+            Serial.print("Frequency=");
+            Serial.print(frequency);
+            Serial.println(" Hz");
+        }
+    }
+}

--- a/lib/apds9960/examples/light_theremin/light_theremin.ino
+++ b/lib/apds9960/examples/light_theremin/light_theremin.ino
@@ -89,8 +89,11 @@ void setup() {
 
 void loop() {
     uint32_t now = millis();
-    if (now - lastSampleMs < SAMPLE_PERIOD_MS)
+    uint32_t elapsed = now - lastSampleMs;
+    if (elapsed < SAMPLE_PERIOD_MS) {
+        delay(SAMPLE_PERIOD_MS - elapsed);
         return;
+    }
 
     lastSampleMs = now;
 

--- a/lib/apds9960/examples/proximity/proximity.ino
+++ b/lib/apds9960/examples/proximity/proximity.ino
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Proximity — detect nearby objects with the APDS9960.
+//
+// Open the serial monitor at 115200 baud.
+
+#include <APDS9960.h>
+#include <Wire.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+APDS9960 sensor(internalI2C);
+
+static const uint8_t NEAR_THRESHOLD = 80;
+static const uint32_t PRINT_PERIOD_MS = 100;
+
+uint32_t lastPrintMs = 0;
+bool wasNear = false;
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial && millis() < 2000)
+        ;
+
+    internalI2C.begin();
+
+    if (!sensor.begin()) {
+        Serial.println("APDS9960 not detected.");
+        while (true)
+            delay(1000);
+    }
+
+    // Conservative settings to avoid saturating the proximity channel.
+    sensor.setLedDrive(APDS9960::LedDrive::MA_25);
+    sensor.setLedBoost(APDS9960::LedBoost::PERCENT_100);
+    sensor.setProximityGain(APDS9960::ProximityGain::X1);
+    sensor.enableProximitySensor(false);
+
+    Serial.println("=======================");
+    Serial.println("   Proximity detector  ");
+    Serial.println("=======================");
+    Serial.print("Near threshold: ");
+    Serial.println(NEAR_THRESHOLD);
+}
+
+void loop() {
+    uint32_t now = millis();
+    if (now - lastPrintMs < PRINT_PERIOD_MS)
+        return;
+
+    lastPrintMs = now;
+
+    uint8_t proximity = 0;
+    if (!sensor.proximity(proximity)) {
+        Serial.println("Proximity read failed.");
+        return;
+    }
+
+    bool isNear = proximity >= NEAR_THRESHOLD;
+
+    Serial.print("Proximity=");
+    Serial.print(proximity);
+    Serial.print(" | ");
+    Serial.println(isNear ? "OBJECT NEAR" : "clear");
+
+    if (isNear != wasNear) {
+        wasNear = isNear;
+        digitalWrite(LED_BUILTIN, isNear ? HIGH : LOW);
+    }
+}

--- a/lib/apds9960/examples/proximity/proximity.ino
+++ b/lib/apds9960/examples/proximity/proximity.ino
@@ -21,6 +21,9 @@ void setup() {
     while (!Serial && millis() < 2000)
         ;
 
+    pinMode(LED_BUILTIN, OUTPUT);
+    digitalWrite(LED_BUILTIN, LOW);
+
     internalI2C.begin();
 
     if (!sensor.begin()) {
@@ -44,8 +47,12 @@ void setup() {
 
 void loop() {
     uint32_t now = millis();
-    if (now - lastPrintMs < PRINT_PERIOD_MS)
+
+    uint32_t elapsed = now - lastPrintMs;
+    if (elapsed < PRINT_PERIOD_MS) {
+        delay(PRINT_PERIOD_MS - elapsed);
         return;
+    }
 
     lastPrintMs = now;
 


### PR DESCRIPTION
# examples(apds9960): Add practical usage examples

## Summary

<!-- What does this PR do? Reference the issue: Closes #XXX -->

Closes #76
Depends on #203 
Opens #206

This PR adds a set of practical Arduino examples demonstrating the main capabilities of the APDS9960 driver on the STeaMi board.

The examples cover ambient light sensing, proximity detection, gesture recognition and an interactive light-controlled theremin. The proposed cross-driver example combining the APDS9960 with other peripherals has been deferred to a dedicated issue.

## Changes

<!-- List the main changes -->

* Add `ambient_light` example demonstrating ambient light and RGB measurements
* Add `proximity` example for infrared proximity sensing
* Add `gesture` example for gesture recognition (up, down, left, right, near and far)
* Add `light_theremin` example using ambient light to control the on-board buzzer frequency
* Document all examples in the driver README
* Defer the proposed cross-driver logging example to a dedicated tracking issue

## Checklist

* [x] `make lint` passes (clang-format)
* [x] `make build` passes (PlatformIO)
* [ ] `make test-native` passes (if native tests exist)
* [ ] `make test-hardware` passes on a connected STeaMi (if hardware tests exist)
* [x] README updated (if adding/changing public API)
* [x] Examples added/updated (if applicable)
* [x] Commit messages follow conventional commits format
