### PR TITLE
test(steami_config): Add native, hardware, and integration tests.

### DIFF
--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -299,16 +299,36 @@ Native tests use lightweight Arduino-compatible mocks stored in
 `tests/native/helpers/`. They are automatically included by the `[env:native]`
 PlatformIO environment.
 
-### GPIO mock
+### Arduino mock
 
-`Arduino.h` provides:
+`Arduino.h` provides lightweight host-side replacements for the Arduino APIs
+used by drivers.
+
+GPIO and timing support:
 
 * `pinMode(pin, mode)` records the mode into `gpioPinMode()`,
 * `digitalWrite(pin, value)` records the state into `gpioPinState()`,
 * `digitalRead(pin)` returns the last recorded state,
-* `delay(ms)` is a no-op.
+* `millis()` returns a simulated 32-bit monotonic clock,
+* `delay(ms)` advances the simulated clock,
+* `attachInterrupt()` and `digitalPinToInterrupt()` provide minimal interrupt
+  compatibility for native tests.
 
-Tests assert expected pin state by querying the two maps directly.
+The mock also provides a minimal Arduino-compatible `String` implementation for
+drivers that expose or manipulate `String` values. It supports the subset used
+by the repository drivers, including:
+
+* construction from strings, integers, and floating-point values,
+* `length()` and `c_str()`,
+* `substring()`,
+* `endsWith()`,
+* `remove()`,
+* character indexing,
+* string concatenation.
+
+The mock intentionally implements only the Arduino APIs required by the native
+test suites. Extend it when a driver requires additional behaviour rather than
+depending on the full Arduino core.
 
 ### I2C mock (`TwoWire`)
 

--- a/tests/hardware/test_steami_config/test_main.cpp
+++ b/tests/hardware/test_steami_config/test_main.cpp
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/*
+ * Hardware unit tests for SteamiConfig on a real STeaMi.
+ *
+ * WARNING: these tests overwrite the DAPLink persistent configuration zone.
+ *
+ * The stored test configuration is intentionally kept well below 255 bytes.
+ * The current Arduino/DAPLink read path cannot reliably restore a serialized
+ * configuration larger than 255 bytes.
+ */
+
+#include <Arduino.h>
+#include <DaplinkBridge.h>
+#include <SteamiConfig.h>
+#include <Wire.h>
+#include <unity.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+DaplinkBridge bridge(internalI2C);
+SteamiConfig config(bridge);
+
+void setUp(void) {
+    config.clear();
+}
+
+void tearDown(void) {}
+
+void test_steami_config_begin(void) {
+    TEST_ASSERT_TRUE(config.begin());
+}
+
+void test_steami_config_board_info_round_trip(void) {
+    config.setBoardRevision(3);
+    config.setBoardName("STeaMi-HW");
+
+    TEST_ASSERT_TRUE(config.save());
+
+    config.clear();
+    TEST_ASSERT_TRUE(config.load());
+
+    int32_t revision = 0;
+    String name;
+
+    TEST_ASSERT_TRUE(config.boardRevision(revision));
+    TEST_ASSERT_EQUAL_INT32(3, revision);
+
+    TEST_ASSERT_TRUE(config.boardName(name));
+    TEST_ASSERT_EQUAL_STRING("STeaMi-HW", name.c_str());
+}
+
+void test_steami_config_temperature_calibration_round_trip(void) {
+    TEST_ASSERT_TRUE(config.setTemperatureCalibration("hts221", 1.01f, -0.5f));
+    TEST_ASSERT_TRUE(config.save());
+
+    config.clear();
+    TEST_ASSERT_TRUE(config.load());
+
+    TemperatureCalibration calibration;
+    TEST_ASSERT_TRUE(config.getTemperatureCalibration("hts221", calibration));
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.01f, calibration.gain);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, -0.5f, calibration.offset);
+}
+
+void test_steami_config_boot_counter_round_trip(void) {
+    config.setBootCount(41);
+    TEST_ASSERT_TRUE(config.save());
+
+    config.clear();
+    TEST_ASSERT_TRUE(config.load());
+
+    uint32_t count = 0;
+    TEST_ASSERT_TRUE(config.bootCount(count));
+    TEST_ASSERT_EQUAL_UINT32(41, count);
+
+    TEST_ASSERT_EQUAL_UINT32(42, config.incrementBootCount());
+    TEST_ASSERT_TRUE(config.save());
+
+    config.clear();
+    TEST_ASSERT_TRUE(config.load());
+    TEST_ASSERT_TRUE(config.bootCount(count));
+    TEST_ASSERT_EQUAL_UINT32(42, count);
+}
+
+void test_steami_config_mixed_small_config_round_trip(void) {
+    config.setBoardRevision(4);
+    config.setBoardName("STeaMi");
+    TEST_ASSERT_TRUE(config.setTemperatureCalibration("hts221", 1.02f, -0.25f));
+    config.setBootCount(9);
+
+    TEST_ASSERT_TRUE(config.save());
+
+    config.clear();
+    TEST_ASSERT_TRUE(config.load());
+
+    int32_t revision = 0;
+    String name;
+    TemperatureCalibration calibration;
+    uint32_t count = 0;
+
+    TEST_ASSERT_TRUE(config.boardRevision(revision));
+    TEST_ASSERT_EQUAL_INT32(4, revision);
+
+    TEST_ASSERT_TRUE(config.boardName(name));
+    TEST_ASSERT_EQUAL_STRING("STeaMi", name.c_str());
+
+    TEST_ASSERT_TRUE(config.getTemperatureCalibration("hts221", calibration));
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.02f, calibration.gain);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, -0.25f, calibration.offset);
+
+    TEST_ASSERT_TRUE(config.bootCount(count));
+    TEST_ASSERT_EQUAL_UINT32(9, count);
+}
+
+void setup() {
+    delay(2000);
+    internalI2C.begin();
+
+    UNITY_BEGIN();
+    RUN_TEST(test_steami_config_begin);
+    RUN_TEST(test_steami_config_board_info_round_trip);
+    RUN_TEST(test_steami_config_temperature_calibration_round_trip);
+    RUN_TEST(test_steami_config_boot_counter_round_trip);
+    RUN_TEST(test_steami_config_mixed_small_config_round_trip);
+    UNITY_END();
+}
+
+void loop() {}

