### PR TITLE
test(wsen-pads): Add hardware and integration tests.

### DIFF
--- a/tests/hardware/test_wsen_pads/test_main.cpp
+++ b/tests/hardware/test_wsen_pads/test_main.cpp
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <Arduino.h>
+#include <Wire.h>
+#include <math.h>
+#include <unity.h>
+
+#include "WSEN_PADS.h"
+#include "WSEN_PADS_const.h"
+#include "driver_checks.h"
+
+namespace {
+
+constexpr uint32_t DATA_READY_TIMEOUT_MS = 2000;
+
+// Physical operating ranges of the WSEN-PADS.
+constexpr float MIN_PRESSURE_HPA = 260.0f;
+constexpr float MAX_PRESSURE_HPA = 1260.0f;
+constexpr float MIN_TEMPERATURE_C = -40.0f;
+constexpr float MAX_TEMPERATURE_C = 85.0f;
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+WSEN_PADS sensor(internalI2C);
+
+bool waitForDataReady(uint32_t timeoutMs = DATA_READY_TIMEOUT_MS) {
+    const uint32_t start = millis();
+
+    while ((millis() - start) < timeoutMs) {
+        if (sensor.dataReady()) {
+            return true;
+        }
+        delay(10);
+    }
+
+    return false;
+}
+
+void assertPlausibleReading(const WSEN_PADS::ReadResult& reading) {
+    TEST_ASSERT_FALSE_MESSAGE(isnan(reading.pressure), "Pressure reading is NaN");
+    TEST_ASSERT_FALSE_MESSAGE(isnan(reading.temperature), "Temperature reading is NaN");
+
+    TEST_ASSERT_GREATER_OR_EQUAL_FLOAT_MESSAGE(MIN_PRESSURE_HPA, reading.pressure,
+                                               "Pressure is below the sensor operating range");
+    TEST_ASSERT_LESS_OR_EQUAL_FLOAT_MESSAGE(MAX_PRESSURE_HPA, reading.pressure,
+                                            "Pressure is above the sensor operating range");
+
+    TEST_ASSERT_GREATER_OR_EQUAL_FLOAT_MESSAGE(MIN_TEMPERATURE_C, reading.temperature,
+                                               "Temperature is below the sensor operating range");
+    TEST_ASSERT_LESS_OR_EQUAL_FLOAT_MESSAGE(MAX_TEMPERATURE_C, reading.temperature,
+                                            "Temperature is above the sensor operating range");
+}
+
+}  // namespace
+
+void setUp(void) {
+    sensor.begin();
+}
+
+void tearDown(void) {
+    sensor.powerOff();
+}
+
+void test_wsen_pads_begin() {
+    check_begin(sensor);
+}
+
+void test_wsen_pads_device_id() {
+    check_who_am_i(sensor, WSEN_PADS_DEVICE_ID);
+}
+
+void test_wsen_pads_read_plausible_measurements() {
+    sensor.powerOn();
+
+    TEST_ASSERT_TRUE_MESSAGE(waitForDataReady(), "Timed out waiting for WSEN-PADS data");
+
+    const WSEN_PADS::ReadResult reading = sensor.read();
+    assertPlausibleReading(reading);
+}
+
+void test_wsen_pads_power_cycle() {
+    sensor.powerOn();
+
+    TEST_ASSERT_TRUE_MESSAGE(waitForDataReady(), "No measurement available before power-off");
+    assertPlausibleReading(sensor.read());
+
+    sensor.powerOff();
+    delay(100);
+
+    sensor.powerOn();
+
+    TEST_ASSERT_TRUE_MESSAGE(waitForDataReady(), "No measurement available after power-on");
+    assertPlausibleReading(sensor.read());
+}
+
+void setup() {
+    delay(2000);
+    internalI2C.begin();
+
+    UNITY_BEGIN();
+    RUN_TEST(test_wsen_pads_begin);
+    RUN_TEST(test_wsen_pads_device_id);
+    RUN_TEST(test_wsen_pads_read_plausible_measurements);
+    RUN_TEST(test_wsen_pads_power_cycle);
+    UNITY_END();
+}
+
+void loop() {}

