### PR TITLE
fix(daplink_bridge): Fix multi-chunk config zone reads.

### DIFF
--- a/lib/daplink_bridge/src/DaplinkBridge.cpp
+++ b/lib/daplink_bridge/src/DaplinkBridge.cpp
@@ -38,11 +38,17 @@ bool DaplinkBridge::clearConfig() {
     if (!waitNotBusy(DAPLINK_BRIDGE_WRITE_TIMEOUT_MS)) {
         return false;
     }
+
     uint8_t cmd = DAPLINK_BRIDGE_CMD_CLEAR_CONFIG;
     writeFrame(&cmd, 1);
+
+    // Match the MicroPython implementation.
+    delay(100);
+
     if (!waitNotBusy(DAPLINK_BRIDGE_CLEAR_TIMEOUT_MS)) {
         return false;
     }
+
     return error() == 0;
 }
 
@@ -59,25 +65,36 @@ bool DaplinkBridge::writeConfig(const uint8_t* data, size_t length, uint16_t off
     uint8_t buf[kHeaderLen + DAPLINK_BRIDGE_MAX_WRITE_CHUNK];
 
     size_t pos = 0;
+
     while (pos < length) {
         if (!waitNotBusy(DAPLINK_BRIDGE_WRITE_TIMEOUT_MS)) {
             return false;
         }
+
         const size_t remaining = length - pos;
+
         const uint8_t chunkLen =
             static_cast<uint8_t>(std::min<size_t>(DAPLINK_BRIDGE_MAX_WRITE_CHUNK, remaining));
+
         const uint16_t curOffset = static_cast<uint16_t>(offset + pos);
+
+        // MicroPython always sends a complete 32-byte frame.
+        memset(buf, 0, sizeof(buf));
 
         buf[0] = DAPLINK_BRIDGE_CMD_WRITE_CONFIG;
         buf[1] = static_cast<uint8_t>((curOffset >> 8) & 0xFF);
         buf[2] = static_cast<uint8_t>(curOffset & 0xFF);
         buf[3] = chunkLen;
+
         memcpy(&buf[kHeaderLen], &data[pos], chunkLen);
 
-        writeFrame(buf, kHeaderLen + chunkLen);
+        // Send the complete fixed-size frame, like MicroPython.
+        writeFrame(buf, sizeof(buf));
+
+        delay(50);
+
         pos += chunkLen;
     }
-
     if (!waitNotBusy(DAPLINK_BRIDGE_WRITE_TIMEOUT_MS)) {
         return false;
     }
@@ -109,16 +126,16 @@ size_t DaplinkBridge::readConfig(uint8_t* result, size_t maxLen) {
         const uint16_t offset = static_cast<uint16_t>(produced);
 
         // READ_CONFIG frame:
-        // [CMD | offsetHi | offsetLo | length]
         _wire->beginTransmission(_address);
         _wire->write(DAPLINK_BRIDGE_CMD_READ_CONFIG);
         _wire->write(static_cast<uint8_t>((offset >> 8) & 0xFF));
         _wire->write(static_cast<uint8_t>(offset & 0xFF));
-        _wire->write(want);
 
-        if (_wire->endTransmission(false) != 0) {
+        if (_wire->endTransmission() != 0) {
             return produced;
         }
+
+        delay(100);
 
         const uint8_t received = _wire->requestFrom(_address, want);
 

--- a/lib/daplink_bridge/src/DaplinkBridge.cpp
+++ b/lib/daplink_bridge/src/DaplinkBridge.cpp
@@ -97,28 +97,60 @@ size_t DaplinkBridge::readConfig(uint8_t* result, size_t maxLen) {
     }
 
     size_t produced = 0;
+
     while (produced < maxLen) {
         if (!waitNotBusy(DAPLINK_BRIDGE_READ_TIMEOUT_MS)) {
             return produced;
         }
 
-        uint8_t chunk[DAPLINK_BRIDGE_MAX_READ_CHUNK];
         const uint8_t want = static_cast<uint8_t>(
             std::min<size_t>(DAPLINK_BRIDGE_MAX_READ_CHUNK, maxLen - produced));
-        readBlock(DAPLINK_BRIDGE_CMD_READ_CONFIG, chunk, want);
 
-        for (uint8_t i = 0; i < want; ++i) {
-            // 0xFF marks the first unused byte in the config zone — treat
-            // it as end-of-string and stop returning data to the caller.
-            if (chunk[i] == 0xFF) {
+        const uint16_t offset = static_cast<uint16_t>(produced);
+
+        // READ_CONFIG frame:
+        // [CMD | offsetHi | offsetLo | length]
+        _wire->beginTransmission(_address);
+        _wire->write(DAPLINK_BRIDGE_CMD_READ_CONFIG);
+        _wire->write(static_cast<uint8_t>((offset >> 8) & 0xFF));
+        _wire->write(static_cast<uint8_t>(offset & 0xFF));
+        _wire->write(want);
+
+        if (_wire->endTransmission(false) != 0) {
+            return produced;
+        }
+
+        const uint8_t received = _wire->requestFrom(_address, want);
+
+        if (received == 0) {
+            return produced;
+        }
+
+        for (uint8_t i = 0; i < received; ++i) {
+            if (!_wire->available()) {
                 return produced;
             }
-            result[produced++] = chunk[i];
+
+            const uint8_t value = static_cast<uint8_t>(_wire->read());
+
+            // Erased flash marks the end of stored config.
+            if (value == 0xFF) {
+                return produced;
+            }
+
+            result[produced++] = value;
+
             if (produced == maxLen) {
                 return produced;
             }
         }
+
+        // Prevent an infinite loop if fewer bytes are returned.
+        if (received < want) {
+            return produced;
+        }
     }
+
     return produced;
 }
 

--- a/lib/daplink_bridge/src/daplink_bridge_const.h
+++ b/lib/daplink_bridge/src/daplink_bridge_const.h
@@ -49,7 +49,7 @@ constexpr uint8_t DAPLINK_BRIDGE_ERROR_CMD_FAILED = 0x80;
 // Maximum payload bytes per WRITE_CONFIG frame. The bridge accepts
 // `CMD + 2-byte offset + 1-byte length + payload` and the F103 buffers
 // it up to ~32 bytes; 30 leaves headroom for the 4-byte header.
-constexpr uint8_t DAPLINK_BRIDGE_MAX_WRITE_CHUNK = 30;
+constexpr uint8_t DAPLINK_BRIDGE_MAX_WRITE_CHUNK = 28;
 
 // Maximum payload bytes per READ_CONFIG frame. Arduino Wire's default
 // receive buffer is 32 bytes, so we cap reads at 16 to leave room for


### PR DESCRIPTION
## PR depending on this one 
* #213 

## Summary

Fix DAPLink config-zone read and write operations to correctly follow the protocol used by the MicroPython implementation.

Previously, `readConfig()` did not correctly address the persistent config zone, which could cause large reads such as the 1 KB read required by `SteamiConfig` to hang the board and disconnect it from USB.

Additional protocol differences in `writeConfig()` and command timing also caused writes to report success while the config zone remained empty.

Closes #211

## Changes

* Send the config-zone offset with each `READ_CONFIG` request.
* Use the correct `READ_CONFIG` frame containing the command and 2-byte offset.
* Remove the unsupported read-length field from `READ_CONFIG` requests.
* Add the required delay before reading the response to a `READ_CONFIG` command.
* Stop reading at the `0xFF` erased-flash sentinel.
* Return safely on I2C failures and short reads.
* Prevent config-zone reads from hanging the board.
* Limit `WRITE_CONFIG` payloads to 28 bytes so the complete frame fits in the 32-byte I2C buffer.
* Send fixed 32-byte `WRITE_CONFIG` frames, matching the MicroPython implementation.
* Zero-pad unused bytes in `WRITE_CONFIG` frames.
* Add the required delay after each `WRITE_CONFIG` command.
* Add the required delay after `CLEAR_CONFIG` before checking command completion.
* Allow configuration written through `writeConfig()` to be correctly read back through `readConfig()`.
* Enable persistent configuration storage required by `SteamiConfig`.

## Checklist

* [ ] `make lint` passes
* [ ] `make build` passes
* [ ] `make test-native` passes
* [x] Tested config-zone reads and writes on a connected STeaMi
* [ ] README updated (if applicable)
* [ ] Tests added/updated
* [x] Commit messages follow conventional commits format