--- a/tests/integration/test_steami_config/test_main.cpp
+++ b/tests/integration/test_steami_config/test_main.cpp
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/*
+ * Integration test for SteamiConfig persistence on a real STeaMi.
+ *
+ * WARNING: this test overwrites the DAPLink persistent configuration zone.
+ *
+ * It exercises repeated save -> clear RAM -> load cycles to verify that
+ * configuration remains coherent across continued use. The serialized data is
+ * deliberately kept below the current 255-byte Arduino/DAPLink read limit.
+ *
+ * The number of write cycles is intentionally small to avoid unnecessary flash
+ * wear on the DAPLink STM32F103 config zone.
+ */
+
+#include <Arduino.h>
+#include <DaplinkBridge.h>
+#include <SteamiConfig.h>
+#include <Wire.h>
+#include <unity.h>
+
+TwoWire internalI2C(I2C_INT_SDA, I2C_INT_SCL);
+DaplinkBridge bridge(internalI2C);
+SteamiConfig config(bridge);
+
+static constexpr uint32_t CYCLE_COUNT = 3;
+static constexpr float EXPECTED_GAIN = 1.015f;
+static constexpr float EXPECTED_OFFSET = -0.35f;
+
+void test_steami_config_repeated_persistence_cycles(void) {
+    TEST_ASSERT_TRUE(config.begin());
+
+    config.clear();
+    config.setBoardRevision(3);
+    config.setBoardName("STeaMi-INT");
+    TEST_ASSERT_TRUE(config.setTemperatureCalibration("hts221", EXPECTED_GAIN, EXPECTED_OFFSET));
+    config.setBootCount(0);
+
+    for (uint32_t cycle = 1; cycle <= CYCLE_COUNT; ++cycle) {
+        TEST_ASSERT_EQUAL_UINT32(cycle, config.incrementBootCount());
+        TEST_ASSERT_TRUE_MESSAGE(config.save(), "save() failed during persistence cycle");
+
+        // Simulate loss of all runtime state while keeping persistent storage.
+        config.clear();
+
+        TEST_ASSERT_TRUE_MESSAGE(config.load(), "load() failed during persistence cycle");
+
+        int32_t revision = 0;
+        String name;
+        TemperatureCalibration calibration;
+        uint32_t count = 0;
+
+        TEST_ASSERT_TRUE(config.boardRevision(revision));
+        TEST_ASSERT_EQUAL_INT32(3, revision);
+
+        TEST_ASSERT_TRUE(config.boardName(name));
+        TEST_ASSERT_EQUAL_STRING("STeaMi-INT", name.c_str());
+
+        TEST_ASSERT_TRUE(config.getTemperatureCalibration("hts221", calibration));
+        TEST_ASSERT_FLOAT_WITHIN(0.001f, EXPECTED_GAIN, calibration.gain);
+        TEST_ASSERT_FLOAT_WITHIN(0.001f, EXPECTED_OFFSET, calibration.offset);
+
+        TEST_ASSERT_TRUE(config.bootCount(count));
+        TEST_ASSERT_EQUAL_UINT32(cycle, count);
+
+        delay(250);
+    }
+}
+
+void test_steami_config_persists_after_idle_period(void) {
+    config.clear();
+    config.setBoardName("STeaMi-IDLE");
+    config.setBootCount(77);
+
+    TEST_ASSERT_TRUE(config.save());
+
+    // Exercise persistence across a longer idle period without touching the
+    // config object or DAPLink storage.
+    delay(3000);
+
+    config.clear();
+    TEST_ASSERT_TRUE(config.load());
+
+    String name;
+    uint32_t count = 0;
+
+    TEST_ASSERT_TRUE(config.boardName(name));
+    TEST_ASSERT_EQUAL_STRING("STeaMi-IDLE", name.c_str());
+
+    TEST_ASSERT_TRUE(config.bootCount(count));
+    TEST_ASSERT_EQUAL_UINT32(77, count);
+}
+
+void setup() {
+    delay(2000);
+    internalI2C.begin();
+
+    UNITY_BEGIN();
+    RUN_TEST(test_steami_config_repeated_persistence_cycles);
+    RUN_TEST(test_steami_config_persists_after_idle_period);
+    UNITY_END();
+}
+
+void loop() {}