--- a/tests/integration/test_wsen_pads/test_main.cpp
+++ b/tests/integration/test_wsen_pads/test_main.cpp
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <Arduino.h>
+#include <Wire.h>
+#include <unity.h>
+
+#include "WSEN_PADS.h"
+#include "WSEN_PADS_const.h"
+
+namespace {
+
+constexpr uint32_t DATA_READY_TIMEOUT_MS = 2000;
+constexpr uint8_t SAMPLE_COUNT = 10;
+
+// WSEN-PADS operating ranges from the component specification.
+constexpr float MIN_PRESSURE_HPA = 260.0f;
+constexpr float MAX_PRESSURE_HPA = 1260.0f;
+constexpr float MIN_TEMPERATURE_C = -40.0f;
+constexpr float MAX_TEMPERATURE_C = 85.0f;
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+WSEN_PADS sensor(internalI2C);
+
+bool waitForDataReady(uint32_t timeoutMs = DATA_READY_TIMEOUT_MS) {
+    const uint32_t start = millis();
+
+    while ((millis() - start) < timeoutMs) {
+        if (sensor.dataReady()) {
+            return true;
+        }
+        delay(10);
+    }
+
+    return false;
+}
+
+void assertPlausible(const WSEN_PADS::ReadResult& reading) {
+    TEST_ASSERT_FALSE_MESSAGE(isnan(reading.pressure), "Pressure reading is NaN");
+    TEST_ASSERT_FALSE_MESSAGE(isnan(reading.temperature), "Temperature reading is NaN");
+
+    TEST_ASSERT_FLOAT_WITHIN_MESSAGE((MAX_PRESSURE_HPA - MIN_PRESSURE_HPA) / 2.0f,
+                                     (MAX_PRESSURE_HPA + MIN_PRESSURE_HPA) / 2.0f, reading.pressure,
+                                     "Pressure is outside the WSEN-PADS operating range");
+
+    TEST_ASSERT_FLOAT_WITHIN_MESSAGE((MAX_TEMPERATURE_C - MIN_TEMPERATURE_C) / 2.0f,
+                                     (MAX_TEMPERATURE_C + MIN_TEMPERATURE_C) / 2.0f,
+                                     reading.temperature,
+                                     "Temperature is outside the WSEN-PADS operating range");
+}
+
+}  // namespace
+
+void setUp(void) {
+    sensor.powerOff();
+    delay(20);
+}
+
+void tearDown(void) {
+    sensor.powerOff();
+}
+
+void test_device_detection_and_id(void) {
+    TEST_ASSERT_TRUE_MESSAGE(sensor.begin(), "WSEN-PADS was not detected on the internal I2C bus");
+    TEST_ASSERT_EQUAL_HEX8_MESSAGE(WSEN_PADS_DEVICE_ID, sensor.deviceId(),
+                                   "Unexpected WSEN-PADS device ID");
+}
+
+void test_repeated_measurements_are_plausible(void) {
+    TEST_ASSERT_TRUE_MESSAGE(sensor.begin(), "WSEN-PADS initialization failed");
+
+    sensor.setContinuous(ODR_1_HZ);
+
+    for (uint8_t sample = 0; sample < SAMPLE_COUNT; ++sample) {
+        TEST_ASSERT_TRUE_MESSAGE(waitForDataReady(), "Timed out waiting for a WSEN-PADS sample");
+
+        const WSEN_PADS::ReadResult reading = sensor.read();
+        assertPlausible(reading);
+
+        // At 1 Hz, wait before polling for the next acquisition.
+        delay(1000);
+    }
+}
+
+void test_power_off_on_cycle_restores_measurements(void) {
+    TEST_ASSERT_TRUE_MESSAGE(sensor.begin(), "WSEN-PADS initialization failed");
+
+    sensor.powerOn();
+    TEST_ASSERT_TRUE_MESSAGE(waitForDataReady(), "No sample received before power-off");
+    assertPlausible(sensor.read());
+
+    sensor.powerOff();
+    delay(100);
+
+    sensor.powerOn();
+    TEST_ASSERT_TRUE_MESSAGE(waitForDataReady(), "No sample received after power-on");
+    assertPlausible(sensor.read());
+}
+
+void setup() {
+    delay(2000);
+    internalI2C.begin();
+
+    UNITY_BEGIN();
+    RUN_TEST(test_device_detection_and_id);
+    RUN_TEST(test_repeated_measurements_are_plausible);
+    RUN_TEST(test_power_off_on_cycle_restores_measurements);
+    UNITY_END();
+}
+
+void loop() {}


### PR DESCRIPTION

## Summary

Adds hardware and integration test suites for the WSEN-PADS Arduino driver. These tests run on a real STeaMi board to validate the driver's hardware contract and continuous runtime behaviour.

Closes #37.

## Changes

- Add `tests/hardware/test_wsen_pads/test_main.cpp`
- Verify successful device initialization (`begin()`)
- Verify device identification (`WHO_AM_I`)
- Validate real pressure and temperature measurements against plausible operating ranges
- Test `powerOff()` / `powerOn()` cycle recovery
- Add `tests/integration/test_wsen_pads/test_main.cpp`
- Validate repeated acquisitions over time
- Verify measurement plausibility during continuous operation
- Validate sensor stability across multiple samples
- Verify recovery after a power cycle during an integration scenario

## Checklist

- [x] `make lint` passes (clang-format)
- [ ] `make build` passes (PlatformIO)
- [ ] `make test-native` passes (if native tests exist)
- [x] `make test-hardware` passes on a connected STeaMi (if hardware tests exist)
- [ ] README updated (if adding/changing public API)
- [ ] Examples added/updated (if applicable)
- [x] Commit messages follow conventional commits format