--- a/tests/native/helpers/Arduino.h
+++ b/tests/native/helpers/Arduino.h
@@ -4,7 +4,10 @@
 
 #include <cstdint>
 #include <functional>
+#include <iomanip>
 #include <map>
+#include <sstream>
+#include <string>
 
 // Mirror the include-guard symbol the real Arduino.h advertises.
 // Driver code uses `#ifdef Arduino_h` to gate pin operations; without
@@ -73,3 +76,106 @@ inline void attachInterrupt(uint8_t /* pin */, const std::function<void()>& /* i
 inline int digitalPinToInterrupt(int pin) {
     return pin;
 }
+
+class String {
+   public:
+    String() = default;
+
+    String(const char* value) : _value(value != nullptr ? value : "") {}
+
+    String(const std::string& value) : _value(value) {}
+
+    String(char value) : _value(1, value) {}
+
+    String(int value) : _value(std::to_string(value)) {}
+
+    String(unsigned int value) : _value(std::to_string(value)) {}
+
+    String(long value) : _value(std::to_string(value)) {}
+
+    String(unsigned long value) : _value(std::to_string(value)) {}
+
+    String(float value, unsigned int decimals) { setFloat(value, decimals); }
+
+    String(double value, unsigned int decimals) { setFloat(value, decimals); }
+
+    size_t length() const { return _value.length(); }
+
+    const char* c_str() const { return _value.c_str(); }
+
+    char operator[](size_t index) const { return _value[index]; }
+
+    String substring(unsigned int from, unsigned int to) const {
+        if (from >= _value.length()) {
+            return String("");
+        }
+
+        if (to > _value.length()) {
+            to = _value.length();
+        }
+
+        if (to <= from) {
+            return String("");
+        }
+
+        return String(_value.substr(from, to - from));
+    }
+
+    bool endsWith(const char* suffix) const {
+        if (suffix == nullptr) {
+            return false;
+        }
+
+        const std::string suffixString(suffix);
+
+        if (suffixString.length() > _value.length()) {
+            return false;
+        }
+
+        return _value.compare(_value.length() - suffixString.length(), suffixString.length(),
+                              suffixString) == 0;
+    }
+
+    void remove(unsigned int index) {
+        if (index < _value.length()) {
+            _value.erase(index);
+        }
+    }
+
+    void remove(unsigned int index, unsigned int count) {
+        if (index < _value.length()) {
+            _value.erase(index, count);
+        }
+    }
+
+    String& operator=(const char* value) {
+        _value = value != nullptr ? value : "";
+        return *this;
+    }
+
+    String& operator+=(const String& other) {
+        _value += other._value;
+        return *this;
+    }
+
+    String& operator+=(const char* value) {
+        if (value != nullptr) {
+            _value += value;
+        }
+        return *this;
+    }
+
+    String& operator+=(char value) {
+        _value += value;
+        return *this;
+    }
+
+   private:
+    std::string _value;
+
+    void setFloat(double value, unsigned int decimals) {
+        std::ostringstream stream;
+        stream << std::fixed << std::setprecision(decimals) << value;
+        _value = stream.str();
+    }
+};

--- a/tests/native/test_steami_config/test_main.cpp
+++ b/tests/native/test_steami_config/test_main.cpp
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <unity.h>
+
+#include "DaplinkBridge.h"
+#include "SteamiConfig.h"
+#include "Wire.h"
+
+DaplinkBridge bridge(Wire);
+SteamiConfig config(bridge);
+
+struct FakeTemperatureSensor {
+    float refLow = 0.0f;
+    float measLow = 0.0f;
+    float refHigh = 0.0f;
+    float measHigh = 0.0f;
+    bool called = false;
+
+    void calibrateTemperature(float newRefLow, float newMeasLow, float newRefHigh,
+                              float newMeasHigh) {
+        refLow = newRefLow;
+        measLow = newMeasLow;
+        refHigh = newRefHigh;
+        measHigh = newMeasHigh;
+        called = true;
+    }
+};
+
+struct FakeAccelerometer {
+    float x = 0.0f;
+    float y = 0.0f;
+    float z = 0.0f;
+    bool called = false;
+
+    void setAccelOffset(float newX, float newY, float newZ) {
+        x = newX;
+        y = newY;
+        z = newZ;
+        called = true;
+    }
+};
+
+void setUp(void) {
+    Wire = TwoWire();
+    bridge = DaplinkBridge(Wire);
+    config = SteamiConfig(bridge);
+}
+
+void tearDown(void) {}
+
+void test_initial_config_is_empty(void) {
+    int32_t revision = 0;
+    String name;
+    uint32_t bootCount = 0;
+    TemperatureCalibration temperature;
+    MagnetometerCalibration magnetometer;
+    AccelerometerCalibration accelerometer;
+
+    TEST_ASSERT_FALSE(config.boardRevision(revision));
+    TEST_ASSERT_FALSE(config.boardName(name));
+    TEST_ASSERT_FALSE(config.bootCount(bootCount));
+    TEST_ASSERT_FALSE(config.getTemperatureCalibration("hts221", temperature));
+    TEST_ASSERT_FALSE(config.getMagnetometerCalibration(magnetometer));
+    TEST_ASSERT_FALSE(config.getAccelerometerCalibration(accelerometer));
+}
+
+void test_board_revision_set_get_and_clear(void) {
+    int32_t revision = 0;
+
+    config.setBoardRevision(3);
+    TEST_ASSERT_TRUE(config.boardRevision(revision));
+    TEST_ASSERT_EQUAL_INT32(3, revision);
+
+    config.clearBoardRevision();
+    TEST_ASSERT_FALSE(config.boardRevision(revision));
+}
+
+void test_board_name_set_get_and_clear(void) {
+    String name;
+
+    config.setBoardName("STeaMi-Test");
+    TEST_ASSERT_TRUE(config.boardName(name));
+    TEST_ASSERT_EQUAL_STRING("STeaMi-Test", name.c_str());
+
+    config.clearBoardName();
+    TEST_ASSERT_FALSE(config.boardName(name));
+}
+
+void test_temperature_calibration_supported_sensors(void) {
+    const char* sensors[] = {
+        "hts221", "lis2mdl", "ism330dl", "wsen_hids", "wsen_pads",
+    };
+
+    for (size_t i = 0; i < sizeof(sensors) / sizeof(sensors[0]); ++i) {
+        const float gain = 1.0f + static_cast<float>(i) * 0.01f;
+        const float offset = -0.5f + static_cast<float>(i) * 0.1f;
+
+        TEST_ASSERT_TRUE(config.setTemperatureCalibration(sensors[i], gain, offset));
+
+        TemperatureCalibration calibration;
+        TEST_ASSERT_TRUE(config.getTemperatureCalibration(sensors[i], calibration));
+        TEST_ASSERT_FLOAT_WITHIN(0.0001f, gain, calibration.gain);
+        TEST_ASSERT_FLOAT_WITHIN(0.0001f, offset, calibration.offset);
+    }
+}
+
+void test_temperature_calibration_rejects_unknown_sensor(void) {
+    TemperatureCalibration calibration;
+
+    TEST_ASSERT_FALSE(config.setTemperatureCalibration("unknown", 1.0f, 0.0f));
+    TEST_ASSERT_FALSE(config.getTemperatureCalibration("unknown", calibration));
+    TEST_ASSERT_FALSE(config.clearTemperatureCalibration("unknown"));
+}
+
+void test_temperature_calibration_clear(void) {
+    TemperatureCalibration calibration;
+
+    TEST_ASSERT_TRUE(config.setTemperatureCalibration("hts221", 1.02f, -0.3f));
+    TEST_ASSERT_TRUE(config.clearTemperatureCalibration("hts221"));
+    TEST_ASSERT_FALSE(config.getTemperatureCalibration("hts221", calibration));
+}
+
+void test_apply_temperature_calibration_uses_linear_hook(void) {
+    FakeTemperatureSensor sensor;
+
+    TEST_ASSERT_TRUE(config.setTemperatureCalibration("hts221", 1.25f, -0.5f));
+    TEST_ASSERT_TRUE(config.applyTemperatureCalibration("hts221", sensor));
+
+    TEST_ASSERT_TRUE(sensor.called);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, -0.5f, sensor.refLow);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.0f, sensor.measLow);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.75f, sensor.refHigh);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 1.0f, sensor.measHigh);
+}
+
+void test_apply_temperature_calibration_returns_false_when_missing(void) {
+    FakeTemperatureSensor sensor;
+
+    TEST_ASSERT_FALSE(config.applyTemperatureCalibration("hts221", sensor));
+    TEST_ASSERT_FALSE(sensor.called);
+}
+
+void test_magnetometer_calibration_set_get_and_clear(void) {
+    config.setMagnetometerCalibration(12.3f, -5.1f, 0.8f, 1.01f, 0.98f, 1.0f);
+
+    MagnetometerCalibration calibration;
+    TEST_ASSERT_TRUE(config.getMagnetometerCalibration(calibration));
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 12.3f, calibration.hardIronX);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, -5.1f, calibration.hardIronY);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.8f, calibration.hardIronZ);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 1.01f, calibration.softIronX);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.98f, calibration.softIronY);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 1.0f, calibration.softIronZ);
+
+    config.clearMagnetometerCalibration();
+    TEST_ASSERT_FALSE(config.getMagnetometerCalibration(calibration));
+}
+
+void test_accelerometer_calibration_set_get_and_clear(void) {
+    config.setAccelerometerCalibration(0.01f, -0.02f, 0.03f);
+
+    AccelerometerCalibration calibration;
+    TEST_ASSERT_TRUE(config.getAccelerometerCalibration(calibration));
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.01f, calibration.offsetX);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, -0.02f, calibration.offsetY);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.03f, calibration.offsetZ);
+
+    config.clearAccelerometerCalibration();
+    TEST_ASSERT_FALSE(config.getAccelerometerCalibration(calibration));
+}
+
+void test_apply_accelerometer_calibration_uses_driver_hook(void) {
+    FakeAccelerometer sensor;
+
+    config.setAccelerometerCalibration(0.01f, -0.02f, 0.03f);
+    TEST_ASSERT_TRUE(config.applyAccelerometerCalibration(sensor));
+
+    TEST_ASSERT_TRUE(sensor.called);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.01f, sensor.x);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, -0.02f, sensor.y);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.03f, sensor.z);
+}
+
+void test_apply_accelerometer_calibration_returns_false_when_missing(void) {
+    FakeAccelerometer sensor;
+
+    TEST_ASSERT_FALSE(config.applyAccelerometerCalibration(sensor));
+    TEST_ASSERT_FALSE(sensor.called);
+}
+
+void test_boot_counter_set_get_and_increment(void) {
+    uint32_t count = 0;
+
+    TEST_ASSERT_FALSE(config.bootCount(count));
+
+    TEST_ASSERT_EQUAL_UINT32(1, config.incrementBootCount());
+    TEST_ASSERT_TRUE(config.bootCount(count));
+    TEST_ASSERT_EQUAL_UINT32(1, count);
+
+    config.setBootCount(41);
+    TEST_ASSERT_TRUE(config.bootCount(count));
+    TEST_ASSERT_EQUAL_UINT32(41, count);
+
+    TEST_ASSERT_EQUAL_UINT32(42, config.incrementBootCount());
+    TEST_ASSERT_TRUE(config.bootCount(count));
+    TEST_ASSERT_EQUAL_UINT32(42, count);
+}
+
+void test_clear_resets_all_in_memory_values(void) {
+    config.setBoardRevision(3);
+    config.setBoardName("STeaMi");
+    config.setTemperatureCalibration("hts221", 1.01f, -0.5f);
+    config.setMagnetometerCalibration(1.0f, 2.0f, 3.0f, 1.1f, 1.2f, 1.3f);
+    config.setAccelerometerCalibration(0.1f, 0.2f, 0.3f);
+    config.setBootCount(7);
+
+    config.clear();
+
+    int32_t revision = 0;
+    String name;
+    uint32_t bootCount = 0;
+    TemperatureCalibration temperature;
+    MagnetometerCalibration magnetometer;
+    AccelerometerCalibration accelerometer;
+
+    TEST_ASSERT_FALSE(config.boardRevision(revision));
+    TEST_ASSERT_FALSE(config.boardName(name));
+    TEST_ASSERT_FALSE(config.bootCount(bootCount));
+    TEST_ASSERT_FALSE(config.getTemperatureCalibration("hts221", temperature));
+    TEST_ASSERT_FALSE(config.getMagnetometerCalibration(magnetometer));
+    TEST_ASSERT_FALSE(config.getAccelerometerCalibration(accelerometer));
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_initial_config_is_empty);
+    RUN_TEST(test_board_revision_set_get_and_clear);
+    RUN_TEST(test_board_name_set_get_and_clear);
+    RUN_TEST(test_temperature_calibration_supported_sensors);
+    RUN_TEST(test_temperature_calibration_rejects_unknown_sensor);
+    RUN_TEST(test_temperature_calibration_clear);
+    RUN_TEST(test_apply_temperature_calibration_uses_linear_hook);
+    RUN_TEST(test_apply_temperature_calibration_returns_false_when_missing);
+    RUN_TEST(test_magnetometer_calibration_set_get_and_clear);
+    RUN_TEST(test_accelerometer_calibration_set_get_and_clear);
+    RUN_TEST(test_apply_accelerometer_calibration_uses_driver_hook);
+    RUN_TEST(test_apply_accelerometer_calibration_returns_false_when_missing);
+    RUN_TEST(test_boot_counter_set_get_and_increment);
+    RUN_TEST(test_clear_resets_all_in_memory_values);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

Add complete test coverage for the Arduino `SteamiConfig` driver across the native, hardware, and integration test tiers.

The native suite validates the public API and calibration logic using host-side mocks. The hardware suite validates persistent save/load behaviour through the real DAPLink bridge on a connected STeaMi. The integration suite verifies repeated persistence cycles and state consistency over time.

This PR also extends the native Arduino mock with the `String` support required by `SteamiConfig` and updates the testing documentation accordingly.

Depends on #213

Closes #33
Closes #45

## Changes

* Add native unit tests for `SteamiConfig`.
* Test board revision and board name setters, getters, and clear operations.
* Test supported temperature calibration entries for HTS221, LIS2MDL, ISM330DL, WSEN-HIDS, and WSEN-PADS.
* Test rejection of unsupported temperature sensor identifiers.
* Test magnetometer calibration storage and clearing.
* Test accelerometer calibration storage and clearing.
* Test boot counter set, get, increment, and reset behaviour.
* Test `applyTemperatureCalibration()` using a fake temperature sensor.
* Test `applyAccelerometerCalibration()` using a fake accelerometer.
* Extend the native `Arduino.h` mock with a lightweight Arduino-compatible `String` implementation.
* Update `TESTING.md` to document `String` support and stateful persistence integration tests.
* Add hardware tests using the real DAPLink persistent configuration zone.
* Verify short configuration save/load round trips on a connected STeaMi.
* Verify board information, temperature calibration, boot counter, and mixed configuration persistence.
* Add integration tests covering repeated `save()`, in-memory `clear()`, and `load()` cycles.
* Verify persistent state remains consistent across repeated cycles and idle periods.
* Keep hardware and integration test payloads below the current configuration read-size limitation inherited from #213.
* Limit repeated persistence cycles to avoid unnecessary DAPLink flash wear.

## Checklist

* [x] `make lint` passes (clang-format)
* [ ] `make build` passes (PlatformIO)
* [x] `make test-native` passes (if native tests exist)
* [x] `make test-hardware` passes on a connected STeaMi (if hardware tests exist)
* [x] README updated (if adding/changing public API)
* [ ] Examples added/updated (if applicable)
* [x] Commit messages follow conventional commits format
